### PR TITLE
Update version to v3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center"><img src="extras/kaptive_logo.png" alt="Kaptive" width="400"></p>
 
+[![DOI:10.1101/22025.02.05.636613](http://img.shields.io/badge/DOI-10.1101/2025.02.05.636613-B31B1B.svg)](https://doi.org/10.1101/2025.02.05.636613)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14000416.svg)](https://doi.org/10.5281/zenodo.14000416)
+
 
 Kaptive reports information about surface polysaccharide loci for _Klebsiella pneumoniae_ species complex and _Acinetobacter baumannii_ genome assemblies. You can also run a graphical version of Kaptive via [this web interface](http://kaptive-web.erc.monash.edu/) ([source code](https://github.com/kelwyres/Kaptive-Web)).
 
@@ -7,4 +10,8 @@ Kaptive reports information about surface polysaccharide loci for _Klebsiella pn
 
 A step-by-step tutorial for the most recent version is available [here](https://docs.google.com/document/d/1EXZanC6uCbhAniVyJn91HOVD8JF6DLRZxmFPGs_nlME/edit?usp=sharing) (Kaptive v3). The tutorial for the previous version is [here](https://bit.ly/kaptive-workshop).
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11257262.svg)](https://doi.org/10.5281/zenodo.11257262)
+If you use Kaptive in your research, please cite:
+
+Stanton TD, Hetland MAK, Löhr IH, Holt KE, Wyres KL. Fast and Accurate in silico Antigen Typing with Kaptive 3 
+[Internet]. bioRxiv; 2025 [cited 2025 Feb 27]. p. 2025.02.05.636613. 
+Available from: https://www.biorxiv.org/content/10.1101/2025.02.05.636613v1

--- a/docs/source/Databases.rst
+++ b/docs/source/Databases.rst
@@ -238,7 +238,7 @@ distinct *Klebsiella* O loci.
 
 O locus classification requires some special logic, as the O1 and O2 serotypes are associated with the same loci and
 the distinction between O1 and each of the defined O2 subtypes (2α, 2β, 2γ) is determined by the
-presence/absence of 'extra genes' (gml2β and orf*) elsewhere in the chromosome as indicated in the table below.
+presence/absence of 'extra genes' (gml2β and orf8) elsewhere in the chromosome as indicated in the table below.
 Kaptive therefore looks for these genes to predict antigen (sub)types.
 
 .. note::

--- a/docs/source/Databases.rst
+++ b/docs/source/Databases.rst
@@ -128,15 +128,11 @@ Let's look at an example that uses extra genes outside of the locus (from the *K
 ======================= ================ ==========
 loci                    genes            phenotype
 ======================= ================ ==========
-OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC	 O2β
-OL2α.1;OL2α.2;OL2α.3	orf8	         O2γ
+OL2α.1;OL2α.2;OL2α.3	orf8	         O2αγ
 ======================= ================ ==========
 
-Here, the first line states that if *wbbY* is present in a genome carrying any of the O1/O2v1, O1/O2v2, or
-O1/O2v3 loci, the phenotype
-will be predicted as 'O1a'. The second line states that if **both** *wbbY* and *wbbZ* are present in a genome
-carrying any of the
-same loci, the phenotype will instead be predicted as 'O1ab'.
+Here, the first line states that if *orf8* is present in a genome carrying any of the OL2α.1, OL2α.2 or OL2α.3 loci,
+the phenotype will be predicted as 'O2αγ'.
 
 .. note::
  Each specific locus and gene is delimited by a semicolon.
@@ -247,24 +243,24 @@ Kaptive therefore looks for these genes to predict antigen (sub)types.
 ========================== ===================================================== =============================================== ==============================================
 New serotype designation   Required genes/loci (implemented in Kaptive v.3.1+)   Prior Kaptive designation (v.2.0.8–v.3.0.0b6)   Prior Kaptive genes/loci (v.2.0.8–v.3.0.0b6)
 ========================== ===================================================== =============================================== ==============================================
-O1αβ,2α                    OL2(α/β/γ), wbbYZ                                     O1ab                                            O1/O2v1, wbbYZ
-O1α,2α                     OL2(α/β/γ), wbbY                                      O1a                                             O1/O2v1, wbbY
-O1αβ,2β                    OL2(α/β/γ), gml2β, wbbYZ                              O1ab                                            O1/O2v2, wbbYZ
-O1α,2β                     OL2(α/β/γ), gml2β, wbbY                               O1a                                             O1/O2v2, wbbY
-O1αβ,2γ                    OL2(α/β/γ), orf8, wbbYZ                               O1ab                                            O1/O2v3, wbbYZ
-O2α                        OL2(α/β/γ)                                            O2a                                             O1/O2v1
-O2β                        OL2(α/β/γ), gml2β                                     O2afg                                           O1/O2v2
-O2γ                        OL2(α/β/γ), orf8                                      O2a                                             O1/O2v3
+O1αβ,2α                    OL2α.(1/2/3), wbbYZ                                   O1ab                                            O1/O2v1, wbbYZ
+O1α,2α                     OL2α.(1/2/3), wbbY                                    O1a                                             O1/O2v1, wbbY
+O1αβ,2β                    OL2α.(1/2/3), gml2β, wbbYZ                            O1ab                                            O1/O2v2, wbbYZ
+O1α,2β                     OL2α.(1/2/3), gml2β, wbbY                             O1a                                             O1/O2v2, wbbY
+O1αβ,2γ                    OL2α.(1/2/3), orf8, wbbYZ                             O1ab                                            O1/O2v3, wbbYZ
+O2α                        OL2α.(1/2/3)                                          O2a                                             O1/O2v1
+O2β                        OL2α.(1/2/3), gml2β                                   O2afg                                           O1/O2v2
+O2αγ                       OL2α.(1/2/3), orf8                                    O2a                                             O1/O2v3
 O3α + O3β                  OL3α/β                                                O3/O3a                                          O3/O3a
 O3γ                        OL3γ                                                  O3b                                             O3b
 O4                         OL4                                                   O4                                              O4
 O5                         OL5                                                   O5                                              O5
 O10                        OL10                                                  OL103                                           OL103
-O11αβ,2α                   OL2(α/β/γ), wbmVWX                                    O2ac                                            O1/O2v1, wbmVWX
-O11α,2α                    OL2(α/β/γ), wbmVW                                     O2ac                                            O1/O2v1, wbmVW
-O11αβ,2β                   OL2(α/β/γ), gml2β, wbmVWX                             O2ac                                            O1/O2v2, wbmVWX
-O11α,2β                    OL2(α/b/γ), gml2β, wbmVW                              O2ac                                            O1/O2v2, wbmVW
-O11αβ,2γ                   OL2(α/β/γ), orf8, wbmVWX                              O2ac                                            O1/O2v3, wbmVW
+O11αβ,2α                   OL2α.(1/2/3), wbmVWX                                  O2ac                                            O1/O2v1, wbmVWX
+O11α,2α                    OL2α.(1/2/3), wbmVW                                   O2ac                                            O1/O2v1, wbmVW
+O11αβ,2β                   OL2α.(1/2/3), gml2β, wbmVWX                           O2ac                                            O1/O2v2, wbmVWX
+O11α,2β                    OL2α.(1/2/3), gml2β, wbmVW                            O2ac                                            O1/O2v2, wbmVW
+O11αβ,2γ                   OL2α.(1/2/3), orf8, wbmVWX                            O2ac                                            O1/O2v3, wbmVW
 O12                        OL12                                                  O12                                             O12
 O13                        OL13                                                  O13                                             OL13
 O14                        OL14                                                  OL102                                           OL102

--- a/docs/source/Databases.rst
+++ b/docs/source/Databases.rst
@@ -125,12 +125,22 @@ KL22, the phenotype is predicted as 'K37', the non-acetylated version of the K22
 
 Let's look at an example that uses extra genes outside of the locus (from the *K. pneumoniae* O locus database):
 
-======================= ============ ===================
-loci                    genes        phenotype
-======================= ============ ===================
-O1/O2v1;O1/O2v2;O1/O2v3	wbbY	     O1a
-O1/O2v1;O1/O2v2;O1/O2v3	wbbY;wbbZ	 O1ab
-======================= ============ ===================
+======================= ============================= ===================
+loci                    genes                         phenotype
+======================= ============================= ===================
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC	              O2β
+OL2α.1;OL2α.2;OL2α.3	orf8	                      O2γ
+OL2α.1;OL2α.2;OL2α.3	wbbY	                      O1α,2α
+OL2α.1;OL2α.2;OL2α.3	wbbY;wbbZ	                  O1αβ,2α
+OL2α.1;OL2α.2;OL2α.3	orf8;wbbY;wbbZ	              O1αβ,2γ
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbbY	          O1α,2β
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbbY;wbbZ	  O1αβ,2β
+OL2α.1;OL2α.2;OL2α.3	wbmV;wbmW	                  O11α,2α
+OL2α.1;OL2α.2;OL2α.3	wbmV;wbmW;wbmX	              O11αβ,2α
+OL2α.1;OL2α.2;OL2α.3	orf8;wbmV;wbmW;wbmX	          O11αβ,2γ
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbmV;wbmW	  O11α,2β
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbmV;wbmW;wbmX O11αβ,2β
+======================= ============================= ===================
 
 Here, the first line states that if *wbbY* is present in a genome carrying any of the O1/O2v1, O1/O2v2, or O1/O2v3 loci, the phenotype
 will be predicted as 'O1a'. The second line states that if **both** *wbbY* and *wbbZ* are present in a genome carrying any of the 
@@ -256,9 +266,9 @@ Database versions:
 
 Genetic determinants of O1 and O2 outer LPS antigens as reported in Kaptive:
 
-========= ==================== ================================== ================================= ======================================== ================================== ==
+========= ==================== ================================== ================================= ======================================== ==================================
 O locus   Extra genes          Kaptive < v2.0 (locus\ :sup:`a`)   Kaptive v2.0+ (locus\ :sup:`a`)   Kaptive v2.0 - v2.0.7 (type\ :sup:`b`)   Kaptive v2.0.8+ (type\ :sup:`b`)
-========= ==================== ================================== ================================= ======================================== ================================== ==
+========= ==================== ================================== ================================= ======================================== ==================================
 O1/O2v1   none                 O2v1                               O1/O2v1                           O2a                                      O2a
 O1/O2v2   none                 O2v2                               O1/O2v2                           O2afg                                    O2afg
 O1/O2v3   none                 Na                                 O1/O2v3                           O2a                                      O2a
@@ -267,7 +277,7 @@ O1/O2v2   *wbbYZ*              O1v2                               O1/O2v2       
 O1/O2v3   *wbbYZ*.             Na                                 O1/O2v3                           Na                                       O1ab
 O1/O2v1   *wbbY* only          O1v1                               O1/O2v1                           O1                                       O1a
 O1/O2v2   *wbbY* only          O1v2                               O1/O2v2                           O1                                       O1a
-O1/O2v3   *wbbY* only          Na.                                O1/O2v3                           O1                                       O1a
+O1/O2v3   *wbbY* only          Na                                 O1/O2v3                           O1                                       O1a
 O1/O2v1   *wbbY* OR *wbbZ*     O1/O2v1                            Na                                Na                                       Na
 O1/O2v2   *wbbY* OR *wbbZ*     O1/O2v2                            Na                                Na                                       Na
 O1/O2v3   *wbbY* OR *wbbZ*     Na                                 Na                                Na                                       Na
@@ -280,7 +290,7 @@ O1/O2v3   *gmlABD*             Na                                 O1/O2v3       
 O1/O2v1   *wbbY* AND *wbmVW*   Na                                 O1/O2v1                           O1 (O2ac)\ :sup:`b`                      O1 (O2ac)\ :sup:`b`
 O1/O2v2   *wbbY* AND *wbmVW*   Na                                 O1/O2v2                           O1 (O2ac)\ :sup:`b`                      O1 (O2ac)\ :sup:`b`
 O1/O2v3   *wbbY* AND *wbmVW*   Na                                 O1/O2v3                           O1 (O2ac)\ :sup:`b`                      O1 (O2ac)\ :sup:`b`
-========= ==================== ================================== ================================= ======================================== ================================== ==
+========= ==================== ================================== ================================= ======================================== ==================================
 
 
 - :sup:`a` as reported in the ‘Best match locus’ column in the Kaptive output.

--- a/docs/source/Databases.rst
+++ b/docs/source/Databases.rst
@@ -125,25 +125,17 @@ KL22, the phenotype is predicted as 'K37', the non-acetylated version of the K22
 
 Let's look at an example that uses extra genes outside of the locus (from the *K. pneumoniae* O locus database):
 
-======================= ============================= ===================
-loci                    genes                         phenotype
-======================= ============================= ===================
-OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC	              O2β
-OL2α.1;OL2α.2;OL2α.3	orf8	                      O2γ
-OL2α.1;OL2α.2;OL2α.3	wbbY	                      O1α,2α
-OL2α.1;OL2α.2;OL2α.3	wbbY;wbbZ	                  O1αβ,2α
-OL2α.1;OL2α.2;OL2α.3	orf8;wbbY;wbbZ	              O1αβ,2γ
-OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbbY	          O1α,2β
-OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbbY;wbbZ	  O1αβ,2β
-OL2α.1;OL2α.2;OL2α.3	wbmV;wbmW	                  O11α,2α
-OL2α.1;OL2α.2;OL2α.3	wbmV;wbmW;wbmX	              O11αβ,2α
-OL2α.1;OL2α.2;OL2α.3	orf8;wbmV;wbmW;wbmX	          O11αβ,2γ
-OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbmV;wbmW	  O11α,2β
-OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbmV;wbmW;wbmX O11αβ,2β
-======================= ============================= ===================
+======================= ================ ==========
+loci                    genes            phenotype
+======================= ================ ==========
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC	 O2β
+OL2α.1;OL2α.2;OL2α.3	orf8	         O2γ
+======================= ================ ==========
 
-Here, the first line states that if *wbbY* is present in a genome carrying any of the O1/O2v1, O1/O2v2, or O1/O2v3 loci, the phenotype
-will be predicted as 'O1a'. The second line states that if **both** *wbbY* and *wbbZ* are present in a genome carrying any of the 
+Here, the first line states that if *wbbY* is present in a genome carrying any of the O1/O2v1, O1/O2v2, or
+O1/O2v3 loci, the phenotype
+will be predicted as 'O1a'. The second line states that if **both** *wbbY* and *wbbZ* are present in a genome
+carrying any of the
 same loci, the phenotype will instead be predicted as 'O1ab'.
 
 .. note::
@@ -237,65 +229,48 @@ KL37    Removed from the database                                               
 *Klebsiella* O locus database
 ------------------------------
 
+In Kaptive 3.1.0, we introduced new O-antigen nomenclature in the *Klebsiella* O locus database
+(``Klebsiella_o_locus_primary_reference.gbk``) along wth the publication of this review:
+`O-antigen polysaccharides in Klebsiella pneumoniae: structures and molecular basis for antigenic diversity <https://journals.asm.org/doi/full/10.1128/mmbr.00090-23#T1>`_.
+
 The *Klebsiella* O locus database (``Klebsiella_o_locus_primary_reference.gbk``) contains annotated sequences for 13
 distinct *Klebsiella* O loci.
 
 O locus classification requires some special logic, as the O1 and O2 serotypes are associated with the same loci and
-the distinction between O1 and each of the four defined O2 subtypes (O2a, O2afg, O2ac, O2aeh) is determined by the
-presence/absence of 'extra genes' elsewhere in the chromosome as indicated in the table below. Kaptive therefore looks
-for these genes to predict antigen (sub)types. (Note that the original implementation of O locus typing in Kaptive
-(< v2.0) distinguished O1 and O2 but not the O2 subtypes.)
+the distinction between O1 and each of the defined O2 subtypes (2α, 2β, 2γ) is determined by the
+presence/absence of 'extra genes' (gml2β and orf*) elsewhere in the chromosome as indicated in the table below.
+Kaptive therefore looks for these genes to predict antigen (sub)types.
 
-Read more about the O locus and its classification here: `The diversity of *Klebsiella* pneumoniae surface polysaccharides <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5320592/>`_.
+.. note::
+    You can find information about the *Klebsiella* O locus database in Kaptive versions <3.1.0 :ref:`here <Legacy-Klebsiella-O-locus-database>`.
 
-Find out about the genetic determinants of O1 and O2 (sub)types here: `Molecular basis for the structural diversity in serogroup O2-antigen polysaccharides in *Klebsiella pneumoniae* <https://pubmed.ncbi.nlm.nih.gov/29602878/>`_.
+========================== ===================================================== =============================================== ==============================================
+New serotype designation   Required genes/loci (implemented in Kaptive v.3.1+)   Prior Kaptive designation (v.2.0.8–v.3.0.0b6)   Prior Kaptive genes/loci (v.2.0.8–v.3.0.0b6)
+========================== ===================================================== =============================================== ==============================================
+O1αβ,2α                    OL2α, wbbYZ                                           O1ab                                            O1/O2v1, wbbYZ
+O1α,2α                     OL2α, wbbY                                            O1a                                             O1/O2v1, wbbY
+O1αβ,2β                    OL2α, gml2β, wbbYZ                                    O1ab                                            O1/O2v2, wbbYZ
+O1α,2β                     OL2α, gml2β, wbbY                                     O1a                                             O1/O2v2, wbbY
+O1αβ,2γ                    OL2α, orf8, wbbYZ                                     O1ab                                            O1/O2v3, wbbYZ
+O2α                        OL2α                                                  O2a                                             O1/O2v1
+O2β                        OL2α, gml2β                                           O2afg                                           O1/O2v2
+O2γ                        OL2α, orf8                                            O2a                                             O1/O2v3
+O3α + O3β                  OL3α/β                                                O3/O3a                                          O3/O3a
+O3γ                        OL3γ                                                  O3b                                             O3b
+O4                         OL4                                                   O4                                              O4
+O5                         OL5                                                   O5                                              O5
+O10                        OL10                                                  OL103                                           OL103
+O11αβ,2α                   OL2α, wbmVWX                                          O2ac                                            O1/O2v1, wbmVWX
+O11α,2α                    OL2α, wbmVW                                           O2ac                                            O1/O2v1, wbmVW
+O11αβ,2β                   OL2α, gml2β, wbmVWX                                   O2ac                                            O1/O2v2, wbmVWX
+O11α,2β                    OL2α, gml2β, wbmVW                                    O2ac                                            O1/O2v2, wbmVW
+O11αβ,2γ                   OL2α, orf8, wbmVWX                                    O2ac                                            O1/O2v3, wbmVW
+O12                        OL12                                                  O12                                             O12
+O13                        OL13                                                  O13                                             OL13
+O14                        OL14                                                  OL102                                           OL102
+O15                        OL15                                                  OL104                                           OL104
+========================== ===================================================== =============================================== ==============================================
 
-Find out about the O1 glycoforms and their genetic determinants here: `Identification of a second glycoform of the clinically prevalent O1 antigen from *Klebsiella pneumoniae*. <https://doi.org/10.1073/pnas.2301302120>`_
-
-Database versions:
-
-* Kaptive v0.4.0 and above include the original version of the *Klebsiella* O locus database, as described in `Wick, R. et al. J Clin Microbiol 2019 <http://jcm.asm.org/content/56/6/e00197-18>`_.
-* Kaptive v2.0 and above include a novel O locus reference (O1/O2v3) and updated 'Extra genes' for prediction of O1 and O2 antigen (sub)types, as shown in the table below and described in `Lam, M.M.C et al. 2021. Microbial Genomics 2022. <https://doi.org/10.1099/mgen.0.000800>`_
-* Kaptive v2.0.8 and above include:
-
-  i) updated 'Extra genes' logic for prediction of O1 glycoforms, reported as O1a (isolate predicted to produce O1a
-     only) and O1ab (isolate predicted to be able to produce both O1a and O1b glycoforms);
-
-  ii) OL101 re-assigned as OL13 and its associated phenotype prediction updated to O13, to reflect the
-      `description of the novel O13 polysaccharide structure <https://www.sciencedirect.com/science/article/pii/S0144861723010469>`_.
-
-Genetic determinants of O1 and O2 outer LPS antigens as reported in Kaptive:
-
-========= ==================== ================================== ================================= ======================================== ==================================
-O locus   Extra genes          Kaptive < v2.0 (locus\ :sup:`a`)   Kaptive v2.0+ (locus\ :sup:`a`)   Kaptive v2.0 - v2.0.7 (type\ :sup:`b`)   Kaptive v2.0.8+ (type\ :sup:`b`)
-========= ==================== ================================== ================================= ======================================== ==================================
-O1/O2v1   none                 O2v1                               O1/O2v1                           O2a                                      O2a
-O1/O2v2   none                 O2v2                               O1/O2v2                           O2afg                                    O2afg
-O1/O2v3   none                 Na                                 O1/O2v3                           O2a                                      O2a
-O1/O2v1   *wbbYZ*              O1v1                               O1/O2v1                           Na                                       O1ab
-O1/O2v2   *wbbYZ*              O1v2                               O1/O2v2                           Na                                       O1ab
-O1/O2v3   *wbbYZ*.             Na                                 O1/O2v3                           Na                                       O1ab
-O1/O2v1   *wbbY* only          O1v1                               O1/O2v1                           O1                                       O1a
-O1/O2v2   *wbbY* only          O1v2                               O1/O2v2                           O1                                       O1a
-O1/O2v3   *wbbY* only          Na                                 O1/O2v3                           O1                                       O1a
-O1/O2v1   *wbbY* OR *wbbZ*     O1/O2v1                            Na                                Na                                       Na
-O1/O2v2   *wbbY* OR *wbbZ*     O1/O2v2                            Na                                Na                                       Na
-O1/O2v3   *wbbY* OR *wbbZ*     Na                                 Na                                Na                                       Na
-O1/O2v1   *wbmVW*              Na                                 O1/O2v1                           O2ac                                     O2ac
-O1/O2v2   *wbmVW*              Na                                 O1/O2v2                           O2ac                                     O2ac
-O1/O2v3   *wbmVW*              Na                                 O1/O2v3                           O2ac                                     O2ac
-O1/O2v1   *gmlABD*             Na                                 O1/O2v1                           O2aeh                                    O2aeh
-O1/O2v2   *gmlABD*             Na                                 O1/O2v2                           O2aeh                                    O2aeh
-O1/O2v3   *gmlABD*             Na                                 O1/O2v3                           O2aeh                                    O2aeh
-O1/O2v1   *wbbY* AND *wbmVW*   Na                                 O1/O2v1                           O1 (O2ac)\ :sup:`b`                      O1 (O2ac)\ :sup:`b`
-O1/O2v2   *wbbY* AND *wbmVW*   Na                                 O1/O2v2                           O1 (O2ac)\ :sup:`b`                      O1 (O2ac)\ :sup:`b`
-O1/O2v3   *wbbY* AND *wbmVW*   Na                                 O1/O2v3                           O1 (O2ac)\ :sup:`b`                      O1 (O2ac)\ :sup:`b`
-========= ==================== ================================== ================================= ======================================== ==================================
-
-
-- :sup:`a` as reported in the ‘Best match locus’ column in the Kaptive output.
-- :sup:`b` predicted antigenic serotype reported in the 'Best match type' column in the Kaptive output (v2.0 and above).
-- Na- not applicable
 
 *Acinetobacter baunannii* K and OC locus databases
 ----------------------------------------------------
@@ -422,6 +397,6 @@ Which would create two files: ``KL1.faa`` and ``KL2.faa``.
         kaptive assembly kpsc_k assembly.fasta -j kaptive_results.json
 
 .. warning::
- It is possible to write **all** text formats (FNA, FAA and FFN) to the same file (including stdout), however
- this is not recommended for downstream analysis.
+ It is possible to write **all** text formats (``fna``, ``faa`` and ``ffn``) to the same file (including stdout),
+ however this is not recommended for downstream analysis.
 

--- a/docs/source/Databases.rst
+++ b/docs/source/Databases.rst
@@ -247,24 +247,24 @@ Kaptive therefore looks for these genes to predict antigen (sub)types.
 ========================== ===================================================== =============================================== ==============================================
 New serotype designation   Required genes/loci (implemented in Kaptive v.3.1+)   Prior Kaptive designation (v.2.0.8–v.3.0.0b6)   Prior Kaptive genes/loci (v.2.0.8–v.3.0.0b6)
 ========================== ===================================================== =============================================== ==============================================
-O1αβ,2α                    OL2α, wbbYZ                                           O1ab                                            O1/O2v1, wbbYZ
-O1α,2α                     OL2α, wbbY                                            O1a                                             O1/O2v1, wbbY
-O1αβ,2β                    OL2α, gml2β, wbbYZ                                    O1ab                                            O1/O2v2, wbbYZ
-O1α,2β                     OL2α, gml2β, wbbY                                     O1a                                             O1/O2v2, wbbY
-O1αβ,2γ                    OL2α, orf8, wbbYZ                                     O1ab                                            O1/O2v3, wbbYZ
-O2α                        OL2α                                                  O2a                                             O1/O2v1
-O2β                        OL2α, gml2β                                           O2afg                                           O1/O2v2
-O2γ                        OL2α, orf8                                            O2a                                             O1/O2v3
+O1αβ,2α                    OL2(α/β/γ), wbbYZ                                     O1ab                                            O1/O2v1, wbbYZ
+O1α,2α                     OL2(α/β/γ), wbbY                                      O1a                                             O1/O2v1, wbbY
+O1αβ,2β                    OL2(α/β/γ), gml2β, wbbYZ                              O1ab                                            O1/O2v2, wbbYZ
+O1α,2β                     OL2(α/β/γ), gml2β, wbbY                               O1a                                             O1/O2v2, wbbY
+O1αβ,2γ                    OL2(α/β/γ), orf8, wbbYZ                               O1ab                                            O1/O2v3, wbbYZ
+O2α                        OL2(α/β/γ)                                            O2a                                             O1/O2v1
+O2β                        OL2(α/β/γ), gml2β                                     O2afg                                           O1/O2v2
+O2γ                        OL2(α/β/γ), orf8                                      O2a                                             O1/O2v3
 O3α + O3β                  OL3α/β                                                O3/O3a                                          O3/O3a
 O3γ                        OL3γ                                                  O3b                                             O3b
 O4                         OL4                                                   O4                                              O4
 O5                         OL5                                                   O5                                              O5
 O10                        OL10                                                  OL103                                           OL103
-O11αβ,2α                   OL2α, wbmVWX                                          O2ac                                            O1/O2v1, wbmVWX
-O11α,2α                    OL2α, wbmVW                                           O2ac                                            O1/O2v1, wbmVW
-O11αβ,2β                   OL2α, gml2β, wbmVWX                                   O2ac                                            O1/O2v2, wbmVWX
-O11α,2β                    OL2α, gml2β, wbmVW                                    O2ac                                            O1/O2v2, wbmVW
-O11αβ,2γ                   OL2α, orf8, wbmVWX                                    O2ac                                            O1/O2v3, wbmVW
+O11αβ,2α                   OL2(α/β/γ), wbmVWX                                    O2ac                                            O1/O2v1, wbmVWX
+O11α,2α                    OL2(α/β/γ), wbmVW                                     O2ac                                            O1/O2v1, wbmVW
+O11αβ,2β                   OL2(α/β/γ), gml2β, wbmVWX                             O2ac                                            O1/O2v2, wbmVWX
+O11α,2β                    OL2(α/b/γ), gml2β, wbmVW                              O2ac                                            O1/O2v2, wbmVW
+O11αβ,2γ                   OL2(α/β/γ), orf8, wbmVWX                              O2ac                                            O1/O2v3, wbmVW
 O12                        OL12                                                  O12                                             O12
 O13                        OL13                                                  O13                                             OL13
 O14                        OL14                                                  OL102                                           OL102

--- a/docs/source/Legacy.rst
+++ b/docs/source/Legacy.rst
@@ -1,0 +1,72 @@
+*******************************************************
+Legacy Database Information
+*******************************************************
+
+.. note::
+    This page contains information about legacy Kaptive databases for backwards compatibility and interpretation of
+    old results.
+
+.. _Legacy-Klebsiella-O-locus-database:
+
+Legacy *Klebsiella* O locus database
+------------------------------------------
+
+The *Klebsiella* O locus database (``Klebsiella_o_locus_primary_reference.gbk``) contains annotated sequences for 13
+distinct *Klebsiella* O loci.
+
+O locus classification requires some special logic, as the O1 and O2 serotypes are associated with the same loci and
+the distinction between O1 and each of the four defined O2 subtypes (O2a, O2afg, O2ac, O2aeh) is determined by the
+presence/absence of 'extra genes' elsewhere in the chromosome as indicated in the table below. Kaptive therefore looks
+for these genes to predict antigen (sub)types. (Note that the original implementation of O locus typing in Kaptive
+(< v2.0) distinguished O1 and O2 but not the O2 subtypes.)
+
+Read more about the O locus and its classification here: `The diversity of *Klebsiella* pneumoniae surface polysaccharides <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5320592/>`_.
+
+Find out about the genetic determinants of O1 and O2 (sub)types here: `Molecular basis for the structural diversity in serogroup O2-antigen polysaccharides in *Klebsiella pneumoniae* <https://pubmed.ncbi.nlm.nih.gov/29602878/>`_.
+
+Find out about the O1 glycoforms and their genetic determinants here: `Identification of a second glycoform of the clinically prevalent O1 antigen from *Klebsiella pneumoniae*. <https://doi.org/10.1073/pnas.2301302120>`_
+
+Database versions:
+
+* Kaptive v0.4.0 and above include the original version of the *Klebsiella* O locus database, as described in `Wick, R. et al. J Clin Microbiol 2019 <http://jcm.asm.org/content/56/6/e00197-18>`_.
+* Kaptive v2.0 and above include a novel O locus reference (O1/O2v3) and updated 'Extra genes' for prediction of O1 and O2 antigen (sub)types, as shown in the table below and described in `Lam, M.M.C et al. 2021. Microbial Genomics 2022. <https://doi.org/10.1099/mgen.0.000800>`_
+* Kaptive v2.0.8 and above include:
+
+  i) updated 'Extra genes' logic for prediction of O1 glycoforms, reported as O1a (isolate predicted to produce O1a
+     only) and O1ab (isolate predicted to be able to produce both O1a and O1b glycoforms);
+
+  ii) OL101 re-assigned as OL13 and its associated phenotype prediction updated to O13, to reflect the
+      `description of the novel O13 polysaccharide structure <https://www.sciencedirect.com/science/article/pii/S0144861723010469>`_.
+
+Genetic determinants of O1 and O2 outer LPS antigens as reported in Kaptive:
+
+========= ==================== ================================== ================================= ======================================== ==================================
+O locus   Extra genes          Kaptive < v2.0 (locus\ :sup:`a`)   Kaptive v2.0+ (locus\ :sup:`a`)   Kaptive v2.0 - v2.0.7 (type\ :sup:`b`)   Kaptive v2.0.8+ (type\ :sup:`b`)
+========= ==================== ================================== ================================= ======================================== ==================================
+O1/O2v1   none                 O2v1                               O1/O2v1                           O2a                                      O2a
+O1/O2v2   none                 O2v2                               O1/O2v2                           O2afg                                    O2afg
+O1/O2v3   none                 Na                                 O1/O2v3                           O2a                                      O2a
+O1/O2v1   *wbbYZ*              O1v1                               O1/O2v1                           Na                                       O1ab
+O1/O2v2   *wbbYZ*              O1v2                               O1/O2v2                           Na                                       O1ab
+O1/O2v3   *wbbYZ*.             Na                                 O1/O2v3                           Na                                       O1ab
+O1/O2v1   *wbbY* only          O1v1                               O1/O2v1                           O1                                       O1a
+O1/O2v2   *wbbY* only          O1v2                               O1/O2v2                           O1                                       O1a
+O1/O2v3   *wbbY* only          Na                                 O1/O2v3                           O1                                       O1a
+O1/O2v1   *wbbY* OR *wbbZ*     O1/O2v1                            Na                                Na                                       Na
+O1/O2v2   *wbbY* OR *wbbZ*     O1/O2v2                            Na                                Na                                       Na
+O1/O2v3   *wbbY* OR *wbbZ*     Na                                 Na                                Na                                       Na
+O1/O2v1   *wbmVW*              Na                                 O1/O2v1                           O2ac                                     O2ac
+O1/O2v2   *wbmVW*              Na                                 O1/O2v2                           O2ac                                     O2ac
+O1/O2v3   *wbmVW*              Na                                 O1/O2v3                           O2ac                                     O2ac
+O1/O2v1   *gmlABD*             Na                                 O1/O2v1                           O2aeh                                    O2aeh
+O1/O2v2   *gmlABD*             Na                                 O1/O2v2                           O2aeh                                    O2aeh
+O1/O2v3   *gmlABD*             Na                                 O1/O2v3                           O2aeh                                    O2aeh
+O1/O2v1   *wbbY* AND *wbmVW*   Na                                 O1/O2v1                           O1 (O2ac)\ :sup:`b`                      O1 (O2ac)\ :sup:`b`
+O1/O2v2   *wbbY* AND *wbmVW*   Na                                 O1/O2v2                           O1 (O2ac)\ :sup:`b`                      O1 (O2ac)\ :sup:`b`
+O1/O2v3   *wbbY* AND *wbmVW*   Na                                 O1/O2v3                           O1 (O2ac)\ :sup:`b`                      O1 (O2ac)\ :sup:`b`
+========= ==================== ================================== ================================= ======================================== ==================================
+
+
+- :sup:`a` as reported in the ‘Best match locus’ column in the Kaptive output.
+- :sup:`b` predicted antigenic serotype reported in the 'Best match type' column in the Kaptive output (v2.0 and above).
+- Na- not applicable

--- a/docs/source/Outputs.rst
+++ b/docs/source/Outputs.rst
@@ -37,7 +37,7 @@ Extra genes, details                     Gene names for the extra genes found in
  Numbers beside gene names indicate the percent identity and percent coverage of the gene in the assembly.
 
 .. note::
- You may sometimes see two copies of the same gene in the ``Expected genes in locus, details `` column.
+ You may sometimes see two copies of the same gene in the ``Expected genes in locus, details`` column.
  These represent (likely) parts of the same gene which have usually been split over contigs.
  In Kaptive v3.0.0 onwards, we adopted this behaviour to allow users to see where locus splitting as occurred,
  and determine the total percent identity of a gene that has been split.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,10 +7,10 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Kaptive'
-copyright = '2024, Tom Stanton, Ryan Wick, Kathryn Holt, Kelly Wyres'
+copyright = '2025, Tom Stanton, Ryan Wick, Kathryn Holt, Kelly Wyres'
 author = 'Tom Stanton'
-release = '3.0.0'
-version = '3.0.0'
+release = '3.1.0'
+version = '3.1.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,15 +12,20 @@
    Outputs
    Interpreting-the-results
    Databases
+   Legacy
    FAQs
 
 ########################
 Introducing Kaptive 3
 ########################
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.11257262.svg
-    :target: https://doi.org/10.5281/zenodo.11257262
-    :alt: DOI
+.. image:: http://img.shields.io/badge/DOI-10.1101/2025.02.05.636613-B31B1B.svg
+    :target: https://doi.org/10.1101/2025.02.05.636613
+    :alt: BioRxiv
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.14000416.svg
+    :target: https://doi.org/10.5281/zenodo.14000416
+    :alt: Zenodo
 
 .. image:: https://img.shields.io/github/stars/klebgenomics/Kaptive
    :alt: GitHub Repo stars
@@ -61,7 +66,8 @@ Kaptive can be found:
 
 Citation
 ==========
-* If you use Kaptive and the *Klebsiella* K or O locus databases in your research, please cite [#kaptive]_ and [#kaptive2]_.
+* If you use Kaptive in your research, please cite [#kaptive3]_.
+* If you use the *Klebsiella* K or O locus databases, please cite [#kaptive]_ and [#kaptive2]_.
 * If you use `Kaptive Web <https://kaptive-web.erc.monash.edu/>`_, please cite [#kaptiveweb]_.
 * If you use the *A. baumannii* K or OC locus database(s) in your research please cite [#aci]_ and [#aciupdate]_.
 * Lists of papers describing each of the individual *A. baumannii* reference loci can be found `here <https://github.com/katholt/Kaptive/tree/master/extras>`_.
@@ -90,11 +96,11 @@ People
 
 `Contact Kelly and Tom <kaptive.typing@gmail.com>`_ for help with Kaptive, or to report bugs or request features.
 
-
 References
 =============
 .. [#aciupdate] Cahill, S.M., Hall, R.M., Kenyon, J.J., 2022. An update to the database for *Acinetobacter baumannii* capsular polysaccharide locus typing extends the extensive and diverse repertoire of genes found at and outside the K locus. *Microbial Genomics* 8. https://doi.org/10.1099/mgen.0.000878
 .. [#kaptive2] Lam, M.M.C., Wick, R.R., Judd, L.M., Holt, K.E., Wyres, K.L., 2022. Kaptive 2.0: updated capsule and lipopolysaccharide locus typing for the *Klebsiella pneumoniae* species complex. *Microbial Genomics* 8. https://doi.org/10.1099/mgen.0.000800
+.. [#kaptive3] Stanton TD, Hetland MAK, Löhr IH, Holt KE, Wyres KL. Fast and Accurate in silico Antigen Typing with Kaptive 3 [Internet]. bioRxiv; 2025 [cited 2025 Feb 27]. p. 2025.02.05.636613. https://www.biorxiv.org/content/10.1101/2025.02.05.636613v1
 .. [#vpara] Van Der Graaf-van Bloois, L., Chen, H., Wagenaar, J.A., Zomer, A.L., 2023. Development of Kaptive databases for *Vibrio parahaemolyticus* O- and K-antigen genotyping. *Microbial Genomics* 9. https://doi.org/10.1099/mgen.0.001007
 .. [#kaptiveweb] Wick, R.R., Heinz, E., Holt, K.E., Wyres, K.L., 2018. Kaptive Web: User-Friendly Capsule and Lipopolysaccharide Serotype Prediction for *Klebsiella* Genomes. *Journal of Clinical Microbiology* 56, 10.1128/jcm.00197-18. https://doi.org/10.1128/jcm.00197-18
 .. [#aci] Wyres, K.L., Cahill, S.M., Holt, K.E., Hall, R.M., Kenyon, J.J., 2020. Identification of *Acinetobacter baumannii* loci for capsular polysaccharide (KL) and lipooligosaccharide outer core (OCL) synthesis in genome assemblies using curated reference databases compatible with Kaptive. *Microbial Genomics* 6. https://doi.org/10.1099/mgen.0.000339

--- a/kaptive/database.py
+++ b/kaptive/database.py
@@ -13,6 +13,7 @@ If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
 import os
+from itertools import chain
 from os import PathLike, path, listdir
 from functools import cached_property
 from typing import Generator, TextIO
@@ -96,10 +97,12 @@ class Database:
         return self._expected_gene_counts
 
     def format(self, format_spec):
-        # f"##gff-version 3\n{''.join([i.as_gff_string() for i in self.loci.values()])}"
-        if format_spec in {'fna', 'ffn', 'faa'}:
-            return ''.join([locus.format(format_spec) for locus in self])
-        raise ValueError(f'Invalid format specifier: {format_spec}')
+        if format_spec in {'fna'}:
+            return ''.join([locus.format(format_spec) for locus in self.loci.values()])
+        elif format_spec in {'ffn', 'faa'}:
+            return ''.join([gene.format(format_spec) for gene in chain(self.genes.values(), self.extra_genes.values())])
+        else:
+            raise ValueError(f'Invalid format specifier: {format_spec}')
 
     def add_locus(self, locus: Locus):
         """

--- a/kaptive/database.py
+++ b/kaptive/database.py
@@ -16,7 +16,6 @@ import os
 from os import PathLike, path, listdir
 from functools import cached_property
 from typing import Generator, TextIO
-from itertools import chain
 import re
 from warnings import catch_warnings
 from io import TextIOBase
@@ -56,19 +55,16 @@ class DatabaseError(Exception):
 
 class Database:
     def __init__(self, name: str, loci: dict[str, Locus] = None, genes: dict[str, Gene] = None,
-                 extra_loci: dict[str, Locus] = None, extra_genes: dict[str, Gene] = None,
-                 gene_threshold: float = None):
+                 extra_genes: dict[str, Gene] = None, gene_threshold: float = None):
         self.name = name
         self.loci = loci or {}
-        self.extra_loci = extra_loci or {}
         self.genes = genes or {}
         self.extra_genes = extra_genes or {}
         self.gene_threshold = gene_threshold or _GENE_THRESHOLDS.get(self.name, 0)
         self._expected_gene_counts = None
 
     def __repr__(self):
-        return (f"{self.name} ({len(self.loci)} Loci) ({len(self.genes)} Genes) ({len(self.extra_loci)} Extra Loci) "
-                f"({len(self.extra_genes)} Extra Genes)")
+        return f"{self.name} ({len(self.loci)} Loci) ({len(self.genes)} Genes) ({len(self.extra_genes)} Extra Genes)"
 
     def __str__(self) -> str:
         return self.name
@@ -77,7 +73,7 @@ class Database:
         return len(self.loci)
 
     def __iter__(self):
-        return chain(self.loci.values(), self.extra_loci.values())
+        return iter(self.loci.values())
 
     def __getitem__(self, item: str | int) -> Locus | Gene:
         if isinstance(item, int):
@@ -85,7 +81,7 @@ class Database:
                 raise DatabaseError(f'Index {item} out of range for database {self.name}')
             return list(self.loci.values())[item]
         if not (
-        result := self.loci.get(item, self.extra_loci.get(item, self.genes.get(item, self.extra_genes.get(item))))):
+        result := self.loci.get(item, self.genes.get(item, self.extra_genes.get(item)))):
             raise DatabaseError(f'Could not find {item} in database {self.name}')
         return result
 
@@ -109,15 +105,19 @@ class Database:
         """
         Adds a locus and its genes to the database. Checks that the locus and genes don't already exist in the database.
         """
-        locus_dict, gene_dict = (self.loci, self.genes) if not locus.extra() else (self.extra_loci, self.extra_genes)
-        if locus.name in locus_dict:
-            raise DatabaseError(f'Locus {locus.name} already exists in database {self.name}.')
-        locus_dict[locus.name] = locus
-        locus.db = self
-        for gene in locus:
-            if gene.name in gene_dict:
-                raise DatabaseError(f'Gene {gene} already exists in database {self.name}.')
-            gene_dict[gene.name] = gene
+        if not locus.name.startswith('Extra_genes'):
+            if locus.name in self.loci:
+                raise DatabaseError(f'Locus {locus.name} already exists in database {self.name}.')
+            self.loci[locus.name] = locus
+            for gene in locus:
+                if gene.name in self.genes:
+                    raise DatabaseError(f'Gene {gene} already exists in database {self.name}.')
+                self.genes[gene.name] = gene
+        else:
+            for gene in locus:
+                if gene.name in self.extra_genes:
+                    raise DatabaseError(f'Gene {gene} already exists in database {self.name}.')
+                self.extra_genes[gene.name] = gene
 
     def add_phenotype(self, loci: list[str], genes: dict[str, str], phenotype: str):
         extra_genes = {(g.name, 'present') for g in self.extra_genes.values() if g.gene_name in genes}
@@ -162,16 +162,29 @@ class Locus:
         n = 1
         for feature in record.features:  # type: SeqFeature
             if feature.type == 'CDS':
-                gene = Gene.from_feature(record, feature, position_in_locus=n, locus=self)
-                if gene.name in self.genes:
-                    raise LocusError(f'Gene {gene} already exists in locus {self}')
-                if gene.locus and gene.locus != self:
-                    raise LocusError(f'Gene {gene} is from a different locus than locus {self}')
+
+                name = f"{locus_name}_{str(n).zfill(2)}" + (
+                    f"_{gene_name}" if (gene_name := feature.qualifiers.get('gene', [''])[0]) else '')
+
+                gene = Gene(
+                    name=name, gene_name=gene_name, dna_seq=feature.extract(record.seq), start=feature.location.start,
+                    end=feature.location.end, strand='+' if feature.location.strand == 1 else '-',
+                    product=feature.qualifiers.get('product', [''])[0]
+                )
+
+                if not len(gene.dna_seq) % 3 == 0:  # Check the gene is a multiple of 3 (complete CDS)
+                    # TODO: this is quite strict, but enforces the inclusion of complete CDS in Kaptive databases
+                    raise GeneError(f'DNA sequence of {name} is not a multiple of 3')
+
+                if name in self.genes:
+                    raise LocusError(f'Gene {name} already exists in locus {self}')
+
                 if extract_translations:  # Force translation of the gene
                     gene.extract_translation()
-                self.genes[gene.name] = gene
+
+                self.genes[name] = gene
                 n += 1
-        self.type_label = type_name if not self.extra() else None  # Extra genes don't have a type
+        self.type_label = type_name if not self.name.startswith('Extra_genes') else None  # Extra genes don't have a type
         return self
 
     def __hash__(self):  # TODO: Check if this is used at all
@@ -190,9 +203,6 @@ class Locus:
 
     def __iter__(self):
         return iter(self.genes.values())
-
-    def extra(self) -> bool:
-        return self.name.startswith('Extra_genes')
 
     def add_phenotype(self, genes: dict[str, str] | None, extra_genes: set[tuple[str, str]] | None, phenotype: str,
                       strict: bool = False):
@@ -228,19 +238,11 @@ class Locus:
                     with open(path.join(f, f'{self.name.replace("/", "_")}.{fmt}'), 'wt') as handle:
                         handle.write(self.format(fmt))
 
-    # def as_gff_record(self) -> GffRecord:
-    #     return GffRecord(seqid=self.name, source='Kaptive', type_='region', start=1, end=len(self), score=0,
-    #                      strand='+', phase=0, attributes={"ID": f"locus:{self.name}", "Name": self.name})
-    #
-    # def as_gff_string(self) -> str:
-    #     return str(self.as_gff_record()) + ''.join([i.as_gff_string() for i in self.genes.values()])
-
 
 class GeneError(Exception):
     pass
 
 
-# TODO: consider renaming this to CDS
 class Gene:
     """
     This class prepares and stores a CDS feature from a Kaptive reference genbank file.
@@ -248,33 +250,16 @@ class Gene:
     extract it from the record.
     """
 
-    def __init__(self, name: str = None, locus: Locus = None, position_in_locus: int | None = 0,
-                 start: int | None = 0, end: int | None = 0, strand: str = None, protein_seq: Seq = None,
-                 dna_seq: Seq = None, gene_name: str = None, product: str = None):
+    def __init__(self, name: str, start: int = 0, end: int = 0, strand: str = "+",
+                 protein_seq: Seq = None, dna_seq: Seq = None, gene_name: str = None, product: str = None):
         self.name = name or ''
-        self.locus = locus  # Keep reference to parent class for now
-        self.position_in_locus = position_in_locus
         self.start = start  # 0-based
         self.end = end
         self.strand = strand  # Either + or -
         self.gene_name = gene_name or ''
-        self.name = name or ''
         self.product = product or ''  # Can also be description
         self.dna_seq = dna_seq or Seq('')
         self.protein_seq = protein_seq or Seq('')
-
-    @classmethod
-    def from_feature(cls, record: SeqRecord, feature: SeqFeature, **kwargs):
-        self = cls(
-            start=feature.location.start, end=feature.location.end, strand='+' if feature.location.strand == 1 else '-',
-            dna_seq=feature.extract(record.seq), product=feature.qualifiers.get('product', [''])[0], **kwargs)
-        self.name = f"{self.locus.name}_{str(self.position_in_locus).zfill(2)}" + (
-            f"_{x}" if (x := feature.qualifiers.get('gene', [''])[0]) else '')
-        self.gene_name = x
-        if not len(self.dna_seq) % 3 == 0:  # Check the gene is a multiple of 3 (complete CDS)
-            # TODO: this is quite strict, but enforces the inclusion of complete CDS in Kaptive databases
-            return quit_with_error(f'DNA sequence of {self} is not a multiple of 3')
-        return self
 
     def __hash__(self):
         return hash(self.name)  # The name of the gene is unique and immutable
@@ -299,9 +284,6 @@ class Gene:
             return f'>{self.name}\n{self.protein_seq}\n'
         raise ValueError(f'Invalid format specifier: {format_spec}')
 
-    def extra(self) -> bool:
-        return self.name.startswith('Extra_genes')
-
     def extract_translation(self, **kwargs):
         """
         Extracts the protein sequence from the DNA sequence of the gene. Implemented as a method so unnecessary
@@ -321,69 +303,6 @@ class Gene:
                 #     warning(f"{i.message}: {self.__repr__()}")
             if len(self.protein_seq) == 0:
                 warning(f'No protein sequence for reference {self}')
-
-    # def as_gff_record(self, ensembl_format: bool = False) -> list[GffRecord]:
-    #     """
-    #     Returns the gene, transcript and CDS GFF Records compatible with bcftools csq.
-    #     See format specification here: https://samtools.github.io/bcftools/bcftools.html#csq
-    #     """
-    #     if ensembl_format:  # for bcftools csq
-    #         return [
-    #             GffRecord(
-    #                 seqid=self.locus.name, source='Kaptive', type_='gene', start=self.start + 1,
-    #                 end=self.end, score=0, strand=self.strand, phase=0,
-    #                 attributes={"ID": f"gene:{self.name}", "biotype": "protein_coding", "Name": self.gene_name,
-    #                             "description": self.product}),
-    #             GffRecord(
-    #                 seqid=self.locus.name, source='Kaptive', type_='transcript', start=self.start + 1,
-    #                 end=self.end, score=0, strand=self.strand, phase=0,
-    #                 attributes={"ID": f"transcript:{self.name}.t1", "Parent": f"gene:{self.name}",
-    #                             "biotype": "protein_coding"}),
-    #             GffRecord(seqid=self.locus.name, source='Kaptive', type_='CDS', start=self.start + 1,
-    #                       end=self.end, score=0, strand=self.strand, phase=0,
-    #                       attributes={"ID": f"CDS:{self.name}.cds1", "Parent": f"transcript:{self.name}.t1"})
-    #         ]
-    #     else:  # Usual NCBI format
-    #         return [
-    #             GffRecord(
-    #                 seqid=self.locus.name, source='Kaptive', type_='gene', start=self.start + 1,
-    #                 end=self.end, score=0, strand=self.strand, phase=0,
-    #                 attributes={"ID": self.name, "Name": self.gene_name, "gene": self.gene_name, "locus_tag": self.name}
-    #             ),
-    #             GffRecord(
-    #                 seqid=self.locus.name, source='Kaptive', type_='CDS', start=self.start + 1,
-    #                 end=self.end, score=0, strand=self.strand, phase=0,
-    #                 attributes={"ID": self.name, "Name": self.gene_name, "gene": self.gene_name, "Parent": self.name,
-    #                             "product": self.product, "transl_table": '11', "locus_tag": self.name}),
-    #         ]
-    #
-    # def as_gff_string(self) -> str:
-    #     return ''.join([str(i) for i in self.as_gff_record()])
-
-
-# class GffRecordError(Exception):
-#     pass
-#
-#
-# class GffRecord:
-#     def __init__(self, seqid: str= None, source: str= None,
-#                  type_: str= None, start: int= None, end: int= None, score: float | None = 0,
-#                  strand: str= None, phase: float | None = 0, attributes: dict= None):
-#         # https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md
-#
-#         self.seqid = seqid or ''
-#         self.source = source or ''
-#         self.type = type_ or ''
-#         self.start = start or 0
-#         self.end = end or 0
-#         self.score = score or 0
-#         self.strand = strand or ''
-#         self.phase = phase or 0
-#         self.attributes = attributes or {}
-#
-#     def __str__(self):
-#         return f"{self.seqid}\t{self.source}\t{self.type}\t{self.start}\t{self.end}\t{self.score}\t{self.strand}\t" \
-#                f"{self.phase}\t{';'.join(f'{key}={value}' for key, value in self.attributes.items() if value)}\n"
 
 
 # Functions ------------------------------------------------------------------------------------------------------------
@@ -467,7 +386,7 @@ def parse_database(db: str | PathLike, locus_filter: re.Pattern = None, load_loc
             locus_name, type_name = name_from_record(record, **kwargs)
             if not locus_name:
                 quit_with_error(f'Could not parse locus name from {record.id}')
-            if type_name == "unknown" or (not type_name and not locus_name.startswith('Extra')):
+            if type_name == "unknown" or (not type_name and not locus_name.startswith('Extra_genes')):
                 type_name = f'unknown ({locus_name})'  # Add the locus name to the type name if it is unknown
             if locus_filter and not locus_filter.search(locus_name):
                 continue
@@ -484,6 +403,8 @@ def load_database(argument: str | PathLike, gene_threshold: float = None, **kwar
     if not db.loci:  # Check that loci were properly loaded
         quit_with_error(f'No loci found in database {db.name}')
     if path.isfile(logic_file := f'{path.splitext(db_path)[0]}.logic'):  # Load phenotype logic
+        logic = list(parse_logic(logic_file))
+
         [db.add_phenotype(*i) for i in parse_logic(logic_file)]
     for n, locus in enumerate(db.loci.values()):
         locus.index = n

--- a/kaptive/typing.py
+++ b/kaptive/typing.py
@@ -178,19 +178,25 @@ class TypingResult:
         if format_spec == 'tsv':
             return '\t'.join(
                 [
-                    self.sample_name, self.best_match.name, self.phenotype, self.confidence, self.problems,
-                    f"{self.percent_identity:.2f}%", f"{self.percent_coverage:.2f}%",
+                    self.sample_name,
+                    self.best_match.name,
+                    self.phenotype,
+                    self.confidence,
+                    self.problems,
+                    f"{self.percent_identity:.2f}%",
+                    f"{self.percent_coverage:.2f}%",
                     f"{self.__len__() - len(self.best_match)} bp" if len(self.pieces) == 1 else 'n/a',
-                    f"{(x := len({i.gene.name for i in self.expected_genes_inside_locus}))} / {(y := len(self.best_match.genes))} ({100 * x / y:.2f}%)",
-                    ';'.join(str(i) for i in x) if (x := self.expected_genes_inside_locus) else '',
-                    ';'.join(self.missing_genes), f"{len(x := self.unexpected_genes_inside_locus)}",
-                    ';'.join(str(i) for i in x) if x else '',
-                    f"{len(x := self.expected_genes_outside_locus)} / {(y := len(self.best_match.genes))} ({100 * len(x) / y:.2f}%)",
-                    ';'.join(str(i) for i in x) if x else '',
-                    f"{len(x := self.unexpected_genes_outside_locus)}",
-                    ';'.join(str(i) for i in x) if x else '',
-                    ';'.join(str(i) for i in filter(lambda z: z.phenotype == "truncated", self)),
-                    ';'.join([str(i) for i in self.extra_genes])
+                    f"{(n_inside := len({i.gene.name for i in self.expected_genes_inside_locus}))} / {(n_expected := len(self.best_match.genes))} ({100 * n_inside / n_expected:.2f}%)",
+                    ';'.join(map(str, self.expected_genes_inside_locus)),
+                    ';'.join(self.missing_genes),
+                    f"{len(self.unexpected_genes_inside_locus)}",
+                    ';'.join(map(str, self.unexpected_genes_inside_locus)),
+                    f"{(n_outside := len({i.gene.name for i in self.expected_genes_outside_locus}))} / {n_expected} ({100 * n_outside / n_expected:.2f}%)",
+                    ';'.join(map(str, self.expected_genes_outside_locus)),
+                    f"{len(self.unexpected_genes_outside_locus)}",
+                    ';'.join(map(str, self.unexpected_genes_outside_locus)),
+                    ';'.join(map(str, filter(lambda z: z.phenotype == "truncated", self))),
+                    ';'.join(map(str, self.extra_genes))
                 ]
             ) + "\n"
         if format_spec == 'fna':  # Return the nucleotide sequence of the locus

--- a/kaptive/version.py
+++ b/kaptive/version.py
@@ -14,4 +14,4 @@ details. You should have received a copy of the GNU General Public License along
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-__version__ = '3.0.0b6'
+__version__ = '3.1.0'

--- a/reference_database/Klebsiella_o_locus_primary_reference.gbk
+++ b/reference_database/Klebsiella_o_locus_primary_reference.gbk
@@ -1,6 +1,5 @@
 LOCUS       LT174601                8064 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O1/O2, Variant 1.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL2α.1
 ACCESSION   LT174601
 VERSION     LT174601.1  GI:1036211075
 KEYWORDS    .
@@ -24,7 +23,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="94"
-                     /serovar="O1/O2 Variant 1"
                      /db_xref="taxon:573"
                      /note="O locus: OL2α.1"
                      /note="O type: O2α"
@@ -304,8 +302,7 @@ ORIGIN
      8041 gcgttaatca cgaggaaaat gtaa
 //
 LOCUS       LT174602                7926 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis
-            gene cluster, type: O1/O2, Variant 2.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL2α.2
 ACCESSION   LT174602 REGION: 1..7926
 VERSION     LT174602.1
 KEYWORDS    .
@@ -330,7 +327,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="441"
-                     /serovar="O1/O2 Variant 2"
                      /db_xref="taxon:573"
                      /note="O locus: OL2α.2"
                      /note="O type: O2α"
@@ -603,8 +599,7 @@ ORIGIN
      7921 gactag
 //
 LOCUS       MG280710                8047 bp    DNA     linear   BCT 14-FEB-2018
-DEFINITION  Klebsiella pneumoniae strain CWK53 rfb gene cluster, complete
-            sequence.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL2α.3
 ACCESSION   MG280710 REGION: 1..8047
 VERSION     MG280710.1
 KEYWORDS    .
@@ -640,7 +635,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="CWK53"
-                     /serotype="O2aeh"
                      /note="O locus: OL2α.3"
                      /note="O type: O2α"
                      /note="Updated from O1/O2v3 by Tom Stanton in March 2025, trimmed to remove HisI and Orf8"
@@ -906,8 +900,7 @@ ORIGIN
      8041 taaataa
 //
 LOCUS       LT174603               11906 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O3/O3a.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL3α/β
 ACCESSION   LT174603
 VERSION     LT174603.1  GI:1036211094
 KEYWORDS    .
@@ -931,9 +924,8 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="AKPRH077088"
-                     /serovar="O3/O3a"
                      /db_xref="taxon:573"
-                     /note="O locus: OL3αβ"
+                     /note="O locus: OL3α/β"
                      /note="O type: O3αβ"
                      /note="annotation edited from original by K. Wyres Jan
                      2018"
@@ -1315,8 +1307,7 @@ ORIGIN
     11881 ctacgctgct ggaaagcaaa tcctga
 //
 LOCUS       LT174604               11838 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O3b.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL3γ
 ACCESSION   LT174604
 VERSION     LT174604.1  GI:1036211103
 KEYWORDS    .
@@ -1340,9 +1331,8 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="539"
-                     /serovar="O3b"
                      /db_xref="taxon:573"
-                     /note="O locus: O3γ"
+                     /note="O locus: OL3γ"
                      /note="O type: O3γ"
                      /note="annotation edited from original by K. Wyres Jan
                      2018"
@@ -1368,7 +1358,7 @@ FEATURES             Location/Qualifiers
                      VKKAVEFLKQNQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
                      AEHWVILAGTGQVTVNGKQFLLTENQSTFIPIGAEHSLENPGRIPLEVLEIQSGSYLGE
                      DDIIRIKDQYGRC"
-                     /locus_tag="O3γ_01_manC"
+                     /locus_tag=" OL3γ_01_manC"
      gene            1439..2821
                      /gene="manB"
      CDS             1439..2821
@@ -1390,7 +1380,7 @@ FEATURES             Location/Qualifiers
                      YCDSGMIPWLLVAELLCLKNSSLKSLVADRQAAFPASGEINRKLGNAAEAIARIRAQYE
                      PAAAHIDTTDGISIEYPEWRFNLRTSNTEPVVRLNVESRADTALMNEKTAELLNLLKEE
                      SL"
-                     /locus_tag="O3γ_02_manB"
+                     /locus_tag=" OL3γ_02_manB"
      gene            2827..3612
                      /gene="wzm"
      CDS             2827..3612
@@ -1407,7 +1397,7 @@ FEATURES             Location/Qualifiers
                      RICLPIIVTASAFINFLIIFGLFVLFLIVTGNFPGMIFFEIIPVLIVQMLFTLGLGIIL
                      GVLNVFVRDVGQFVNILLQFWFWFTPIVYVSKTLPEWVSGLLAYNPMATIIGSYQNVML
                      YHQSPNWLALLPVTVLSVILFLFAWRLFKKHAADIVDEI"
-                     /locus_tag="O3γ_03_wzm"
+                     /locus_tag=" OL3γ_03_wzm"
      gene            3615..4910
                      /gene="wzt"
      CDS             3615..4910
@@ -1428,7 +1418,7 @@ FEATURES             Location/Qualifiers
                      EEYRWGQGGAKIIDYHIQSAGVDFPPSLTGNQQTDFLMKVVFEYDFDCVVPGLLIKTLD
                      GLFLYGTNSFLASEGRENISVSRGDVRVFKFSFPVDLNSGDYLLSFGISEGSPQTEMTP
                      LDRRYDSIILHVTKSMDFWGVIDLKSTFNSYK"
-                     /locus_tag="O3γ_04_wzt"
+                     /locus_tag=" OL3γ_04_wzt"
      gene            4931..6988
                      /gene="wbdD"
      CDS             4931..6988
@@ -1452,7 +1442,7 @@ FEATURES             Location/Qualifiers
                      PQDVTTNVQPRIEIEQSKAVDSEEIMRLHTQLNDAQQEIENLRHEIAKIHYSRSWKMTK
                      WYRYAGLQYYLLRQYGFKQRFKHLLKRVLSNVIYFLRAHPRLKQKVINLLRTIGIYDFA
                      YRMHRRMNPGSHNPYPNDPQYQSQTEKQILHPELLPPEVNSIFSELKNKR"
-                     /locus_tag="O3γ_05_wbdD"
+                     /locus_tag=" OL3γ_05_wbdD"
      gene            6999..9521
                      /gene="wbdA"
      CDS             6999..9521
@@ -1480,7 +1470,7 @@ FEATURES             Location/Qualifiers
                      LFIIGKQGWHVDDLCERLRHHPQLNKKLFWLQNISDEFLTKLYSQSSALIFASLGEGFG
                      LPLIEAAQKKLPVIIRDIPVFKEIAQEHAWYFSGEAPADIAKAVEDWLALYEQNAHPRS
                      ENINWLTWKQSAEFLLKNLPIIAPAAKQ"
-                     /locus_tag="O3γ_06_wbdA"
+                     /locus_tag=" OL3γ_06_wbdA"
      gene            9568..10713
                      /gene="wbdB"
      CDS             9568..10713
@@ -1500,7 +1490,7 @@ FEATURES             Location/Qualifiers
                      LLQAYQLLPMETRMRYPLILSGYRGWEDDVLWQLVERGTREGWIRYLGYVPDEDLPYLY
                      AAARTFVYPSFYEGFGLPILEAMSCGVPVVCSNVTSLPEVVGDAGLVADPNDVDAISAH
                      ILQSLQDDSWREIATARGLAQAKQFSWENCTTQTINAYKLL"
-                     /locus_tag="O3γ_07_wbdB"
+                     /locus_tag=" OL3γ_07_wbdB"
      gene            10723..11838
                      /gene="wbdC"
      CDS             10723..11838
@@ -1520,7 +1510,7 @@ FEATURES             Location/Qualifiers
                      IVGGGPLEAEVRREAQQRGLSNVVFTGMLNDEDKYILFQLCRGVVFPSHLRSEAFGITL
                      LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPNDSQALVEAMNELWHNDETASRYGE
                      NSRRRFEEMFTADHMIDAYVNLYTTLLESKS"
-                     /locus_tag="O3γ_08_wbdC"
+                     /locus_tag=" OL3γ_08_wbdC"
 ORIGIN
         1 atgttgcttc ctgtgatcat ggctggtggt accggcagtc gtctctggcc gatgtctcgc
        61 gagctttacc cgaaacagtt cctccgcctg ttcgggcaga actccatgct gcaggaaacc
@@ -1722,8 +1712,7 @@ ORIGIN
     11821 ctggaaagca aatcctga
 //
 LOCUS       LT174605                9449 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O4.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL4
 ACCESSION   LT174605
 VERSION     LT174605.1  GI:1036211112
 KEYWORDS    .
@@ -1747,9 +1736,8 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="AJ214"
-                     /serovar="O4"
                      /db_xref="taxon:573"
-                     /note="O locus: O4"
+                     /note="O locus: OL4"
                      /note="O type: O4"
                      /note="sequence manually trimmed to removed insertion
                      sequences"
@@ -2034,8 +2022,7 @@ ORIGIN
      9421 attatattct tttataagaa catttccag
 //
 LOCUS       LT174606               12084 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O5.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL5
 ACCESSION   LT174606
 VERSION     LT174606.1  GI:1036211123
 KEYWORDS    .
@@ -2059,7 +2046,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="AKPRH1202322"
-                     /serovar="O5"
                      /db_xref="taxon:573"
                      /note="O locus: OL5"
                      /note="O type: O5"
@@ -2444,8 +2430,7 @@ ORIGIN
     12061 acgctgctgg aaagcaaatc ctga
 //
 LOCUS       LT174598                8048 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: OL10.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL10
 ACCESSION   LT174598
 VERSION     LT174598.1  GI:1036211050
 KEYWORDS    .
@@ -2469,7 +2454,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="QMP"
-                     /serovar="rfb_OL10"
                      /db_xref="taxon:573"
                      /note="O locus: OL10"
                      /note="O type: O10"
@@ -2734,8 +2718,7 @@ ORIGIN
      8041 cggaataa
 //
 LOCUS       LT174600                9797 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O12.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL12
 ACCESSION   LT174600
 VERSION     LT174600.1  GI:1036211066
 KEYWORDS    .
@@ -2759,7 +2742,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="AKPRH094188"
-                     /serovar="O12"
                      /db_xref="taxon:573"
                      /note="O locus: OL12"
                      /note="O type: O12"
@@ -3092,8 +3074,7 @@ ORIGIN
      9781 ttaaaaagaa tcgctaa
 //
 LOCUS       LT174596               12064 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis
-            gene cluster, type: O13 (formerly known as OL101).
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL13
 ACCESSION   LT174596
 VERSION     LT174596.1  GI:1036211031
 KEYWORDS    .
@@ -3514,8 +3495,7 @@ ORIGIN
     12061 tcat
 //
 LOCUS       LT174597                6874 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: OL14.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL14
 ACCESSION   LT174597
 VERSION     LT174597.1  GI:1036211041
 KEYWORDS    .
@@ -3539,7 +3519,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="K261An"
-                     /serovar="rfb_OL14"
                      /db_xref="taxon:573"
                      /note="O locus: OL14"
                      /note="O type: unknown"
@@ -3807,8 +3786,7 @@ ORIGIN
      6841 ccattacttt aaagtagata acgctcattg ctaa
 //
 LOCUS       LT174599               11834 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: OL15.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene cluster OL15
 ACCESSION   LT174599
 VERSION     LT174599.1  GI:1036211057
 KEYWORDS    .
@@ -3832,7 +3810,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="D-026-I-b-1"
-                     /serovar="rfb_OL15"
                      /db_xref="taxon:573"
                      /note="O locus: OL15"
                      /note="O type: unknown"
@@ -4211,8 +4188,7 @@ ORIGIN
     11821 agcagaaacc ctga
 //
 LOCUS       MG602074                3913 bp    DNA     linear   BCT 14-FEB-2018
-DEFINITION  Klebsiella pneumoniae strain 5053 wbmVWX gene cluster, complete
-            sequence.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen modification genes wbmVWX
 ACCESSION   MG602074 REGION: 1032..4944
 VERSION     MG602074.1
 KEYWORDS    .
@@ -4247,7 +4223,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="5053"
-                     /serotype="O2ac"
                      /db_xref="taxon:573"
                      /note="sequence edited to trim to wbmVWX only, Tom Stanton, March 2025"
                      /note="Extra genes: wbmVWX"
@@ -4380,8 +4355,7 @@ ORIGIN
      3901 aatttatctt cat
 //
 LOCUS       UGMM01000004            3130 bp    DNA     linear   BCT 04-OCT-2023
-DEFINITION  Klebsiella pneumoniae strain NCTC11682 genome assembly, contig:
-            ERS670329SCcontig000004, whole genome shotgun sequence.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen modification genes wbbYZ
 ACCESSION   UGMM01000004 REGION: 4729980..4733109
 VERSION     UGMM01000004.1  GI:1440143122
 KEYWORDS    WGS.
@@ -4402,7 +4376,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="NCTC11682"
-                     /serovar="not available: to be reported later"
                      /db_xref="taxon:573"
                      /note="contig: ERS670329SCcontig000004"
                      /note="Extra genes: wbbYZ"
@@ -4506,8 +4479,7 @@ ORIGIN
      3121 GTTAAAATAA
 //
 LOCUS       LT174602                2817 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis
-            gene cluster, type: O1/O2, Variant 2.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen modification genes gml2β
 ACCESSION   LT174602 REGION: complement(7996..10812)
 VERSION     LT174602.1
 KEYWORDS    .
@@ -4532,11 +4504,10 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="441"
-                     /serovar="O1/O2 Variant 2"
                      /db_xref="taxon:573"
                      /note="sequence edited to trim to gmlABC only and reverse
                      complement, Tom Stanton, March 2025"
-                     /note="Extra genes: gmlABC"
+                     /note="Extra genes: gml2β"
      gene            1..378
                      /gene="gmlA"
      CDS             1..378
@@ -4547,7 +4518,7 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /product="GtrA-like protein"
                      /protein_id="CZQ25303.1"
-                     /locus_tag="Extra_genes_gmlABC_01_gmlA"
+                     /locus_tag="Extra_genes_gml2β_01_gmlA"
                      /translation="MPSSGPLWQLMKYGLVGIVNTLITAVVIFLLMHLGLGIYLSNAM
                      GYVVGIVFSFIANTIFTFTQPISINRLIKFLCVCFICYVANIIVIKIFFVFMPEKIYS
                      AQILGMFTYTITGFILNKFWAMK"
@@ -4562,7 +4533,7 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /product="glycosyltransferase"
                      /protein_id="CZQ25302.1"
-                     /locus_tag="Extra_genes_gmlABC_02_gmlB"
+                     /locus_tag="Extra_genes_gml2β_02_gmlB"
                      /translation="MTTSTDIKSTPSLAIVVPCYNEQEAFPFCLEKLSNVLNSLIARN
                      KINNNSYLLFVDDGSRDNTWAQIKDASTAYHYVRGIKLSRNKGHQIALMAGLRSVDTD
                      VTISIDADLQDDVNCIEKMIDAYSQGYDIVYGVRGNRDSDTFFKRTTANAFYAIMSHL
@@ -4578,7 +4549,7 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /product="Uncharacterised protein"
                      /protein_id="CZQ25301.1"
-                     /locus_tag="Extra_genes_gmlABC_03_gmlC"
+                     /locus_tag="Extra_genes_gml2β_03_gmlC"
                      /translation="MQNLINPLAEGNKKNVYIFYFFLLMLTFSPVIFFSYAFSDDWST
                      LFDAITRNGSSFQWDVQSGRPVYAVFRYYGKMLINDISSFSYLRLFNILSLVVLSCFI
                      YNFIDSRKIFDNPVFKIIFPLLICLLPAFQVYASWATCFPFTISVLLAGISYNKCFPH
@@ -4638,8 +4609,7 @@ ORIGIN
      2761 gattgtatgg ttattaaaac gtcagatgca atgcgaaggt caacgataaa ttattag
 //
 LOCUS       MG280710                1020 bp    DNA     linear   BCT 14-FEB-2018
-DEFINITION  Klebsiella pneumoniae strain CWK53 rfb gene cluster, complete
-            sequence.
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen modification genes orf8
 ACCESSION   MG280710 REGION: 8381..9400
 VERSION     MG280710.1
 KEYWORDS    .
@@ -4675,7 +4645,6 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="CWK53"
-                     /serotype="O2aeh"
                      /db_xref="taxon:573"
                      /note="sequence edited to trim to Orf8 on;y, Tom Stanton, March 2025"
                      /note="Extra genes: orf8"

--- a/reference_database/Klebsiella_o_locus_primary_reference.gbk
+++ b/reference_database/Klebsiella_o_locus_primary_reference.gbk
@@ -1,3 +1,3096 @@
+LOCUS       LT174601                8064 bp    DNA     linear   BCT 13-JUN-2016
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
+            cluster, type: O1/O2, Variant 1.
+ACCESSION   LT174601
+VERSION     LT174601.1  GI:1036211075
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
+            Enterobacteriaceae; Klebsiella.
+REFERENCE   1
+  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
+            Holt,K.E. and Thomson,N.R.
+  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
+            antigens
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 8064)
+  AUTHORS   Informatics,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
+            1SA, UNITED KINGDOM
+FEATURES             Location/Qualifiers
+     source          1..8064
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="94"
+                     /serovar="O1/O2 Variant 1"
+                     /db_xref="taxon:573"
+                     /note="O locus: OL2α.1"
+                     /note="O type: O2α"
+                     /note="Updated from O1/O2v1 by Tom Stanton in Feb 2025"
+     gene            1..768
+                     /gene="wzm"
+     CDS             1..768
+                     /gene="wzm"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002920348.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="lipopolysaccharide O-antigen ABC transport system
+                     transmembrane component"
+                     /protein_id="CZQ25287.1"
+                     /db_xref="GI:1036211076"
+                     /translation="MKYNLGYLFDLLVVITNKDLKVRYKSSMLGYLWSVANPLLFAMIY
+                     YFIFKLVMRVQIPNYTVFLITGLFPWQWFASSATNSLFSFIANAQIIKKTVFPRSVIPL
+                     SNVMMEGLHFLCTIPVIVVFLFVYGMTPSLSWVWGIPLIAIGQVIFTFGVSIIFSTLNL
+                     FFRDLERFVSLGIMLMFYCTPILYASDMIPEKFSWIITYNPLASMILSWRDLFMNGTLN
+                     YEYISILYFTGIILTVVGLSIFNKLKYRFAEIL"
+                     /locus_tag="OL2α.1_01_wzm"
+     gene            768..1508
+                     /gene="wzt"
+     CDS             768..1508
+                     /gene="wzt"
+                     /EC_number="3.6.3.40"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006499564.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Teichoic acid export ATP-binding protein TagH"
+                     /protein_id="CZQ25288.1"
+                     /db_xref="GI:1036211077"
+                     /translation="MHPVINFSHVTKEYPLYHHIGSGIKDLIFHPKRAFQLLKGRKYLA
+                     IEDVSFTVGKGEAVALIGRNGAGKSTSLGLVAGVIKPTKGTVTTEGRVASMLELGGGFH
+                     PELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGEFIDEPIRVYSSGMLAKLGFSV
+                     ISQVEPDILIIDEVLAVGDIAFQAKCIQTIRDFKKRGVTILFVSHNMSDVEKICDRVIW
+                     IENHRLREVGSADRIIELYKQAMA"
+                     /locus_tag="OL2α.1_02_wzt"
+     gene            1524..3419
+                     /gene="wbbM"
+     CDS             1524..3419
+                     /gene="wbbM"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006635427.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyltransferase"
+                     /protein_id="CZQ25289.1"
+                     /db_xref="GI:1036211078"
+                     /translation="MNNSVKIYTSHHKPSAFLNAAIIKPLHVGKANSYNEIGCPGDDTG
+                     DNISFKNPFYCELTAHYWVWKNEELADYVGFMHYRRHLNFSEKQTFSEDTWGVVNHPCI
+                     DEEYEKIFGLNEETIQRCVEGIDILLPKKWSVTAAGSKNNYDHYERGEYLHIRDYQAAI
+                     AIVEKLYPEYSTAIKTFNDASDGYYTNMFVMRKDIFVDYSKWLFSILDNLEDAISMNNY
+                     NAQEKRVIGHIAERLFNIYIIKLQQDGELKVKELQRTFVSNETFNGALNPVFDSAVPVV
+                     ISFDDNYAISGGALINSIVRHADKNKNYDIVVLENKVSYLNKTRLVNLTSAHPNISLRF
+                     FDVNAFTEINGVHTRAHFSASTYARLFIPQLFRRYDKVVFIDSDTVVKADLGELLDVPL
+                     GNNLVAAVKDIVMEGFVKFSAMSASDDGVMPAGEYLQKTLNMNNPDEYFQAGIIVFNVK
+                     QMVEENTFAELMRVLKAKKYWFLDQDIMNKVFYSRVTFLPLEWNVYHGNGNTDDFFPNL
+                     KFATYMKFLAARKKPKMIHYAGENKPWNTEKVDFYDDFIENIANTPWEMEIYKRQMSLA
+                     ASIGLTHSEPQQQILFQTKIKNVLMPYVNKYAPIGTPRRNMMTKYYYKVRRAILG"
+                     /locus_tag="OL2α.1_03_wbbM"
+     gene            3435..4589
+                     /gene="glf"
+     CDS             3435..4589
+                     /gene="glf"
+                     /EC_number="5.4.99.9"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_005955557.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="UDP-galactopyranose mutase"
+                     /protein_id="CZQ25290.1"
+                     /db_xref="GI:1036211079"
+                     /translation="MKSKKILIVGAGFSGAVIGRQLAEQGHQVHIIDQRDHIGGNSYDA
+                     RDAETNVMVHVYGPHIFHTDNETVWNYVNEHAEMMPYVNRVKATVNGQVFSLPINLHTI
+                     NQFFSKTCSPDEARALIAEKGDSTIADPQTFEEQALRFIGKELYEAFFKGYTIKQWGMQ
+                     PSELPASILKRLPVRFNYDDNYFNHKFQGMPKCGYTQMIKSILNHENIKVDLQREFIVE
+                     ERTHYDHVFYSGPLDAFYGYQYGRLGYRTLDFKKFTYQGDYQGCAVMNYCSVDVPYTRI
+                     TEHKYFSPWEQHDGSVCYKEYSRACEENDIPYYPIRQMGEMALLEKYLSLAENEINITF
+                     VGRLGTYRYLDMDVTIAEALKTAEVYLNSLTENQPMPVFTVSVR"
+                     /locus_tag="OL2α.1_04_glf"
+     gene            4586..5479
+                     /gene="wbbN"
+     CDS             4586..5479
+                     /gene="wbbN"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006635429.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyl transferase"
+                     /protein_id="CZQ25291.1"
+                     /db_xref="GI:1036211080"
+                     /translation="MKYTALIVTFNRLGKLKKTVEETLKLEFTNIVIVNNGSTDGTQAW
+                     LSSIVDTRVIVLTLTENTGGAGGFKTGSQYICEQLASDWVFFYDDDAYPYPDTLKSFSQ
+                     LDKRGCRVFSGLVKDPQGKPCPMNMPFSRVPTSLGDTVRYLRYPGEFIPAANRSMFVQT
+                     VSFVGMVIHRDLLATSLDYIREQLFIYFDDLYFGYQLSLAGEQIMYSPELLFYHDVSIQ
+                     GKLIAPEWKVYYLCRNLILSKKIFQKNGVYSNSAIAIRILKYILILPWQRQKYSYMKFI
+                     LRGISHGIKGISGKYH"
+                     /locus_tag="OL2α.1_05_wbbN"
+     gene            5492..6625
+                     /gene="wbbO"
+     CDS             5492..6625
+                     /gene="wbbO"
+                     /EC_number="2.4.1.250"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_005227845.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="galactosyl transferase"
+                     /protein_id="CZQ25292.1"
+                     /db_xref="GI:1036211081"
+                     /translation="MRKLCYFINSDWYFDLHWIDRAIASRDAGYEIHIISHFIDDNIIN
+                     KFKTFGFICHNVTLDAQSFNALVFFRTYHDVQKIIKNIKPDLLHCITIKPCLIGGVLAK
+                     KFNLPVIVSFVGLGRVFSSDSMPLKLLRQFTIAAYKYIASNKRCIFMFEHDRDRKKLAK
+                     LVGLEKQQTIVIDGAGINPEIYKYSLEQDNDVPVVLFASRMLWSKGLGDLIEAKKILRS
+                     KNIHFTLNVAGILVENDKDAISLQVIENWHQQGLINWLGRSNNVCDLIEQSNIVALPSV
+                     YSEGVPRILLEASSVGRACIAYDVGGCDSLIIDNDNGIIVKSNSPEELADKLAFLLSNP
+                     KARVEMGIKGRKRIQDKFSSGMIISKTLKTYHDVVEG"
+                     /locus_tag="OL2α.1_06_wbbO"
+     gene            6748..8064
+                     /gene="kfoC"
+     CDS             6748..8064
+                     /gene="kfoC"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_005227844.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyl transferase family protein"
+                     /protein_id="CZQ25293.1"
+                     /db_xref="GI:1036211082"
+                     /translation="MSERSSSALVSVVIPVHDAAEYISDTLSSILSQSLQDIEVIIIDD
+                     NSADDTLKLLQSFAANDSRIRLLNNSQNIGAGASRNMGLKIASGEYIIFLDDDDYADAN
+                     MLKRMYDHAALLQADVVICRCQSLDLQTHSYAPMPWSVRVDLLPQKELFSSDEITHNFF
+                     DAFIWWPWDKLFRRQAILDTGLQFQDLRTTNDLFFVSAFMLLTKRMAFLDEILISHSIN
+                     RSGSLSVTREKSWHCALDALRALYSFMDSKHLLPSRGRDFNNYAVTFLEWNLNTISGPA
+                     FDSLFTASREFIASLDIDESDFYDDFIKAAHYRLIRLTPEEYLFSLKDRVLHELESSNL
+                     STEKLQASIASQDQVLKAREEEIDELRASVAQKKERIDRLVQRNAYLETEYQKQQEQLT
+                     KLQNELNNAAQRYSALISSLSWKVTRPLRLIKALITRKM"
+                     /locus_tag="OL2α.1_07_kfoC"
+ORIGIN
+        1 atgaagtaca atttagggta tttatttgat ttacttgttg tgataacaaa taaagatcta
+       61 aaagtgcgct ataagagcag catgctaggc tatttatggt cagtagcaaa tccattgctt
+      121 tttgctatga tttattattt tatatttaag ctggtaatga gagtacaaat tccaaattat
+      181 acagttttcc tcattaccgg cttgtttccg tggcaatggt ttgccagttc ggccactaac
+      241 tcattatttt cattcatcgc taacgctcaa attatcaaga agacagtttt tccccggtcc
+      301 gtgattccgc taagtaatgt gatgatggaa ggcttgcatt ttctttgcac catcccggtt
+      361 attgttgtct ttctttttgt ttatggcatg acgccgtcct tgtcctgggt ttggggtata
+      421 cctctcattg ctattggcca ggtgattttc acctttggtg tttcaatcat cttttcaacg
+      481 ctgaacctgt ttttccgtga cctggagcgc tttgtcagtc tggggattat gctgatgttt
+      541 tattgtacgc cgattttata tgcgtctgat atgattccgg aaaaatttag ctggataatt
+      601 acctacaatc cgctagcgag tatgattctt agttggcgtg atttattcat gaatgggact
+      661 cttaattatg agtatatttc tatactctat tttacgggaa tcattttgac ggttgtcggt
+      721 ttgtctattt tcaataaatt aaaatatcga tttgcagaga tcttgtaatg cacccagtta
+      781 ttaacttcag tcatgttaca aaagagtatc ctctgtacca tcatattggc tcaggaatca
+      841 aagatttaat tttccaccca aaacgcgctt ttcagttgct gaaggggcgg aaatatttag
+      901 ctatcgaaga cgtatccttt acagttggca aaggtgaggc tgttgccctg attggacgta
+      961 atggggcagg aaagagtacc tcgcttggcc tggttgctgg cgtgattaag ccaactaagg
+     1021 gaaccgtcac cactgaagga cgggtggcat cgatgcttga actcggcgga ggctttcatc
+     1081 ctgaacttac cgggcgtgag aatatttacc tgaatgctac tctgctgggc cttaggcgta
+     1141 aagaggtcca gcaacgtatg gaacgtatta ttgaattttc ggaacttgga gaattcatcg
+     1201 acgagcccat cagagtatat tcaagcggaa tgctagctaa gttaggtttt tcggtcatca
+     1261 gtcaggttga accggatatt ttaattattg atgaagttct ggcagtaggt gatatcgctt
+     1321 ttcaggctaa atgtattcag accatcagag attttaagaa aagaggcgtg acgatactct
+     1381 ttgttagcca caatatgagt gacgttgaaa aaatctgcga tagagtcatc tggatcgaaa
+     1441 atcatagact cagagaagtg ggatctgcag atcgaattat tgaactgtac aagcaagcaa
+     1501 tggcttaatc agtgggtaat ataatgaaca atagcgttaa aatctatacc agccaccata
+     1561 agcctagtgc ttttcttaat gctgcaatta tcaaacctct gcatgtcggc aaagcaaatt
+     1621 cttataatga aattggttgc ccaggagatg acactggcga taatatttcc tttaagaatc
+     1681 cgttttattg cgaactaact gcgcattatt gggtttggaa aaacgaagag ctagccgact
+     1741 atgtcggttt tatgcactat cgccgtcatc ttaatttttc cgaaaaacaa actttttctg
+     1801 aggatacctg gggggtagtg aaccatccat gcattgatga agaatatgag aagatctttg
+     1861 gattaaacga agaaacaatt caacggtgtg tcgaaggtat tgatatcttg ctgcccaaaa
+     1921 aatggtctgt cactgcggcg ggaagtaaaa ataattacga tcactatgaa cggggtgaat
+     1981 acttacacat tcgagattat caggctgcca ttgccatcgt tgaaaaacta tatccagagt
+     2041 atagtacagc aataaaaacg tttaatgatg ccagtgatgg ctattacaca aatatgtttg
+     2101 ttatgcgcaa agatattttt gttgattatt ctaagtggct cttttccatt ctggataatc
+     2161 tcgaagatgc catctcgatg aacaattata atgcccagga aaaacgcgtt attgggcata
+     2221 tagctgaacg gctgtttaat atttacataa ttaagttgca acaagatggt gagcttaagg
+     2281 taaaagaatt acagcgtacc tttgtaagta atgaaacatt caatggtgca ctgaatccag
+     2341 tttttgattc tgcggttcca gttgttatca gtttcgatga taattacgca atcagcggtg
+     2401 gcgcattaat taattccatt gtccggcatg cggataaaaa taaaaattat gatatcgtcg
+     2461 tactcgaaaa taaagtaagc tatttgaata aaacacggtt agtaaatcta acctctgctc
+     2521 atccgaatat ttctcttcgt ttttttgacg ttaatgcctt cactgaaata aatggtgtgc
+     2581 atacccgagc gcattttagc gcatcaactt atgcccgtct ttttattcct caactgttca
+     2641 gacgatacga taaagtcgta tttattgatt cggataccgt tgtaaaggct gacctgggtg
+     2701 aactgcttga tgtccctctg ggcaacaatt tagttgcagc ggttaaggat atcgtcatgg
+     2761 aaggttttgt aaaattttct gcaatgtcgg catcagatga tggcgttatg ccggcaggcg
+     2821 aatatttaca gaaaacctta aacatgaata accctgatga atattttcag gcagggatta
+     2881 ttgtttttaa tgtcaaacaa atggtcgaag aaaatacttt tgctgaattg atgcgggtat
+     2941 taaaggcaaa gaaatactgg ttcctcgacc aggatatcat gaataaagta ttttactctc
+     3001 gagtcacatt tctgccatta gagtggaacg tttatcatgg taatggcaac acggatgatt
+     3061 tcttccctaa tcttaagttt gcaacgtata tgaaattttt agcagctcgc aagaagccta
+     3121 aaatgattca ttatgcgggt gagaacaaac catggaatac cgaaaaagtc gatttttatg
+     3181 acgactttat tgagaacatc gctaacactc catgggaaat ggaaatctat aaacgacaga
+     3241 tgtcgttagc ggcttcgatt ggtttaaccc atagcgagcc gcaacaacaa atcttgttcc
+     3301 agaccaaaat caagaacgta ctgatgcctt atgttaataa atatgcacca ataggcacgc
+     3361 caagaagaaa catgatgact aaatattatt acaaagtacg ccgtgctatt cttggataat
+     3421 aaaagagaca acagatgaaa agtaaaaaaa tattgatcgt aggtgcaggc ttctctggtg
+     3481 cagttattgg tcgccagctt gctgagcagg gacatcaagt ccatattatc gatcagcgtg
+     3541 atcatattgg gggaaattcc tatgatgcac gggacgctga aacgaatgtt atggtacatg
+     3601 tttatggacc ccatattttc catactgaca atgaaacagt gtggaactat gtcaacgagc
+     3661 atgcagagat gatgccctat gtgaaccggg ttaaagcgac agttaatggt caggtatttt
+     3721 ccctgcctat taatttgcat accatcaatc agtttttctc aaaaacttgt tcgcctgatg
+     3781 aggccagagc gctcattgct gagaaagggg atagcactat tgctgatcca caaacttttg
+     3841 aagagcaagc gttacgcttt attggtaaag agttatatga ggcctttttt aaaggctata
+     3901 cgattaaaca gtgggggatg caaccctcgg aactgcccgc atctattctt aaacgtcttc
+     3961 ctgttcgttt taactatgat gataattatt ttaaccacaa atttcagggc atgccgaaat
+     4021 gtggttatac gcagatgatt aagtccattc tcaatcatga aaatatcaag gttgacttac
+     4081 agcgggaatt tatcgttgaa gagcgaactc attacgatca cgtattctat agcggtccat
+     4141 tagatgcgtt ttatggctac caatatggcc gtctgggcta tcgaacatta gattttaaaa
+     4201 agtttaccta tcagggtgat taccagggct gcgcagtgat gaactattgt tctgttgatg
+     4261 tcccctatac tcgcatcact gaacataaat atttttctcc ctgggaacaa cacgacggct
+     4321 ctgtttgtta taaagagtat agccgtgctt gcgaagaaaa tgatattcct tactatccta
+     4381 ttcgtcagat gggagagatg gctcttcttg aaaaatattt gtcactggcc gagaatgaaa
+     4441 tcaatatcac ttttgtcggt cgtcttggaa cctaccgtta ccttgatatg gatgtgacca
+     4501 tcgccgaagc attgaaaacg gcagaagtct atttaaattc actcactgaa aatcagccaa
+     4561 tgcctgtgtt tacggtttct gtacgatgaa atatacggca ttgatagtga cattcaatcg
+     4621 gctcggtaaa ctgaaaaaaa ccgttgaaga gaccctcaaa cttgaattca ctaatattgt
+     4681 tattgtcaat aacgggtcca cggatgggac ccaagcctgg ctttcgtcaa ttgttgatac
+     4741 acgagtcatt gtgttaaccc ttaccgagaa taccggtggg gcggggggct ttaaaaccgg
+     4801 tagtcagtat atctgtgaac agctggcaag tgattgggta tttttctacg atgacgatgc
+     4861 ttacccctat ccagacacgt tgaagtcctt ttcacagctg gataagcggg gatgtcgggt
+     4921 atttagtgga ctggtgaaag atccgcaagg aaaaccgtgt ccgatgaata tgccgttctc
+     4981 gcgtgtacca acctcccttg gcgacactgt acgctattta cgctaccctg gagagtttat
+     5041 cccggcagct aatcgttcta tgttcgtaca aacggtttca tttgttggga tggtcataca
+     5101 tcgtgatctg ctcgcgacca gtcttgacta cattcgcgaa cagctcttta tctactttga
+     5161 tgatctttac tttggctatc agctatcatt agctggtgag caaattatgt atagcccgga
+     5221 gttgcttttt tatcatgatg tgagtattca gggcaaactt attgcacctg aatggaaggt
+     5281 ttactatcta tgccgtaatt tgatcctgtc gaagaaaata ttccagaaaa atggcgtgta
+     5341 tagcaattca gcgatagcga tacgcatcct aaaatatata ttaatcctgc catggcaacg
+     5401 tcaaaaatat tcctatatga aatttattct tcgtggaatt tcacatggca taaaaggtat
+     5461 tagtggtaag tatcattaag tgggcatagc aatgagaaaa ttgtgttatt tcataaattc
+     5521 ggattggtac ttcgatttac actggatcga tcgtgccatc gcctcccgtg atgcaggtta
+     5581 tgagattcac atcatcagcc attttattga tgacaacata ataaataaat tcaaaacatt
+     5641 cggctttatt tgccataatg ttactcttga tgctcaatct tttaatgcat tagttttctt
+     5701 tcgtacttac catgatgtgc aaaaaattat taaaaatata aaaccggatc tcttgcattg
+     5761 catcactatc aagccatgtt tgattggtgg tgtgctcgcg aagaaattta atctgccggt
+     5821 catcgtgagt tttgttgggc ttggaagagt attttcttct gacagcatgc ctttaaaatt
+     5881 attgcggcag tttactattg ctgcatataa atatattgct agtaataagc gctgtatatt
+     5941 tatgtttgaa catgaccgcg acagaaaaaa actggctaag ttggttggac tcgaaaaaca
+     6001 acagactatt gttattgatg gtgcaggcat taatccagag atatacaaat attctcttga
+     6061 acaggataac gatgtccctg ttgtattgtt tgccagccgt atgttgtgga gtaaaggact
+     6121 gggcgactta attgaagcga agaaaatatt acgcagtaag aatattcact ttactttgaa
+     6181 tgttgctgga attctggtcg aaaatgataa agatgcgatt tcccttcagg tcattgaaaa
+     6241 ttggcatcag caaggattaa ttaactggtt aggtcgttcg aataacgttt gcgatcttat
+     6301 tgagcaatca aatatcgttg ctttgccgtc agtttattct gaaggtgttc cgcgaattct
+     6361 tctggaagca tcttctgtgg gtcgcgcttg tattgcttat gatgttggtg gttgtgatag
+     6421 ccttattatt gataacgata atggaattat tgttaaaagc aattcacctg aagagctggc
+     6481 tgataaactt gcctttttac ttagcaatcc taaagcacgt gttgaaatgg gtattaaagg
+     6541 acgtaagcgt attcaggata aattctcgag cgggatgatt attagtaaga cgctaaagac
+     6601 ttatcatgat gtggttgagg gatagttgtc gatcaaacgg ttatcctttt ttattaattg
+     6661 ccagatattg tttctttacc atcaaatttt ttttgaagta tattattaac taaaattact
+     6721 gtaacgtgtc acttgggagg cgatcaaatg tctgaaagat cttcaagtgc actggtctct
+     6781 gttgtgatac ctgtgcacga tgctgcagaa tatatatctg atacgctaag ttccatttta
+     6841 tcgcaatcgt tacaggatat tgaagtcatc attattgatg acaattcggc tgatgatacg
+     6901 ttaaagctac tgcagtcctt tgccgctaat gactcgcgta tacgtctttt gaataattcg
+     6961 cagaatatcg gtgcaggtgc atcacgtaac atggggttaa aaatagcaag tggcgaatat
+     7021 atcatttttc ttgatgatga cgattatgcc gatgctaata tgctcaaacg gatgtatgat
+     7081 catgctgcat tgctgcaagc cgatgtggtt atctgccgat gccagtcttt agatctacaa
+     7141 acccattcat atgcaccaat gccatggtct gtgcgcgtag atttactccc ccaaaaagaa
+     7201 ctattttcat cagatgaaat tactcataat ttctttgatg catttatctg gtggccctgg
+     7261 gataagcttt tccgtcgcca ggctatactg gatactgggt tacaattcca ggatttaaga
+     7321 acgactaatg atttattttt tgttagcgct tttatgctac ttaccaaaag aatggcgttc
+     7381 ctggatgaga tcttgatttc tcattccatt aaccgcagtg gttcattatc ggtgaccaga
+     7441 gagaaatcct ggcactgtgc tcttgatgcg ttacgtgccc tctattcctt tatggactca
+     7501 aagcacttgt tgccttcacg tggtagagac tttaataatt atgcagtgac ttttcttgag
+     7561 tggaatttaa atacgatttc tggtccggcg tttgattctt tattcactgc ttcacgcgaa
+     7621 ttcatcgcct cattggatat tgatgaaagc gatttttatg atgattttat caaagcggca
+     7681 cactatcgcc tgattcgatt aacgccggaa gagtatcttt tctcgttaaa agatcgggta
+     7741 ttacatgagc ttgaatcctc taatctatct acagagaagt tgcaagccag tattgcttct
+     7801 caggatcaag ttcttaaagc cagggaagaa gaaattgatg agctaagagc gtccgttgca
+     7861 cagaaaaaag aacgtattga taggttggtc cagcgaaatg catatttaga gactgagtat
+     7921 cagaaacagc aagagcaatt aactaaacta caaaatgaat taaataacgc tgctcaacgt
+     7981 tattcagccc ttatttcatc attgtcatgg aaagttacaa gacctttaag gttaatcaaa
+     8041 gcgttaatca cgaggaaaat gtaa
+//
+LOCUS       LT174602                7926 bp    DNA     linear   BCT 13-JUN-2016
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis
+            gene cluster, type: O1/O2, Variant 2.
+ACCESSION   LT174602 REGION: 1..7926
+VERSION     LT174602.1
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Pseudomonadati; Pseudomonadota; Gammaproteobacteria;
+            Enterobacterales; Enterobacteriaceae; Klebsiella/Raoultella group;
+            Klebsiella; Klebsiella pneumoniae complex.
+REFERENCE   1
+  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
+            Holt,K.E. and Thomson,N.R.
+  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae
+            surface antigens
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 7926)
+  AUTHORS   Informatics,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
+            1SA, UNITED KINGDOM
+FEATURES             Location/Qualifiers
+     source          1..7926
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="441"
+                     /serovar="O1/O2 Variant 2"
+                     /db_xref="taxon:573"
+                     /note="O locus: OL2α.2"
+                     /note="O type: O2α"
+                     /note="Updated from O1/O2v2 by Tom Stanton in Feb 2025, also trimmed gmlABC"
+     gene            1..768
+                     /gene="wzm"
+     CDS             1..768
+                     /gene="wzm"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002920348.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="lipopolysaccharide O-antigen ABC transport
+                     system transmembrane component"
+                     /protein_id="CZQ25294.1"
+                     /locus_tag="OL2α.2_01_wzm"
+                     /translation="MKYNLGYLFDLLVVITNKDLKVRYKSSMLGYLWSVANPLLFAMI
+                     YYFIFKLVMRVQIPNYTVFLITGLFPWQWFASSATNSLFSFIANAQIIKKTVFPRSVI
+                     PLSNVMMEGLHFLCTIPVIVVFLFVYGMTPSLSWVWGIPLIAIGQVIFTFGVSIIFST
+                     LNLFFRDLERFVSLGIMLMFYCTPILYASDMIPEKFSWIITYNPLASMILSWRDLFMN
+                     GTLNYEYISILYFTGIILTVVGLSIFNKLKYRFAEIL"
+     gene            768..1508
+                     /gene="wzt"
+     CDS             768..1508
+                     /gene="wzt"
+                     /EC_number="3.6.3.40"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006499564.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Teichoic acid export ATP-binding protein TagH"
+                     /protein_id="CZQ25295.1"
+                     /locus_tag="OL2α.2_02_wzt"
+                     /translation="MHPVINFSHVTKEYPLYHHIGSGIKDLIFHPKRAFQLLKGRKYL
+                     AIEDVSFTVGKGEAVALIGRNGAGKSTSLGLVAGVIKPTKGTVTTEGRVASMLELGGG
+                     FHPELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGEFIDEPIRVYSSGMLAKLG
+                     FSVISQVEPDILIIDEVLAVGDIAFQAKCIQTIKDFKKRGVTILFVSHNMSDVEKICD
+                     RVIWIENHRLREVGSAERIIELYKQAMA"
+     gene            1524..3419
+                     /gene="wbbM"
+     CDS             1524..3419
+                     /gene="wbbM"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006635427.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyltransferase"
+                     /protein_id="CZQ25296.1"
+                     /locus_tag="OL2α.2_03_wbbM"
+                     /translation="MNNSVKIYTSHHKPSAFLNAAIIKPLHVGKANSCNEIGCPGDDT
+                     GDNISFKNPFYCELTAHYWVWKNEELADYVGFMHYRRHLNFSEKQTFSEDTWGVVNHP
+                     CIDEEYEKIFGLNEETIQRCVEGIDILLPKKWSVTAAGSKNNYDHYERGEYLHIRDYQ
+                     AAIAIVEKLYPEYSAAIKTFNDASDGYYTNMFVMRKDIFVDYSEWLFSILDNLEDAIS
+                     MNNYNAQEKRVIGHIAERLFNIYIIKLQQDGELKVKELQRTFVSNETFNGALNPVFDS
+                     AVPVVISFDDNYAVSGGALINSIVRHADKNKNYDIVVLENKVSYLNKTRLVNLTSAHP
+                     NISLRFFDVNAFTEINGVHTRAHFSASTYARLFIPQLFRRYDKVVFIDSDTVVKADLG
+                     ELLDVPLGNNLVAAVKDIVMEGFVKFSAMSASDDGVMPAGEYLQKTLNMNNPDEYFQA
+                     GIIVFNVKQMVEENTFAELMRVLKAKKYWFLDQDIMNKVFYSRVTFLPLEWNVYHGNG
+                     NTDDFFPNLKFATYMKFLAARKKPKMIHYAGENKPWNTEKVDFYDDFIENIANTPWEM
+                     EIYKRQMSLAASIGLTHSEPQQQILFQTKIKNVLMPYVNKYAPIGTPRRNMMTKYYYK
+                     VRRAILG"
+     gene            3435..4589
+                     /gene="glf"
+     CDS             3435..4589
+                     /gene="glf"
+                     /EC_number="5.4.99.9"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_005955557.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="UDP-galactopyranose mutase"
+                     /protein_id="CZQ25297.1"
+                     /locus_tag="OL2α.2_04_glf"
+                     /translation="MKSKKILIVGAGFSGAVIGRQLAEKGHQVHIIDQRDHIGGNSYD
+                     ARDAETNVMVHVYGPHIFHTDNETVWNYVNKHAEMMPYVNRVKATVNGQVFSLPINLH
+                     TINQFFSKTCSPDEARALIAEKGDSTIADPQTFEEQALRFIGKELYEAFFKGYTIKQW
+                     GMQPSELPASILKRLPVRFNYDDNYFNHKFQGMPKCGYTQMIKSILNHENIKVDLQRE
+                     FIVDERTHYDHVFYSGPLDAFYGYQYGRLGYRTLDFKKFTYQGDYQGCAVMNYCSVDV
+                     PYTRITEHKYFSPWEQHDGSVCYKEYSRACEENDIPYYPIRQMGEMALLEKYLSLAEN
+                     ETNITFVGRLGTYRYLDMDVTIAEALKTAEVYLNSLTDNQPMPVFTVSVR"
+     gene            4586..5479
+                     /gene="wbbN"
+     CDS             4586..5479
+                     /gene="wbbN"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006635429.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyl transferase"
+                     /protein_id="CZQ25298.1"
+                     /locus_tag="OL2α.2_05_wbbN"
+                     /translation="MKYTALIVTFNRLGKLKKTVEETLKLEFTNIVIVNNGSTDGTQA
+                     WLSSIVDTRVIVLTLTENTGGAGGFKTGSQYICEQLASDWVFFYDDDAYPYPDTLKSF
+                     SQLDKRGCRVFSGLVKDPQGKPCPMNMPFSRVPTSLGDTVRYLRYPGEFIPAANRSMF
+                     VQTVSFVGMVIHRDLLATSLDHIHEQLFIYFDDLYFGYQLSLAGEKIMYSTELLFYHD
+                     VSIQGKLIAPEWKVYYLCRNLILSKKIFQKNAVYSNSAIAIRILKYILILPWQRQKYS
+                     YMKFILRGISHGIKGISGKYH"
+     gene            5492..6622
+                     /gene="wbbO"
+     CDS             5492..6622
+                     /gene="wbbO"
+                     /EC_number="2.4.1.21"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_005227845.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="galactosyl transferase"
+                     /protein_id="CZQ25299.1"
+                     /locus_tag="OL2α.2_06_wbbO"
+                     /translation="MRKLCYFINSDWYFDLHWIDRAIASRDAGYEIHIISHFIDDNII
+                     NKFKTFGFICHNVTLDAQSFNALVFFRTYHDVQKIIKNIKPDLLHCITIKPCLIGGVL
+                     AKKFNLPVIVSFVGLGRVFSSDSMPLKLLRQFTIAAYKYIASNKRCIFMFEHDRDRKK
+                     LAKLVGLEEQQTIVIDGAGINPEIYKYSLEQDHDVPVVLFASRMLWSKGLGDLIEAKK
+                     ILRSKNIHFTLNVAGILVENDKDAISLQVIENWHQQGLINWLGRSNNVCDLIEQSNIV
+                     ALPSVYSEGVPRILLEASSVGRACIAYDVGGCDSLIIDNDNGIIVKSNSPEELADKLA
+                     FLLSNPKARVEMGIKGRKRIQDKFSSVMIIDKTLQIYHDVVR"
+     gene            6718..7926
+                     /gene="kfoC"
+     CDS             6718..7926
+                     /gene="kfoC"
+                     /EC_number="2.4.1.212"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006635431.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="capsular polysaccharide biosynthsis protein"
+                     /protein_id="CZQ25300.1"
+                     /locus_tag="OL2α.2_07_kfoC"
+                     /translation="MAHEKSDIIVSVVIPVYNAEEYIADTLKNIVSQSLYEIEIIIIN
+                     DHSSDNTLDILKEIASSDERIRIIDNAVNIGAGISRNIGLSEAKGEYIIFLDDDDYVD
+                     TNMLKHMSDCAELSGADIVVCRSRSFNLQSLQYAPMPDSIRKDLLPEKAVFSPGDIER
+                     DFFRAFIWWPWDKLFRREFIIQHSLSYQDLRTSNDLFFVCASMLSAEKVTILDEILIT
+                     HTINRKTSLSSTRSVSYHCALDALVALRDFLFKNGMMQKRQRDFYNYIVVFLEWHLNT
+                     LSGEAFNKLFQDVKLFISSFDINNEDFYDEFILSAYRRIADMSAEEYLFSLKDRVLNE
+                     LENAQRNILTLQNEVEEIKQQLQQKDEMIASMNRENLAIKADNKILENYNEELKTVQT
+                     KFLKLLSSKD"
+ORIGIN
+        1 atgaagtaca atttagggta tttatttgat ttacttgttg tcataacaaa taaagatcta
+       61 aaagtgcgct ataagagcag catgctaggc tatttatggt cagtagcaaa tccattgctt
+      121 tttgccatga tttattattt tatatttaag ctggtaatga gagtacaaat tccaaattat
+      181 actgttttcc tcattaccgg cttgtttccg tggcaatggt ttgccagttc ggccactaac
+      241 tcattatttt cattcatcgc taacgctcaa attatcaaga agacagtttt tccccggtcc
+      301 gtgattccgc taagtaatgt aatgatggaa gggttgcatt ttctttgcac catcccggtt
+      361 attgtagtct ttctttttgt ttatggcatg acgccgtcct tgtcctgggt ttggggtata
+      421 cctctcattg ctattggcca ggtgattttc acctttggtg tttcaatcat cttttcaacg
+      481 ctgaacctgt ttttccgtga cctggagcgc tttgtcagtc tagggattat gctgatgttt
+      541 tattgtacgc cgattttata tgcgtctgat atgattccgg aaaaatttag ctggataatt
+      601 acctacaatc cgctagcgag tatgattctt agttggcgtg atttattcat gaatgggact
+      661 cttaattatg agtatatttc tatactctat tttacgggaa tcattttgac ggttgtcggt
+      721 ttgtctattt tcaataaatt aaaatatcga tttgcagaga tcttgtaatg cacccagtta
+      781 ttaacttcag tcatgttaca aaagagtatc ctctgtacca tcatattggc tcaggaatca
+      841 aagatttaat tttccatccg aaacgcgctt ttcagttgct gaaggggcgg aaatatttag
+      901 ctatcgaaga cgtatccttt acagttggca aaggtgaggc tgttgccctg attggacgta
+      961 atggggcagg aaagagtacc tctcttggcc tggttgccgg cgtgattaag ccaactaagg
+     1021 gaaccgtcac cactgaagga cgggtggcat cgatgcttga actcggcgga ggctttcatc
+     1081 ctgaacttac cgggcgtgag aatatttacc tgaatgctac tctgctgggc cttcggcgta
+     1141 aagaggtcca gcaacgtatg gaacgtatta ttgaattttc ggaactggga gaattcatag
+     1201 acgagccaat cagagtgtac tcaagcggaa tgctagctaa gttaggtttt tcggtcatca
+     1261 gtcaggttga accggatatt ttaattattg atgaagttct ggcagtaggt gatatcgctt
+     1321 ttcaggcaaa atgtattcag accatcaaag attttaagaa aagaggcgtg acaatattgt
+     1381 ttgttagcca caatatgagt gacgttgaaa aaatctgcga cagagtcatc tggatcgaaa
+     1441 atcataggct cagagaagtg gggtctgcag agcgaatcat tgaactgtac aagcaagcaa
+     1501 tggcttaatc agtgggtaat ataatgaaca atagcgttaa aatctatacc agccaccata
+     1561 agcctagtgc ttttcttaat gctgcaatta tcaaacctct gcatgtcggc aaagctaatt
+     1621 cttgtaatga aattggttgt ccaggagatg acactggcga taatatttcc tttaagaatc
+     1681 cgttttattg cgaacttact gcgcattatt gggtttggaa aaacgaagag ctggcagact
+     1741 atgtcggttt catgcactat cgccgtcatc ttaatttttc cgaaaaacaa actttttctg
+     1801 aggatacgtg gggggtcgtg aaccatccat gcattgatga agaatatgag aagatctttg
+     1861 gattaaacga agaaacaatt caacggtgtg tcgaaggtat tgacatcttg ctgcccaaaa
+     1921 aatggtctgt cactgcggcg ggaagtaaaa ataattacga tcactatgaa cgaggtgaat
+     1981 acttacatat tcgtgattat caggctgcca ttgccatcgt tgaaaaacta tatccagagt
+     2041 atagcgcggc aataaaaacg tttaatgatg ccagtgatgg ctattacaca aatatgtttg
+     2101 tcatgcgcaa agatattttt gttgactatt ctgagtggct cttttccatt ctggataatc
+     2161 tcgaagatgc tatctcgatg aacaattata atgctcagga aaaacgcgtt attgggcata
+     2221 tagcagaacg gctgtttaat atttacatta ttaagttgca acaagatggt gagcttaagg
+     2281 taaaagaatt acagcgtact tttgtcagca atgaaacatt caatggtgca ctgaatccag
+     2341 tttttgattc tgcggttcca gtggttatca gtttcgatga taattacgca gtcagcggtg
+     2401 gtgcattaat taattccatt gtccggcatg cggataaaaa taaaaattat gatatcgtcg
+     2461 tactcgaaaa caaagtaagc tatttgaata aaacgcggtt agtaaatcta acctcggctc
+     2521 atccgaatat ttctcttcgt ttttttgacg ttaatgcttt cactgaaata aacggtgtgc
+     2581 atacccgagc gcattttagc gcatcaacgt atgcccgtct ttttattcct caactgttca
+     2641 gacgatacga taaagtcgta tttattgatt cggataccgt tgtaaaggct gacctgggcg
+     2701 aactgcttga tgtccctctg ggcaacaatt tagttgcagc ggttaaggat atcgtcatgg
+     2761 aaggttttgt aaaattttct gcaatgtcgg catcagatga tggcgttatg ccggcaggcg
+     2821 aatatttaca gaaaacctta aacatgaata accctgatga atattttcag gcagggatta
+     2881 ttgtttttaa tgtcaaacaa atggtcgaag aaaatacttt tgctgaattg atgcgggtat
+     2941 taaaggcaaa aaaatactgg ttcctcgacc aggatatcat gaataaagtt ttctactctc
+     3001 gagtcacatt tctgccatta gagtggaacg tttatcatgg taatggcaac acggatgatt
+     3061 tcttccctaa tcttaagttt gcaacgtata tgaaattttt agcagctcgc aagaagccta
+     3121 aaatgattca ttatgcgggt gagaacaaac catggaatac cgaaaaagtc gatttttatg
+     3181 acgactttat tgaaaacatc gctaacactc catgggagat ggaaatctat aaacgtcaga
+     3241 tgtcgttagc ggcttcgatt ggtttaaccc atagcgagcc gcaacaacaa atcttgttcc
+     3301 agaccaaaat caagaacgta ctgatgcctt atgttaataa atatgcacca ataggcacgc
+     3361 caagaagaaa catgatgact aaatattatt acaaagtacg ccgtgctatt cttggataat
+     3421 aaaagagaca acagatgaaa agtaaaaaaa tattgatcgt aggtgctggc ttctctggtg
+     3481 cagttatcgg tcgccaactt gctgagaagg gacatcaagt ccatattatc gatcagcgtg
+     3541 atcatattgg ggggaattcc tatgatgcac gggacgctga aacgaatgtg atggtacatg
+     3601 tttatggacc ccatattttc catactgaca atgaaacagt gtggaactat gtcaacaagc
+     3661 atgcagagat gatgccctat gtgaaccggg ttaaagcgac agttaatggt caggtatttt
+     3721 ccctgcctat taatttgcat actatcaatc agtttttctc aaaaacttgt tcgcctgatg
+     3781 aggccagagc gctcattgct gagaaagggg acagcactat tgctgatcca caaacttttg
+     3841 aagagcaagc gttacgcttt attggtaaag agttatatga ggcctttttt aaaggatata
+     3901 cgattaaaca gtgggggatg caaccctcgg aactgcccgc atctattctt aaacgtcttc
+     3961 ctgttcgttt taactatgat gataattatt ttaaccacaa atttcagggc atgccgaaat
+     4021 gtggttatac gcagatgatt aagtccattc tcaatcatga aaatatcaag gttgacttac
+     4081 agcgggaatt tatcgttgac gagcgaactc attacgatca cgtattctat agcggtccat
+     4141 tagatgcgtt ttatggctac caatatggcc gtctgggcta tcgaacatta gattttaaaa
+     4201 agtttaccta tcagggtgat taccagggct gcgcagtgat gaactattgt tctgttgatg
+     4261 tcccctatac tcgcatcact gaacataaat atttttctcc ctgggaacaa cacgacggct
+     4321 ctgtttgtta taaagagtat agccgtgctt gtgaagaaaa tgatattcct tactatccta
+     4381 ttcgccagat gggagagatg gctcttcttg aaaaatattt gtcactggcc gagaatgaaa
+     4441 ccaatatcac ttttgtcggt cgtcttggaa cctaccgtta cctcgacatg gatgtgacca
+     4501 tcgccgaagc attgaaaacg gcagaagtct atttaaattc actcactgat aatcagccaa
+     4561 tgcctgtgtt tacggtttct gtacgatgaa atatacggca ttgatagtga cattcaatcg
+     4621 tctcggcaaa ctgaaaaaaa ccgttgaaga gaccctcaaa cttgaattca ctaatattgt
+     4681 tattgtcaat aacgggtcca cggatgggac ccaagcctgg ctttcgtcaa ttgttgatac
+     4741 acgagtcatt gtattaaccc tcaccgagaa taccggtggg gcggggggct ttaaaaccgg
+     4801 tagtcagtat atctgtgaac agctggcaag tgattgggta tttttctacg atgatgatgc
+     4861 ttacccctat ccagacacgt tgaagtcctt ttcacagctg gataagcggg gatgtcgggt
+     4921 atttagtgga ctggtgaaag atccgcaagg aaaaccgtgt ccgatgaata tgccgttctc
+     4981 gcgtgtgcca acttcacttg gcgacactgt acgctattta cgctaccctg gagagtttat
+     5041 cccggcagct aatcgttcta tgttcgtaca aacggtttca tttgttggga tggtcataca
+     5101 tcgtgatctg ctcgcgacca gtcttgacca catccatgaa cagcttttta tctactttga
+     5161 tgatctttac tttggctatc agctatcact agctggtgag aaaattatgt atagcacgga
+     5221 gttgcttttt tatcatgatg tgagtattca gggcaaactt attgcacctg aatggaaggt
+     5281 ttactatctc tgccgtaatt tgatcctgtc gaagaaaata ttccagaaaa atgccgtgta
+     5341 tagcaattca gcgatagcga tacgcatcct aaaatatata ttaatcctgc catggcaacg
+     5401 tcaaaaatat tcctatatga aatttattct tcgtggaatt tcacatggca taaaaggtat
+     5461 tagtggtaag tatcattaag tgggcatagc aatgagaaaa ttgtgttatt tcataaattc
+     5521 ggattggtac ttcgatttac actggatcga tcgtgccatc gcctcccgtg atgcaggtta
+     5581 tgagattcac atcatcagcc attttattga tgacaacata ataaataaat tcaaaacatt
+     5641 tggctttatt tgccataatg ttactcttga tgctcaatct tttaatgcat tagttttctt
+     5701 tcgtacttac catgatgtgc aaaaaattat taaaaatata aaaccggatc tcttgcattg
+     5761 catcactatc aagccatgtt tgattggtgg tgtgctcgcg aagaaattta atctgccggt
+     5821 catcgtaagt tttgttgggc ttggaagagt attttcttct gacagcatgc ctttaaaatt
+     5881 attgcggcag tttactattg ctgcatataa atatattgcc agtaataagc gctgtatatt
+     5941 tatgtttgaa catgaccgcg acagaaaaaa actggctaag ttggttggac tcgaagaaca
+     6001 acagactatt gttattgatg gtgcaggcat taatccagag atatacaaat attctcttga
+     6061 acaggatcac gatgtccctg ttgtattgtt tgccagccgt atgttgtgga gtaaaggact
+     6121 gggcgactta attgaagcga agaaaatatt acgcagtaag aatattcact ttactttgaa
+     6181 tgttgctgga attctggtcg aaaatgataa agatgcaatt tcccttcagg tcattgaaaa
+     6241 ttggcatcag caaggattaa ttaactggtt aggtcgttcg aataatgttt gcgatcttat
+     6301 tgagcaatca aatatcgttg ctttgccgtc agtttattct gaaggtgttc cgcgaattct
+     6361 tctggaagca tcttctgtgg gtcgcgcttg tattgcttat gatgttggtg gttgtgatag
+     6421 ccttattatt gataacgata atggaattat tgttaaaagc aattcacctg aagagctggc
+     6481 tgataaactt gcctttttac ttagcaatcc taaagcacgc gttgaaatgg gtattaaggg
+     6541 gaggaaacgt atacaagata aattttctag tgttatgatt atcgataaaa cattgcaaat
+     6601 atatcatgat gtagttcgat gatgtgtaag tttcacattt attattgcga aaaaccttca
+     6661 tattgataat agtaatgttt atataatgta attcaattta ctactaatgg tatttttatg
+     6721 gctcatgaaa aaagtgatat aattgtttcg gtcgttattc ctgtttacaa cgccgaagag
+     6781 tatattgcag atactctaaa aaacattgtt tcacagtcat tgtatgaaat tgaaattata
+     6841 ataatcaatg atcattcgag tgataataca ttagatatcc ttaaggagat tgcatccagc
+     6901 gatgaaagaa tacgaattat tgataacgct gtaaatattg gagctggcat atcacgtaat
+     6961 ataggtcttt cagaagcaaa gggagaatat ataatatttc ttgatgacga tgattatgtc
+     7021 gatacgaaca tgttgaagca catgtctgat tgtgcggagc tatcaggggc agatatcgtt
+     7081 gtatgcagaa gccgctcatt taatctacaa tctctccagt atgctccaat gccagattca
+     7141 attcgaaaag atttattacc tgaaaaagca gttttctcgc ctggagatat tgagcgagac
+     7201 tttttcaggg catttatatg gtggccatgg gacaaactat tccgacgtga atttattatt
+     7261 cagcactcgt tgagctacca agatttaaga acatcaaatg atctgttttt tgtgtgtgca
+     7321 tctatgctta gtgccgaaaa ggtaactatt cttgatgaaa tattgattac tcatacgatt
+     7381 aatcgaaaaa catcattgtc ttcaactcgc tccgtttcct atcattgcgc acttgatgct
+     7441 cttgttgctc taagggattt tctttttaaa aatggcatga tgcaaaagcg acaaagggat
+     7501 ttttataatt acattgtcgt attccttgag tggcacttaa atacgctatc gggtgaagcc
+     7561 tttaataaac tgtttcaaga tgtcaaatta ttcatcagca gttttgatat caataatgaa
+     7621 gacttttatg atgagtttat tctttctgct tatcgacgaa tcgctgatat gtctgctgaa
+     7681 gagtatcttt tttcattaaa agatcgggtt cttaatgaat tagagaatgc ccaacgaaat
+     7741 attttgacct tacaaaacga agttgaggag ataaaacagc agcttcaaca aaaggacgaa
+     7801 atgattgctt ctatgaatag ggaaaattta gctattaaag cagataataa aattctcgaa
+     7861 aattacaatg aagaactaaa gactgttcag acaaagtttc ttaaactact ctcaagtaaa
+     7921 gactag
+//
+LOCUS       MG280710                8047 bp    DNA     linear   BCT 14-FEB-2018
+DEFINITION  Klebsiella pneumoniae strain CWK53 rfb gene cluster, complete
+            sequence.
+ACCESSION   MG280710 REGION: 1..8047
+VERSION     MG280710.1
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Pseudomonadati; Pseudomonadota; Gammaproteobacteria;
+            Enterobacterales; Enterobacteriaceae; Klebsiella/Raoultella group;
+            Klebsiella; Klebsiella pneumoniae complex.
+REFERENCE   1  (bases 1 to 8047)
+  AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
+            Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
+            Whitfield,C.
+  TITLE     Molecular basis for structural diversity in serogroup O2-antigen
+            polysaccharides in Klebsiella pneumoniae
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 8047)
+  AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
+            Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
+            Whitfield,C.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (27-OCT-2017) Dept of Molecular and Cellular Biology,
+            University of Guelph, 50 Stone Road, Guelph, Ontario N1G 2W1,
+            Canada
+COMMENT     ##Assembly-Data-START##
+            Assembly Method       :: Velvet v. 1.2.10
+            Assembly Name         :: Klebsiella pneumoniae CWK53 O-antigen
+                                     biosynthesis (rfb) gene cluster
+            Coverage              :: 100x
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
+FEATURES             Location/Qualifiers
+     source          1..8047
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="CWK53"
+                     /serotype="O2aeh"
+                     /note="O locus: OL2α.3"
+                     /note="O type: O2α"
+                     /note="Updated from O1/O2v3 by Tom Stanton in March 2025, trimmed to remove HisI and Orf8"
+                     /db_xref="taxon:573"
+     gene            1..768
+                     /gene="wzm"
+     CDS             1..768
+                     /gene="wzm"
+                     /note="lipopolysaccharide O-antigen export protein
+                     integral membrane component"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Wzm"
+                     /protein_id="AVA30565.1"
+                     /locus_tag="OL2α.3_01_wzm"
+                     /translation="MKYNIGYLFDLLVVITNKDLKVRYKSSVFGYLWSIANPLLFAMI
+                     YYFIFKLVMRVQIPNYTLFLITGLFPWQWFASSATNSLFSFIANAQIIKKTVFPRSVI
+                     PLSNVMMEGLHFLCTIPVIIAFLFVYGMSPSISWLWGIPIIAIGQVIFTFGISIIFST
+                     LNLFFRDLERFVSLGIMLMFYCTPILYAADMIPEKFSWIITYNPLASMILSWRQLFMD
+                     GVLNYEYISILYVTGIILTIVGLSIFNKLKYRFAEIL"
+     gene            768..1508
+                     /gene="wzt"
+     CDS             768..1508
+                     /gene="wzt"
+                     /note="lipopolysaccharide O-antigen export protein
+                     nucleotide binding component"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Wzt"
+                     /protein_id="AVA30566.1"
+                     /locus_tag="OL2α.3_02_wzt"
+                     /translation="MEPVINFSHVTKEYPLYHHIGSGIKDLVFHPKRAFQLLKGRKYL
+                     AIEDISFTVGKGEAVALIGRNGAGKSTSLGLVAGVIKPTKGTVTTQGRVASMLELGGG
+                     FHPELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGDFIDEPIRVYSSGMLAKLG
+                     FSVISQVEPDILIIDEVLAVGDISFQAKCIQTIKDFKSKGVTILFVSHNMSDVEKICD
+                     RVVWIEDHKLREIGSAERIIELYKQAMA"
+     gene            1523..3415
+                     /gene="wbbM"
+     CDS             1523..3415
+                     /gene="wbbM"
+                     /note="glycosyltransferase involved in lipopolysaccharide
+                     O-antigen biosynthesis"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="WbbM"
+                     /protein_id="AVA30567.1"
+                     /locus_tag="OL2α.3_03_wbbM"
+                     /translation="MNSIKIYTCHHKPSAFLNASIIKPLHVGKANTYNDIGCEGEDSG
+                     DNISFKNPFYCELTAHYWVWKNEPLADYVGFMHYRRHLNFAEQQNHPEDNWGVVNYPL
+                     INAEYESQFGLSDESISTCVDGYDLLLPKKWSVTSAGSKNNLDHYAKGEFLHIKDYQS
+                     ALDVVEELYPEYKDAIQQFNNATDGYYTNMFVMRKDMFTDYSEWLFAILSNLEDRISM
+                     NNYNAQEKRVIGHIAERLFNIYIIKSQQDKQLKIKELQRTFVTAETFNGKLNPIFDES
+                     VPVVISFDNNYALSGGALINSIVRHSDANRNYDIVVLENKVSHLNKQRLIKLVAGHNN
+                     ISLRFFDVNSFTEMSDVHTRAHFSASTYARLFIPQLFREYKKVVFIDSDTVVKSDLAT
+                     LLDVEIGTNLVAAVKDIVMEGFVKFGTMSESDDGIMPAGEYLKKTLGMTNPDEYFQAG
+                     IIVFNVEQMVKENTFAQLMSALKAKKYWFLDQDIMNKVFFGRVKFLPLEWNVYHGNGN
+                     TDDFFPNLKFSTYMRFLEARRNPKMIHYAGENKPWNTEKVDFYDDFLENVLNTPWEKE
+                     IYYRQLPVATVVPNQHTELQQTVLLQTKIKRALMPYVNKYAPVGSPRRNKLTKYYYKV
+                     RRSILG"
+     gene            3434..4588
+                     /gene="glf"
+     CDS             3434..4588
+                     /gene="glf"
+                     /EC_number="5.4.99.9"
+                     /note="UDP-galactopyranose mutase"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Glf"
+                     /protein_id="AVA30568.1"
+                     /locus_tag="OL2α.3_04_glf"
+                     /translation="MKRNNILIVGAGFSGVVIARQLAEQGHKVKIIDQRDHIGGNSYD
+                     TRDPQTDVMVHVYGPHIFHTDNETVWNYVNRYAEMMPYVNRVKATVNGQVFSLPINLH
+                     TINQFFAKTCSPDEARALISEKGDSSILEPKTFEEQALRFIGKELYEAFFKGYTIKQW
+                     GMQPSELPASILKRLPVRFNYDDNYFNHKFQGMPKLGYTHMIEAIADHENITLQLQRE
+                     FAAENRESYDHVFYSGPLDAFYSYQHGRLGYRTLDFERFTWQGDYQGCAVMNYCSVDV
+                     PYTRITEHKYFSPWESHEGSVCYKEYSRACGEDDIPYYPIRQMGEMALLDKYLSLAEN
+                     EKNITFVGRLGTYRYLDMDVTIAEALKTADKYLSSLSNDEAMPVFVADVR"
+     gene            4585..5475
+                     /gene="wbbN"
+     CDS             4585..5475
+                     /gene="wbbN"
+                     /note="putative glycosyltransferase involved in
+                     lipopolysaccharide O-antigen biosynthesis"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="WbbN"
+                     /protein_id="AVA30569.1"
+                     /locus_tag="OL2α.3_05_wbbN"
+                     /translation="MKHTALIVTFNRLEKLKKTVAETVKLHFTSIVIVNNGSTDGTSD
+                     WLQTITDPRVIVLNLACNNGGAGGFKAGSQYICSSVDSDWVFFYDDDAYPQSDILDKF
+                     STINKEGCRVFTALVKDLQGRTCAMNVPFAKVPTSFSDTLQYIKHPQRYVPDNKEMLV
+                     QTVSFVGMIIKREVLNEHLHHIYDELFLYFDDLYFGYQLTLSGEKIIYNPELVFTHDV
+                     SIQGKVISPEWKVYYLCRNLILAKRIFTEVAVFSSSSILLRLCKYISIFPVQRRKWVY
+                     LKFLCRGIVHGVKGISGKFH"
+     gene            5488..6621
+                     /gene="wbbO"
+     CDS             5488..6621
+                     /gene="wbbO"
+                     /note="glycosyltransferase involved in lipopolysaccharide
+                     O-antigen biosynthesis"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="WbbO"
+                     /protein_id="AVA30570.1"
+                     /locus_tag="OL2α.3_06_wbbO"
+                     /translation="MKKLCYFINSDWYFDLHWTDRAIAARDAGYEIHIISHFVDDKIA
+                     IKFKTLGFICHNIPLVAQSFNVLIFFRAFFKARKIIQSINPDLLHCITIKPCLIGGFL
+                     AKSTHRPVILSFVGLGRVFSAESGCLKLLRSFTVMAYKYIASNKCSLFMFEHDKDRAK
+                     LADLVGIDYKQTIVIDGAGINPEIYKYSLEQQRDVPVVLFASRMLWSKGLGDLIEAKK
+                     ILSNKNIHFTLNVAGILVENDKDAIPLATIQKWQSEGVINWLGHCSNVFDLIEESNIV
+                     ALPSVYAEGVPRILLEASSVGRACIAYDVGGCDSLIINNDNGLIVKSKSVEELAEKLG
+                     FLLDNPETRVAMGINGRKRIQDKFSSVMIINKTLKTYRDVVEE"
+     CDS             6743..8047
+                     /note="Orf7"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="hypothetical protein"
+                     /protein_id="AVA30571.1"
+                     /locus_tag="OL2α.3_07"
+                     /translation="MSEKKSIAVSVIIPVHNAAGYISDTLSTVLSQTLNDIEIIIIND
+                     CSNDNTLEIVSALAETDSRIRVINNTTNLGGGGSRNVGLDAAIGEYVIFLDDDDYADN
+                     MMLERMYAQASDTQADVVICRSQSFDPSLQVYAPMPWSVRQELLPDLMVFSSQDIPSD
+                     FFRAFVWWPWDKLLRRQFIATHQLRFQEIRTTNDLFFVCAFMLMANRISVLNETLISH
+                     TINRSESLSATRAESHRCAVEALVALKAFICQQGMMDQRLRDYKNYVVVFLEWHLNTI
+                     SGPAFHPFYQQVKEFIVALDAKDDDFYDEFIAAAHHRITTLSAEEYLFSLKDRVLKEL
+                     EFFQAKSSALQQEVETLTDSFAEQKDENAILHNQLHEIEERVTEQEKNIRQLTDKNNN
+                     MHHEITIKQQEFNEIYQHHKNLISSLSWKLTKPLRVVRRFFK"
+ORIGIN
+        1 atgaagtata atataggata tttgtttgat cttcttgttg taataacaaa caaagatttg
+       61 aaagtacgtt ataaaagcag cgtatttggt tacttatggt caatcgcaaa tccactgctt
+      121 ttcgcaatga tatattattt cattttcaaa cttgttatgc gggtacagat accaaattat
+      181 acactctttt taattacggg tcttttccca tggcaatggt ttgcgagttc tgcgaccaac
+      241 tctctattct cgtttattgc taacgcacaa attattaaga agacagtatt ccctcgttca
+      301 gtaatcccat taagcaatgt gatgatggaa gggttacatt ttctctgtac tattcctgtc
+      361 attatcgcat ttttgtttgt ttatggtatg agtccatcaa tatcctggct gtgggggata
+      421 ccaataattg cgattgggca agttattttt acatttggta tttctataat cttttcaaca
+      481 ctcaatctct ttttccggga tctggagcgg tttgtgagtc ttggcatcat gctgatgttt
+      541 tattgcacgc caattttata tgcagcagat atgatcccgg agaagtttag ctggattatc
+      601 acctataatc ctcttgcaag tatgatcctc agctggcgcc agttattcat ggatggtgta
+      661 ttgaactatg agtatatctc aatactttat gttacaggta ttatcctgac catagtgggt
+      721 ctaagcatct ttaataaatt aaaatatcga tttgcagaga ttttgtaatg gaaccagtaa
+      781 taaattttag tcacgttacg aaagaatatc cactttatca tcatattggc tcaggaataa
+      841 aagacttagt atttcatcct aagcgtgctt tccagttact gaaagggcgg aaataccttg
+      901 ctatcgagga tatctctttt actgttggca agggggaagc ggttgcattg atcggacgta
+      961 atggcgcggg gaaaagtact tcattaggtt tggtggctgg tgttatcaag ccaacgaaag
+     1021 gtaccgttac gactcagggc cgggttgcat caatgctgga gctaggcggt gggttccatc
+     1081 cagaattgac tggtcgggaa aatatttatc tcaatgccac ccttcttgga ttacgacgta
+     1141 aagaagttca gcagcgtatg gaacgtatca ttgagttctc ggaattaggt gactttattg
+     1201 atgaacctat ccgtgtttac tcaagcggca tgcttgcaaa actggggttc tctgtcatca
+     1261 gccaggttga gcctgatatt cttatcattg atgaagtgct tgctgtgggc gatatctcat
+     1321 tccaggccaa gtgcattcag accatcaaag actttaaaag caaaggagtg acgatattat
+     1381 tcgtcagtca caatatgagt gatgttgaaa aaatctgtga cagagttgtt tggatcgaag
+     1441 accacaaact ccgcgaaatt ggctcagcag agagaatcat tgaactttac aagcaagcaa
+     1501 tggcttaata attggtaata agatgaatag tatcaaaatt tacacatgtc accacaaacc
+     1561 cagtgctttt ctaaacgcct ctattattaa accactgcat gtcgggaagg ctaatactta
+     1621 taatgatatt ggctgtgaag gggaggatag cggagacaac atttccttta aaaacccctt
+     1681 ttattgtgag ctgacggccc actactgggt gtggaagaat gaaccccttg ctgactatgt
+     1741 gggattcatg cattaccgca gacacttgaa ctttgcagaa caacaaaatc atcctgagga
+     1801 taactggggg gtggtcaact acccgctcat caatgccgaa tacgaaagcc agtttggatt
+     1861 aagtgatgaa tccataagca cctgcgtcga tggatatgat ctgctgttac ccaaaaaatg
+     1921 gtcggtaact tcggcaggaa gtaagaataa ccttgatcat tatgcaaagg gtgagttttt
+     1981 acacattaaa gactatcagt ctgctctgga tgtcgttgaa gagctgtatc cagaatataa
+     2041 agatgcgatt caacaattca ataatgcaac tgatggttat tatacgaaca tgtttgttat
+     2101 gcgcaaagac atgttcacgg attattctga atggcttttt gctattttgt ctaatcttga
+     2161 agatcggatt tcgatgaata actacaatgc tcaagaaaaa cgagttatag gacacattgc
+     2221 tgagcgttta ttcaatattt atatcatcaa aagccaacaa gataaacagc tgaaaataaa
+     2281 agaactacag cgtacgtttg tcactgctga aacatttaat ggcaaattaa atccgatttt
+     2341 tgacgaaagt gttccggttg ttatcagttt tgataataac tatgcattaa gtggcggggc
+     2401 attaataaat tcaattgttc gccattctga tgctaaccga aactatgata tcgttgttct
+     2461 ggaaaataag gtcagtcatt taaataaaca acgccttatc aagctagttg ctggtcataa
+     2521 caacatatca ctgcgctttt ttgatgtgaa ttcattcact gagatgagtg atgttcatac
+     2581 ccgtgcgcat tttagtgcgt cgacatatgc gcgcttgttc atcccgcaac ttttccgcga
+     2641 gtataaaaaa gttgtgttta tcgattctga taccgtggtg aagtctgatt tggcgacact
+     2701 tctggatgtt gagatcggca ctaacctggt tgccgctgtt aaagacatcg tcatggaagg
+     2761 atttgtgaag tttggtacga tgtcagaatc tgatgatggc attatgccag caggggaata
+     2821 cctgaaaaag acattaggaa tgactaaccc tgacgaatat tttcaggccg ggattattgt
+     2881 ttttaacgtc gaacaaatgg ttaaagagaa cacctttgcg caattgatgt cagcattgaa
+     2941 agccaaaaag tattggttct tagatcagga tatcatgaac aaagtcttct ttggccgagt
+     3001 caagttttta ccattagaat ggaatgtgta ccatggtaat ggtaataccg atgatttctt
+     3061 cccgaatctc aagttttcaa cctatatgcg gtttttggaa gccagaagaa atccaaaaat
+     3121 gattcactat gcgggtgaaa acaaaccatg gaatactgag aaagtcgatt tctatgatga
+     3181 ttttcttgaa aatgttttaa atacgccatg ggaaaaagaa atttactatc gccagttacc
+     3241 tgtggccacg gtagtaccta accaacatac tgaactgcag caaaccgtgt tactgcagac
+     3301 aaagattaaa cgagctttaa tgccatatgt taacaaatat gctcctgtcg gttcgccaag
+     3361 aagaaataag ctcactaaat attattataa agttcgtcgc tcgattcttg gctaatataa
+     3421 ctggagatac attatgaagc gtaacaatat tctcatcgtc ggcgctggtt tttcaggtgt
+     3481 ggtcattgcc cgccagcttg ctgaacaagg tcacaaggtt aaaatcatcg atcagcggga
+     3541 ccacattgga ggaaactctt atgacactcg cgatcctcag actgatgtca tggttcatgt
+     3601 ctacggtccg catattttcc atacggataa tgaaaccgtc tggaactatg tcaatcggta
+     3661 tgcggaaatg atgccctatg tgaatagagt aaaagctact gttaatggtc aggttttttc
+     3721 actgccgatt aatctgcata ctattaatca gttctttgct aaaacctgtt ctcctgatga
+     3781 agctcgcgcg ctcattagcg aaaaaggtga tagctcgatt ctggaaccga agacatttga
+     3841 agagcaggct ttgcgcttta ttggtaaaga attatatgaa gcgttcttca aaggctacac
+     3901 cataaaacag tgggggatgc agccttccga gcttccggca tctatactca aacggttgcc
+     3961 tgtgcgtttc aattatgacg ataactactt caatcataaa ttccagggca tgccgaagtt
+     4021 gggctatacc catatgattg aagcgatcgc cgatcatgaa aatatcactc tgcaattaca
+     4081 gcgtgagttt gcggctgaaa atcgtgaaag ttatgatcat gtgttttata gcgggccgtt
+     4141 agacgcgttc tattcatacc agcatgggcg tcttggctac cgtactctgg actttgagcg
+     4201 atttacctgg caaggtgatt atcagggctg cgcggtcatg aattattgct cagttgatgt
+     4261 cccgtatacg cgaattacgg aacataaata tttttccccg tgggaaagcc atgaaggttc
+     4321 cgtatgttat aaggaatata gtcgcgcttg cggtgaagat gatattcctt actatccaat
+     4381 ccgccagatg ggtgagatgg ctctgctgga taaatattta tcactggcgg agaatgagaa
+     4441 aaatattact ttcgttggac gcctggggac ttatcgctac cttgatatgg atgtaacgat
+     4501 tgcagaagca ttgaaaacgg ccgataaata tctgtcctca ttgtccaacg acgaagcgat
+     4561 gcctgtattt gtggccgacg tacgatgaaa catactgcat taatagtcac ttttaaccgt
+     4621 cttgaaaagc taaaaaagac ggttgctgaa actgttaagc tgcactttac ctctatcgtt
+     4681 attgtcaaca acgggtccac ggatgggacc tctgattggc ttcagacaat cactgatccc
+     4741 cgtgtaattg tcttgaatct ggcctgtaat aacggtggcg ccggagggtt taaggccggt
+     4801 agtcaataca tatgcagttc tgttgatagc gattgggtct tcttttatga cgatgatgct
+     4861 tatccgcaaa gtgatattct tgataagttc tcaacgataa ataaagaagg ttgtcgtgtt
+     4921 tttacggctt tagttaaaga tttgcagggc cggacatgcg cgatgaatgt tccatttgca
+     4981 aaagtcccga cctcgtttag tgatactttg caatatatca aacatcccca acgatatgta
+     5041 ccagataata aggaaatgct ggtgcaaaca gtttcatttg ttggcatgat cattaagcgt
+     5101 gaagtcttga atgagcacct tcatcatatt tatgatgaac ttttccttta ttttgatgac
+     5161 ctctattttg gttatcaatt aactctaagt ggtgagaaaa ttatctataa tccggaactt
+     5221 gtttttactc atgatgtgag tatccaggga aaggtcatat cgccagagtg gaaggtttac
+     5281 tatctttgtc gaaacttaat tttggctaag agaatattta cggaagtggc agtttttagt
+     5341 agttcatcaa tccttttgcg cctatgcaag tatatctcca tattccctgt acagcgccgg
+     5401 aaatgggtgt atctaaagtt tttatgccgt gggattgtac atggtgtaaa aggaattagc
+     5461 ggtaagtttc actaagtgga catagcaatg aaaaaactgt gttatttcat aaattcggat
+     5521 tggtattttg atttgcattg gaccgatcgt gcaattgccg cccgagatgc cggttatgag
+     5581 attcacatta ttagccattt tgtcgatgat aaaatagcga taaaattcaa aacactaggt
+     5641 tttatttgtc ataatattcc tcttgtcgct caatcgttca acgttttgat tttctttcgg
+     5701 gcctttttta aggctcggaa aattattcaa agcattaatc ctgatttatt acactgcatt
+     5761 accatcaaac cgtgtttgat cggcggattt ctggctaaaa gtacccatcg tcctgttatt
+     5821 ctgagttttg tcggtttagg ccgagtattt tcggcagagt ctggctgtct taagctgctg
+     5881 cgtagtttta ctgttatggc atataagtat atcgccagta acaaatgcag cttgtttatg
+     5941 ttcgaacatg ataaagacag agccaaactc gccgatctgg ttggtatcga ttacaaacag
+     6001 actattgtta ttgatggtgc gggtattaat ccagagattt acaaatattc tctggagcaa
+     6061 caacgtgatg tcccggtcgt cctttttgcc agccgtatgc tgtggagtaa aggacttggt
+     6121 gatctgattg aagccaaaaa aatactgagt aataaaaata ttcactttac gctgaatgtt
+     6181 gccggtatct tagttgagaa tgataaagac gcgattccgc tagcgacgat acagaagtgg
+     6241 caaagcgaag gcgtgattaa ctggctcggt cattgctcta atgtatttga tttaattgaa
+     6301 gaatcaaata tcgttgcttt gccgtcggtc tacgccgaag gcgtaccacg tatcttgctg
+     6361 gaagcttcct cggtcgggcg tgcttgtatc gcttatgatg ttggtggctg tgatagctta
+     6421 attatcaaca acgataatgg gttaattgta aaaagtaaat ctgttgagga attagcggag
+     6481 aaactcggtt tcctgttaga taatcctgaa acgcgagtcg caatgggtat caatggcaga
+     6541 aagcgtattc aagataaatt ctcgagtgtg atgatcatta ataaaacatt aaaaacatat
+     6601 cgcgatgttg ttgaagagta atttttgatg aagctgagtt gctttcatct tacctatcct
+     6661 taatgaactg gaaacctaca aattaaatgc taccaataaa taaatataat tgcgtttaga
+     6721 agctaagcgt caaggtgatt acatgtctga aaaaaagagt attgctgttt ctgttattat
+     6781 ccctgtgcac aatgctgctg gatatatttc cgatacatta agcaccgttt tgtcgcaaac
+     6841 attaaatgat atcgaaatca ttattatcaa tgattgttct aacgataata ccttagagat
+     6901 tgtctctgcg ctggctgaaa ctgattcacg gattagagtg attaacaaca cgacaaatct
+     6961 tggtggtgga ggttcgagaa acgttgggtt ggatgctgct atcggtgagt acgttatttt
+     7021 tctcgatgac gacgattacg ctgataacat gatgttggag cgcatgtacg cgcaggccag
+     7081 cgatacacaa gcggatgtcg ttatttgtcg cagccagtct tttgatccct ccttacaagt
+     7141 ttatgctccg atgccgtggt cagttcgcca ggagctgcta cctgatctta tggttttttc
+     7201 ctcccaggat attccctctg actttttccg cgcctttgtc tggtggccat gggacaagct
+     7261 tctcaggcgt caatttattg ctactcatca gcttcgtttt caggaaatca ggacaacaaa
+     7321 cgatcttttc ttcgtctgtg ccttcatgct gatggcgaac agaatctcgg tcttaaatga
+     7381 aacgttaatt tctcatacca tcaatcgtag tgaatcctta tccgccacga gagcagaatc
+     7441 gcaccgctgt gctgttgaag cattagtggc tcttaaagca tttatctgtc agcaggggat
+     7501 gatggatcaa cgtctcagag attacaaaaa ctatgttgtc gttttccttg agtggcattt
+     7561 aaacacgata tctggtccgg catttcatcc gttttatcag caagtgaaag agtttattgt
+     7621 tgcgttagat gcaaaggatg atgattttta tgatgaattt atcgccgccg cgcatcatag
+     7681 aatcaccacg ctgtcagctg aagagtacct attctccctt aaagatcgtg ttctgaagga
+     7741 gcttgagttt ttccaggcaa agagctccgc attacagcaa gaagttgaga cgctgactga
+     7801 ctcattcgct gagcaaaagg atgaaaatgc gatattacat aatcaattgc atgagattga
+     7861 agagcgggtt actgaacagg aaaagaatat tcgtcagtta actgacaaaa ataataatat
+     7921 gcatcatgaa ataactatca aacagcaaga attcaatgaa atttatcagc atcacaaaaa
+     7981 tttaatctct tctttatcct ggaagttgac taagccacta cgagtggtaa gacgtttttt
+     8041 taaataa
+//
+LOCUS       LT174603               11906 bp    DNA     linear   BCT 13-JUN-2016
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
+            cluster, type: O3/O3a.
+ACCESSION   LT174603
+VERSION     LT174603.1  GI:1036211094
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
+            Enterobacteriaceae; Klebsiella.
+REFERENCE   1
+  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
+            Holt,K.E. and Thomson,N.R.
+  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
+            antigens
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 11906)
+  AUTHORS   Informatics,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
+            1SA, UNITED KINGDOM
+FEATURES             Location/Qualifiers
+     source          1..11906
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="AKPRH077088"
+                     /serovar="O3/O3a"
+                     /db_xref="taxon:573"
+                     /note="O locus: OL3αβ"
+                     /note="O type: O3αβ"
+                     /note="annotation edited from original by K. Wyres Jan
+                     2018"
+                     /note="Updated from O3/O3a by Tom Stanton in Feb 2025"
+     gene            1..1416
+                     /gene="manC"
+     CDS             1..1416
+                     /gene="manC"
+                     /EC_number="2.7.7.13"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006635421.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mannose-1-phosphate guanylyltransferase"
+                     /protein_id="CZQ25304.1"
+                     /db_xref="GI:1036211095"
+                     /translation="MLLPVIMAGGTGSRLWPMSRELYPKQFLRLYGQNSMLQETITRLS
+                     GLEIHEPMVICNEEHRFLVAEQLRQLNKLSNNIILEPVGRNTAPAIALAALQATRHGDD
+                     PLMLVLAADHIINNQPVFHDAIRVAEQYADEGHLVTFGIVPNAPETGYGYIQRGVALTD
+                     SAHTPYQVARFVEKPDRERAEAYLASGEYYWNSGMFMFRAKKYLSELAKFRPDILEACQ
+                     AAVNAADNGSDFISIPHDIFCECPDESVDYAVMEKTADAVVVGLDADWSDVGSWSALWE
+                     VSPKDEQGNVLSGDAWVHNSENCYINSDEKLVAAIGVENLVIVSTKDAVLVMNRERSQD
+                     VKKAVEFLKQNQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
+                     AEHWVILAGTGQVTVNGKQFLLTENQSTFIPIGAEHSLENPGRIPLEVLEIQSGSYLGE
+                     DDIIRIKDQYGRC"
+                     /locus_tag="OL3αβ_01_manC"
+     gene            1439..2821
+                     /gene="manB"
+     CDS             1439..2821
+                     /gene="manB"
+                     /EC_number="5.4.2.2"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237527.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="phosphomannomutase"
+                     /protein_id="CZQ25305.1"
+                     /db_xref="GI:1036211096"
+                     /translation="MTQLTCFKAYDIRGELGEELNEDIAYRIGRAYGEFLKPGKIVVGG
+                     DVRLTSESLKLALARGLMDAGTDVLDIGLSGTEEIYFATFHLGVDGGIEVTASHNPMNY
+                     NGMKLVRENAKPISGDTGLRDIQRLAEENQFPPVDPARRGTLRQISVLKEYVDHLMGYV
+                     DLANFTRPLKLVVNSGNGAAGHVIDEVEKRFAAAGAPVTFIKVHHQPDGHFPNGIPNPL
+                     LPECRQDTADAVRAHQADMGIAFDGDFDRCFLFDDEASFIEGYYIVGLLAEAFLQKQPG
+                     AKIIHDPRLTWNTVDIVTRSGGQPVMSKTGHAFIKERMRQEDAIYGGEMSAHHYFRDFA
+                     YCDSGMIPWLLVAELLCLKNSSLKSLVADRQAAFPASGEINRKLGNAAEAIARIRAQYE
+                     PAAAHIDTTDGISIEYPEWRFNLRTSNTEPVVRLNVESRADTALMNEKTAELLNLLKEE
+                     SL"
+                     /locus_tag="OL3αβ_02_manB"
+     gene            2827..3612
+                     /gene="wzm"
+     CDS             2827..3612
+                     /gene="wzm"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237528.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ABC transporter permease"
+                     /protein_id="CZQ25306.1"
+                     /db_xref="GI:1036211097"
+                     /translation="MFSAIYRYRGFIIDSVKRDFQSRYQTSFLGAAWLILQPIAMISVY
+                     TLIFSELMRARLAGMDGPFAYSIYLCSGVLTWGLFTETLGNLVNVFLTNANILKKLSFP
+                     RICLPIIVTASAFINFLIIFGLFVLFLIVTGNFPGMIFFEIIPVLIVQMLFTLGLGIIL
+                     GVLNVFVRDVGQFVNILLQFWFWFTPIVYVSKTLPEWVSGLLAYNPMATIIGSYQNVML
+                     YHQSPNWMALLPVTVVSVILFLFAWRLFKKHAADIVDEI"
+                     /locus_tag="OL3αβ_03_wzm"
+     gene            3615..4910
+                     /gene="wzt"
+     CDS             3615..4910
+                     /gene="wzt"
+                     /EC_number="3.6.3.40"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237529.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ABC transporter ATP-binding protein"
+                     /protein_id="CZQ25307.1"
+                     /db_xref="GI:1036211098"
+                     /translation="MSIKVQHVGKAYKYYPSKWNRVIEKLLPGDKPRHSKKWVLKDINF
+                     SIEPGEAVGIVGVNGAGKSTLLKLLTGTTQPTKGSIEIQGRVAALLELGMGFHPDFTGR
+                     QNVYMSGLMMGLGREEIERLMPEIEAFADIGDYIEEPVRIYSSGMQMRLAFAVATASRP
+                     DILIVDEALSVGDSRFQAKCYARIADFKKQGTTLLLVSHSAGDIVKHCDRAIFLKNGDI
+                     CMDGTARDVTNRYLDELFGKPDKDSATKSATAISSASGESQMSLDEIEDVYHTRPGYRP
+                     EEYRWGQGGAKIIDYHIQSAGVDFPPSLTGNQQTDFLMKVVFEYDFDCVVPGILIKTLD
+                     GLFLYGTNSFLASEGRENISVSRGDVRVFKFSLPVDLNSGDYLLSFGISAGNPQTDMTP
+                     LDRRYDSIILHVTKSMDFWGVIDLKSSFTSYQ"
+                     /locus_tag="OL3αβ_04_wzt"
+     gene            4930..7056
+                     /gene="wbdD"
+     CDS             4930..7056
+                     /gene="wbdD"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237530.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="methyltransferase"
+                     /protein_id="CZQ25308.1"
+                     /db_xref="GI:1036211099"
+                     /translation="MTKDLNTLVSELPEIYQTIFGHPEWDGDAARDCNQRLDLITEQYD
+                     NLSRALGRPLNVLDLGCAQGFFSLSLASKGATIVGIDFQQENINVCRALAEENPDFAAE
+                     FRVGRIEEVIAALEEGEFDLAIGLSVFHHIVHLHGIDEVKRLLSRLADVTQAVILELAV
+                     KEEPLYWGVSQPDDPRELIEQCAFYRLIGEFDTHLSPVPRPMYLVSNHRVLMNDFNQPF
+                     QHWQNQPYAGAGLAHKRSRRYFFGEDYVCKFFYYDMPHGILTAEESQRNKHELHNEIKF
+                     LAQPPAGFDAPALLAHGENAQSGWLVMEKLPGRLLSDMLAAGEEIDREKILGSLLRSLA
+                     ALEKQGFWHDDVRPWNVMVDARQHARLIDFGSIVTTPQDCSWPTNLVQSFFVFVNELFA
+                     ENKSWTGFWRSAPVHPFNLPQPWSNWLYAVWQEPVERWNFALLLALFEKKAKLPSAEQQ
+                     RGATEQWIIAQETVLLELQSRVRHESAGSEALRGQIHTLEQQMAQLQAAQDAFVEKAQQ
+                     PVEVSHELTWLGENMEQLAALLQTAQAHAQADVQPELPPETAELLQRLEAANREIHHLS
+                     NENQQLRQEIEKIHRSRSWRMTKGYRYLGLQIHLLRQYGFVQRCKHFIKRVLRFVFSFM
+                     RKHPQVKHTAVNGLHKLGLYQPAYRLYRRMNPLPHSQYQADAQILSQTELQVMHPELLP
+                     PEVYEIYLKLTKNK"
+                     /locus_tag="OL3αβ_05_wbdD"
+     gene            7067..9589
+                     /gene="wbdA"
+     CDS             7067..9589
+                     /gene="wbdA"
+                     /EC_number="2.4.1.246"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237531.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mannosyltransferase A"
+                     /protein_id="CZQ25309.1"
+                     /db_xref="GI:1036211100"
+                     /translation="MHILIDVQGYQSESKFRGIGRSTLAMSRAIIENAGEHRVSILING
+                     MYPIDNINDVKMAYRDLLTDEDMFIFSAVAPTAYCNIENHGRSKAAQAARDIAIANIAP
+                     DIVYVISFFEGHGDSYTVSIPADNVPWKTVCVCHDLIPLLNKERYLGDPNFREFYMNKL
+                     AEFERADAIFAISQSAAQEVIEYTDIASDRVLNISSAVGEEFAVIDYSAERIQSLKDKY
+                     SLPDEFILTLAMIEPRKNIEALIHAYSMLPAELQQRYPMVLAYKVHPEDLERILRLAES
+                     YGLSRSQLIFTGFLTDDDLIALYNLCKLFVFPSLHEGFGLPPLEAMRCGAATLGSNITS
+                     LPEVIGWEDAMFNPHDVQDIRRVMEKALTDEAFYRELKAHALAQSAKFSWANTAHLAIE
+                     GFTRLLQSSQEANAGQAESVTASRIQTMQKIDALSEVDRLGLAWAVARNSFKRHSRKLL
+                     VDISVLAKHDAKTGIQRVSRSILSELLKSGVPGYEVSAVYYTPGECYRYANQYLSSHFP
+                     GEFGADEPVLFSKDDVLIATDLTAHLFPEVVTQIDSMRAAGAFACFVVHDILPLRRPEW
+                     SIEGIQREFPIWLSCLAEHADRLICVSASVAEDVKAWIAENRHWVKPNPLLTVSNFHLG
+                     ADLDASVPSTGMPDNAQALLATMAAAPSFIMVGTMEPRKGHAQTLAAFEELWREGKDYN
+                     LFIVGKQGWNVDSLCEKLRHHPQLNKKLFWLQNISDEFLAELYARSRALIFASQGEGFG
+                     LPLIEAAQKKLPVIIRDIPVFKEIAQEHAWYFSGEAPSDIAKAVEEWLALYEQNAHPRS
+                     ENINWLTWKQSAEFLLKNLPIIAPAAKQ"
+                     /locus_tag="OL3αβ_06_wbdA"
+     gene            9636..10781
+                     /gene="wbdB"
+     CDS             9636..10781
+                     /gene="wbdB"
+                     /EC_number="2.4.1.250"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237532.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mannosyltransferase B"
+                     /protein_id="CZQ25310.1"
+                     /db_xref="GI:1036211101"
+                     /translation="MKIIFATEPIKYPLTGIGRYSLELVKRLAVAREIEELKLFHGASF
+                     IDQIPQVENKSDTKASNHGRLSAFLRRQPLLIEAYRLLHPRRQAWALRDYKDYIYHGPN
+                     FYLPHRLERAVTTFHDISIFTCPEYHPKDRVRYMEKSLHESLDSAKLILTVSDFSRSEI
+                     IRLFNYPADRIVTTKLACSSDYIPRSPAECLPVLQKYQLAWQGYALYIGTMEPRKNIRG
+                     LLQAYQLLPMETRMRYPLILSGYRGWEDDVLWQLVERGTREGWIRYLGYVPDEDLPYLY
+                     AAARTFVYPSFYEGFGLPILEAMSCGVPVVCSNVTSLPEVVGDAGLVADPNDVDAISAH
+                     ILQSLQDDSWREIATARGLAQAKQFSWENCTTQTINAYKLL"
+                     /locus_tag="OL3αβ_07_wbdB"
+     gene            10791..11906
+                     /gene="wbdC"
+     CDS             10791..11906
+                     /gene="wbdC"
+                     /EC_number="2.4.1.11"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237533.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyl transferase family protein"
+                     /protein_id="CZQ25311.1"
+                     /db_xref="GI:1036211102"
+                     /translation="MRVLHVYKTYYPDTYGGIEQVIYQLSQGCARRGIAADVFTFSPDK
+                     ETGPVAYEDHRVIYNKQLFEIASTPFSLKALKRFKQIKDDYDIINYHFPFPFMDMLHLS
+                     ARPDARTVVTYHSDIVKQKRLMKLYQPLQERFLASVDCIVASSPNYVASSQTLKKYQDK
+                     TVVIPFGLEQHDVQHDPQRVAHWRETVGDNFFLFVGAFRYYKGLHILLDAAERSRLPVV
+                     IVGGGPLEAEVRREAQQRGLSNVVFTGMLNDEDKYILFQLCRGVVFPSHLRSEAFGITL
+                     LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPNDSQALVEAMNELWHNDETASRYGE
+                     NSRRRFEEMFTADHMIDAYVNLYTTLLESKS"
+                     /locus_tag="OL3αβ_08_wbdC"
+ORIGIN
+        1 atgttacttc ctgtaattat ggctggtggt accggcagtc gtctctggcc gatgtctcgc
+       61 gagctttacc cgaaacagtt cctccggctg tacgggcaga actccatgct gcaggaaacc
+      121 atcacccgac tctcgggcct tgaaatccat gaaccgatgg tcatctgtaa cgaagagcac
+      181 cgcttcctgg tggctgaaca gctgcgccag ctcaacaagc tgtccaacaa cattattctt
+      241 gagccggtcg ggcgcaacac cgccccggcc atcgccctgg cggccctcca ggccacccgt
+      301 cacggcgacg acccgctgat gctggtcctc gccgccgacc atatcatcaa taaccagccg
+      361 gtcttccacg acgccatccg cgtcgccgag cagtatgccg atgaaggcca tctggtcacc
+      421 ttcggtatcg tgccgaacgc cccggaaacc ggctacggtt acatccagcg cggcgtggcc
+      481 ctcaccgaca gcgcccacac cccgtaccag gttgcccgct tcgtggagaa gccggaccgc
+      541 gagcgcgccg aggcctacct cgcctccggg gagtactact ggaacagcgg catgtttatg
+      601 ttccgcgcca aaaaatacct ctccgagctg gccaaattcc gcccggatat cctcgaagcc
+      661 tgccaggccg cggtcaatgc cgccgacaac ggcagcgact tcatcagcat tccgcatgac
+      721 attttctgcg agtgcccgga cgagtccgtg gactacgcgg tgatggagaa aaccgccgac
+      781 gcggtggtgg tcggtctcga tgccgactgg agcgacgtcg gctcctggtc cgccctgtgg
+      841 gaggtcagcc cgaaagacga gcagggtaac gtcctcagcg gtgacgcgtg ggtgcataac
+      901 agcgaaaact gctacatcaa cagcgacgag aagctggtgg cggccatcgg cgtggaaaac
+      961 ctggtgattg tcagcaccaa ggacgccgtg ctggtgatga accgcgagcg ttcccaggac
+     1021 gtgaagaagg cggtcgagtt cctcaagcag aaccagcgca gcgagtacaa gcgccaccgc
+     1081 gagatttacc gtccctgggg ccgctgcgac gtggtggtcc agaccccgcg cttcaacgtc
+     1141 aaccgcatca ccgtgaaacc gggcggcgcc ttctcgatgc agatgcacca ccaccgcgcc
+     1201 gagcactggg tcattctcgc cggcaccggc caggtgacgg tgaacggcaa gcagttcctg
+     1261 ctgaccgaga accagtccac ctttattccg attggcgccg agcacagcct ggaaaacccg
+     1321 ggccgtattc cgctggaagt gctggagatc cagtcggggt cgtacctcgg cgaggacgac
+     1381 attattcgta ttaaagacca gtatggtcgt tgctaatttt ttcgggacaa aacgcagaat
+     1441 gacacagtta acatgcttta aggcttatga catccgtggt gaactgggcg aggagctgaa
+     1501 cgaggacatc gcctaccgta tcggccgcgc ctatggcgaa tttctgaaac ccgggaagat
+     1561 agtggtgggg ggcgatgtgc gcctcaccag cgagtcgctg aagctggcgc tggcccgcgg
+     1621 gctgatggac gccggcaccg acgtgctgga tatcggcctg agcggcaccg aagagattta
+     1681 cttcgccacc ttccacctcg gggtggacgg cggcatcgag gtgacggcga gccataaccc
+     1741 gatgaactac aacggcatga agctggtgcg cgagaacgcg aagcccatca gcggcgacac
+     1801 cggcctgcgg gatatccagc gcctggcgga ggagaaccag ttcccgccgg tggacccggc
+     1861 gcgtcgcgga accctgcgcc agatatcggt gctgaaggag tacgtcgacc acctgatggg
+     1921 ctacgtggac ctggcgaact tcacccgtcc gctgaagctg gtggtgaact ccggcaacgg
+     1981 ggcggcgggg cacgtgattg atgaggtgga gaaacgcttc gcggcggccg gggcgccggt
+     2041 gacctttatc aaggtgcatc accagccgga cggccatttc ccgaacggta tcccgaaccc
+     2101 gctgctgccg gagtgccgcc aggacaccgc cgacgcggtg cgtgcgcatc aggcggacat
+     2161 gggtatcgcc tttgacggcg acttcgaccg ctgcttcctg ttcgatgacg aggcgtcgtt
+     2221 tatcgagggg tactacattg tcggcctgct ggcggaagcg ttcctgcaga agcagccggg
+     2281 ggcgaaaatc attcacgacc cgcgtctgac atggaacacg gtggacatcg tgacccgcag
+     2341 cggcggccag ccggtgatgt cgaagacggg gcatgcgttc atcaaggagc ggatgcgcca
+     2401 ggaagacgcc atctacggcg gggagatgag cgcgcaccat tacttccgcg acttcgccta
+     2461 ctgcgacagc gggatgatcc cgtggctgct ggtggcggag ctgctgtgcc tgaagaacag
+     2521 ctcgctgaaa tcgctggtgg cggaccgcca ggcggcgttc ccggcgtcgg gggagatcaa
+     2581 ccgcaagctg gggaacgcgg cggaggcgat agcgcgcatc cgggcgcagt atgagccggc
+     2641 ggccgcacac atcgacacaa cggacggtat cagtattgaa taccctgagt ggcgctttaa
+     2701 cctgcgcacg tccaataccg agccggtggt gcgtctgaac gttgagtcca gagcggatac
+     2761 tgcgttaatg aatgagaaaa ccgccgagct gctcaacctg ttaaaagagg aatcgctttg
+     2821 agtcctatgt tttcagcgat ctatcgctac cgtggcttta ttattgacag cgttaaacgg
+     2881 gactttcagt cccgttacca gaccagtttt ttaggcgcgg catggttgat cttacagccg
+     2941 atcgccatga tttccgtcta tacattaatt ttttcagagt taatgcgtgc ccgcctggcg
+     3001 gggatggatg gtccttttgc ctacagtatc tacctctgtt ccggggtatt aacctggggg
+     3061 ttgtttacgg aaacgctcgg caatctggtc aacgtttttc tgaccaatgc caatatcctc
+     3121 aagaaactga gctttccgcg gatctgttta ccgatcattg tcaccgcctc ggcgttcatt
+     3181 aacttcctga tcatttttgg tctgtttgta ctgtttctga tcgtcacggg caatttcccg
+     3241 ggcatgattt tctttgaaat cattccggtg ctgatcgtcc agatgctgtt tactcttggc
+     3301 ctggggatta tcctcggggt gctgaacgtt tttgtccgcg acgtcgggca gttcgtcaat
+     3361 atcctgctgc agttttggtt ctggtttacg ccgattgttt acgtatccaa aacgctgccg
+     3421 gaatgggtat caggtctgct ggcatataac ccgatggcga caattatcgg ttcctaccag
+     3481 aacgtgatgc tctatcacca gagccctaac tggatggcgc tgcttccggt cacagtggtg
+     3541 tcggtcattc tgtttttatt tgcctggcgt ttatttaaaa aacatgccgc tgatattgtg
+     3601 gacgagattt aatcatgagt atcaaagttc agcacgtcgg caaggcgtat aaatattatc
+     3661 catctaaatg gaaccgggtc attgagaaac tactgccggg cgataagccg cggcacagca
+     3721 agaaatgggt attgaaagat atcaatttca gcattgaacc cggtgaagcg gtcggcattg
+     3781 ttggggtgaa cggcgcaggt aaaagtacgt tactgaagct gctgactggc accactcagc
+     3841 ccaccaaagg cagcattgaa atccaggggc gcgtcgccgc gctgctggag ctgggcatgg
+     3901 gcttccatcc tgactttacc ggccggcaga acgtgtatat gtccgggctg atgatgggcc
+     3961 tgggccggga agagatcgag cgcttaatgc cggagatcga agccttcgcc gatattggcg
+     4021 actacattga agagcccgtg cgcatctatt ccagcggtat gcaaatgcgc ctggcgttcg
+     4081 ctgtcgccac ggcctcccgg ccggatattc tgatcgtcga tgaagcgctc tccgtgggtg
+     4141 actcccgttt tcaggcgaaa tgctatgctc gcatcgcgga cttcaaaaag caggggacca
+     4201 cgctgctact ggtttcccac agcgccgggg atatcgtcaa gcactgcgac cgcgccattt
+     4261 tcctcaaaaa tggtgacatc tgcatggacg gtaccgcccg cgacgtgacc aaccgttacc
+     4321 tggatgagct gtttggcaaa ccggataaag acagcgcgac aaaaagcgca acggctatct
+     4381 cgtcagccag tggcgaaagc cagatgtctc tcgatgagat tgaagatgtg taccacacgc
+     4441 gcccaggcta ccgtccggaa gaatatcgct gggggcaggg tggcgcgaaa atcatcgatt
+     4501 atcatatcca gagcgccggg gttgattttc ctccctcact gacgggcaat cagcagaccg
+     4561 attttctgat gaaggtcgtg tttgaatacg attttgattg cgtggtgcca ggcatcctga
+     4621 ttaagaccct cgatggctta ttcctctacg gaaccaactc tttcctcgcc tctgaagggc
+     4681 gggaaaatat ttcggtttcc cgcggcgatg ttcgggtctt taaatttagc cttccggttg
+     4741 atttaaacag tggcgattac ctgctgtcat ttggtatctc tgccggcaac ccacagacgg
+     4801 atatgacgcc gctggacaga cgttacgact ccattatttt acatgtgacc aagagcatgg
+     4861 atttctgggg tgtcatcgat cttaagtcgt cctttactag ctaccaatga cgttgagaaa
+     4921 aacgattcca tgactaaaga cttaaacacg ctggttagcg aattacctga gatttatcaa
+     4981 actatttttg gccatcccga atgggatggc gacgccgctc gtgattgtaa tcaacgcctc
+     5041 gatttgatta ccgaacagta cgataactta tcccgtgcac tggggcgccc gcttaacgtt
+     5101 ctcgatctgg gctgcgcgca gggctttttt agcctgagtc tggcaagcaa aggcgcgact
+     5161 atcgttggta tcgatttcca gcaggaaaat attaacgtgt gccgcgcgct ggccgaagag
+     5221 aaccccgatt ttgccgccga gttccgggta ggcagaattg aagaggtgat cgccgcgctg
+     5281 gaagaggggg agtttgatct ggccattggc ttaagcgtgt ttcaccatat tgttcacctt
+     5341 catggtatcg atgaagttaa acgtctgctc tcgcgcctgg ccgatgtcac ccaggcggtg
+     5401 atccttgagc tggcggtgaa agaagaaccg ctttactggg gcgtttctca gccggacgac
+     5461 ccgcgcgaac tgattgagca gtgcgcgttt tatcgcctga tcggtgagtt tgatacccat
+     5521 ttatcccccg taccgcgccc gatgtacctg gtcagcaacc accgggtgct gatgaacgat
+     5581 tttaatcagc cgttccagca ctggcagaat cagccctatg ccggggccgg cctcgcgcat
+     5641 aagcgcagcc gtcgctactt ctttggcgaa gattatgtat gcaagttttt ctattacgac
+     5701 atgccccacg gcatcctgac ggcggaagag agccagcgta ataaacatga actgcataat
+     5761 gaaataaagt tcctggcgca accgccagcg ggctttgacg cgcccgcatt actggcccac
+     5821 ggcgaaaatg ctcagtctgg ctggctggtg atggaaaaac tcccgggtcg tttgctgagc
+     5881 gatatgctgg cagccgggga ggagatcgat cgtgaaaaaa tcctcggtag cttgcttcgt
+     5941 tccttagcgg cgctggagaa acaagggttc tggcatgacg atgtacgccc gtggaacgtg
+     6001 atggtcgatg cccgacagca tgcccgctta atcgacttcg gctctatcgt taccacgccg
+     6061 caggactgca gctggccgac gaaccttgtc cagtcgttct tcgtgtttgt gaatgagctg
+     6121 tttgccgaaa acaaaagctg gactggtttc tggcgctcgg cgcctgttca tccgtttaat
+     6181 ctaccccagc cgtggtctaa ctggctgtat gcggtctggc aggagccggt tgaacgctgg
+     6241 aactttgccc tgctgttggc gctgttcgag aagaaagcga agctgccttc agctgaacag
+     6301 cagcgcgggg cgacggaaca gtggatcatc gctcaggaga cggtgctgct ggagctccag
+     6361 tcccgggtgc gtcatgaaag cgccggctca gaagcgttgc gcggccaaat ccataccctg
+     6421 gagcagcaga tggctcagct gcaggccgct caggatgcgt tcgtcgagaa agctcaacag
+     6481 ccagtggaag tcagccatga actcacctgg cttggtgaga atatggagca gctggcggcg
+     6541 ctgttgcaga cggcgcaagc gcacgcccag gctgacgttc agcccgagtt gccacctgaa
+     6601 accgctgagc tactgcagcg actggaagcc gctaaccggg agatccacca tttaagcaac
+     6661 gaaaaccagc agcttcgcca ggaaattgaa aaaatccatc gcagccgttc ctggagaatg
+     6721 accaagggtt atcgttatct gggcctgcag atccatttgc tgaggcagta tggtttcgtg
+     6781 cagcggtgta aacattttat taagcgcgtc ctgcggtttg ttttctcgtt tatgagaaaa
+     6841 catccgcagg taaaacatac cgcggtaaat ggtttacata agctgggcct ttatcagccg
+     6901 gcctaccgtt tgtatcgtcg tatgaatcca ctgccgcaca gtcagtatca ggctgatgcg
+     6961 cagattttat cgcagactga actgcaagtg atgcatccgg agcttttacc tccggaggtt
+     7021 tatgaaattt atctcaaact aacgaaaaat aaataaggag attaacttgc atattttgat
+     7081 tgatgtccag ggttaccagt cggaaagtaa attccgcggt atcggtcgca gtaccctggc
+     7141 catgagccgc gccattattg aaaatgccgg tgagcatcgc gtcagtattt tgatcaatgg
+     7201 tatgtacccc attgataata tcaatgatgt caaaatggcc tatcgggacc tgctgacgga
+     7261 tgaagatatg ttcatcttct cagccgttgc gccaacggcc tattgcaaca tcgaaaacca
+     7321 cggtcgcagc aaggcagccc aggcggcccg cgatatcgct atcgccaata tcgcgcctga
+     7381 tatcgtctat gttattagct tcttcgaagg ccatggggat agttataccg tgtctattcc
+     7441 ggcggataat gtgccctgga agacggtgtg tgtatgccac gatctgatcc cgctgttaaa
+     7501 taaagagcgt tacctcggcg atccgaattt ccgtgagttt tatatgaaca agctggcgga
+     7561 atttgagcgg gcagacgcga tcttcgctat ttcgcagtcg gcagctcagg aagtgatcga
+     7621 atataccgac atcgccagcg atcgggtact gaacatctcc tcggcggtgg gcgaagagtt
+     7681 tgcggtgatc gattattctg ctgagcgtat tcagtcttta aaagacaaat acagcctgcc
+     7741 ggatgagttt atcctaacgc tggcgatgat cgagccgcgg aaaaacattg aagcgcttat
+     7801 tcatgcttac agcatgctgc ctgccgaact gcagcagcgc tatccgatgg tgctcgcgta
+     7861 taaggtgcat cctgaagatc tggagcgtat tctgcgtctg gcggaaagct atggcctgtc
+     7921 acgcagccag cttatcttta ccggcttcct gaccgacgac gatctgattg ccttgtacaa
+     7981 cctttgcaaa ctgtttgtgt tcccgtcgct gcatgaggga ttcggcctgc cgccgctgga
+     8041 agcgatgcgc tgtggggccg cgaccctggg ttcaaacatc accagcctgc cggaagtcat
+     8101 tggctgggaa gatgccatgt tcaatccgca tgatgtgcag gacattcgcc gggtcatgga
+     8161 gaaggcgctg accgatgagg cgttttatcg tgagctgaaa gcgcatgctc tcgcgcagtc
+     8221 ggccaaattc tcctgggcca ataccgccca tctggcgatc gagggtttca ctcgtctgct
+     8281 gcagtcgtcc caagaggcga atgccgggca ggcggaaagc gtgaccgcct cccgtatcca
+     8341 gacgatgcag aaaatcgatg cgctgagcga agtcgaccgt cttggtctgg catgggcggt
+     8401 tgcgcgcaat agctttaagc gccattcccg caagctgctg gtggacattt cggttctggc
+     8461 gaaacatgac gcgaagaccg ggatccagcg cgtctcgcgc agtatcctca gcgaattact
+     8521 gaaatctggc gtgccgggtt acgaggtttc cgctgtctac tacacccctg gcgagtgtta
+     8581 tcgctacgcc aaccaatatc tgtccagtca tttcccgggc gaatttggcg ctgacgaacc
+     8641 ggtgctgttc agcaaagacg atgtgcttat cgccaccgat ctgaccgcgc atctcttccc
+     8701 ggaggtggtg acgcaaattg acagcatgcg cgccgccggg gcgttcgcct gcttcgtggt
+     8761 gcatgatatt ctgccattac gccgcccgga gtggagtatc gaaggcattc agcgtgaatt
+     8821 cccgatctgg ctgtcctgcc tcgcagagca cgccgatcgg ctgatctgcg tctctgccag
+     8881 cgttgccgag gatgtgaaag cgtggattgc ggaaaatcgc cattgggtga aaccgaaccc
+     8941 gctgctgacc gtcagcaact tccatctggg agccgacctc gatgccagcg taccgtccac
+     9001 tggcatgccg gataatgcac aggcgctgtt agcaacgatg gctgcagccc cgtcatttat
+     9061 catggtgggt accatggagc cgcgcaaagg ccatgcccag acgctggccg ccttcgagga
+     9121 actgtggcgc gagggcaaag actacaactt gtttatcgtc ggcaaacagg gctggaacgt
+     9181 tgacagcttg tgcgaaaaat tacgccatca tccgcagctg aacaaaaagc tcttctggct
+     9241 gcagaatatc agcgacgagt ttttggccga gctatacgct cgttcacgcg cgctgatctt
+     9301 tgcctcgcag ggagaaggct ttggcctgcc attgattgaa gcggcgcaga aaaagctgcc
+     9361 agtgattatt cgcgacattc cagtgtttaa agagattgct caggaacatg cctggtattt
+     9421 ctccggtgaa gcgccgtccg atatcgcgaa ggcggtagaa gagtggttag ccctgtacga
+     9481 gcaaaacgcg catcctcgtt ccgaaaatat caactggtta acctggaaac agagcgcgga
+     9541 atttctcctg aaaaacctgc cgattatcgc gccagccgcg aagcaataat cgctatcaac
+     9601 agggctactc cggtggccct tgtgatgagt tcgttatgaa aattattttt gctactgagc
+     9661 caattaaata cccattaacg ggcatcggtc ggtattccct ggagctggtt aagcggctgg
+     9721 cggttgcccg tgaaatcgaa gagctgaagc tgtttcacgg cgcgtcgttt atcgatcaga
+     9781 tcccccaggt ggagaataaa agcgatacca aagccagcaa tcatggtcgt ctgtcggcgt
+     9841 ttctgcgtcg ccagccgctg ctgattgagg cgtatcgcct gctgcatccg cggcgccagg
+     9901 cgtgggcatt gcgcgattac aaagactaca tttaccatgg tcccaatttc tatctgccgc
+     9961 atcgcctgga acgcgccgtg accacgtttc atgacatctc catttttacc tgcccggaat
+    10021 atcatccaaa agatcgggtt cgctatatgg agaagtccct gcacgagagc ctggattcgg
+    10081 cgaagctgat cctgaccgtc tccgacttct cgcgcagtga aatcatccgc ctgttcaact
+    10141 atccggcgga tcggatcgtc accaccaagc tggcctgcag cagcgactat attccgcgca
+    10201 gcccggcgga gtgcctgccg gtcctgcaga aatatcagct ggcgtggcag gggtatgcgt
+    10261 tatatatcgg caccatggag ccgcgtaaaa atatccgagg tctgctgcag gcctatcagc
+    10321 tgctgccgat ggagacccgc atgcgctacc cgctgatcct cagcggttat cgcggatggg
+    10381 aagacgatgt gctgtggcag ttagtcgagc gcggtacgcg tgaagggtgg atccgttacc
+    10441 tgggctatgt cccggatgaa gacctgcctt atctgtacgc ggcggccaga acctttgttt
+    10501 atccctcctt ctatgaggga ttcggtttac ctattcttga agcgatgtct tgcggtgtgc
+    10561 cggtagtatg ttccaatgtc acttctttgc ctgaggtggt tggcgatgcc ggcctcgttg
+    10621 ccgatcctaa tgatgtagac gcgattagcg cgcatatttt gcagagcctg caggatgata
+    10681 gctggcggga aatcgccacc gcgcgcggtc ttgcccaggc gaaacagttt tcgtgggaga
+    10741 actgtacgac ccagaccatt aacgcctata aattactcta agggtgtcag ttgagagttc
+    10801 tacacgtcta taagacctac tatcccgata cctacggcgg tattgagcag gtcatttatc
+    10861 agctaagtca gggctgcgcc cgccggggaa tcgcagccga tgtttttact tttagcccgg
+    10921 acaaagagac aggtcctgtc gcctacgaag accatcgggt catttataat aagcagcttt
+    10981 ttgaaattgc ctccacgccg ttttcgctga aagcgttaaa gcgttttaag cagattaaag
+    11041 atgattacga catcatcaac taccattttc cgtttccatt catggatatg ttgcatctct
+    11101 cggcgcggcc tgacgccaga acggtggtga cctatcactc ggatattgtg aaacaaaaac
+    11161 ggttaatgaa gttgtaccag ccgctgcagg agcgattcct cgccagcgta gactgcatcg
+    11221 tcgcctcgtc gcccaactac gtggcctcca gccagaccct gaaaaaatat caggataaaa
+    11281 ccgtggtgat cccgtttggt ctggagcagc atgacgtgca gcacgatccg cagcgggtgg
+    11341 cgcactggcg ggaaaccgtc ggcgataact tcttcctctt cgttggcgct ttccgctact
+    11401 acaaagggct gcacattctg ctggatgccg ccgagcgtag ccggctgccg gtggtgatcg
+    11461 tcgggggcgg gccgctggag gcggaagtgc gtcgtgaagc gcagcagcgc gggctgagca
+    11521 atgtggtgtt taccggcatg ctcaacgacg aagataaata cattctcttc cagctctgcc
+    11581 ggggcgtggt cttcccctcg catctgcgct ccgaggcgtt tggcattacg ttactggaag
+    11641 gcgcgcgctt cgccaggccg ctgatctcct gcgagatcgg caccgggacc tcgttcatta
+    11701 accaggacaa agtgaatggc tgcgtgatcc cgccgaatga cagtcaggcg ctggtggagg
+    11761 cgatgaatga gctctggcat aacgatgaaa ccgccagccg ctatggcgaa aactcgcgtc
+    11821 gtcgttttga agagatgttt actgccgacc atatgattga cgcttacgtc aatctctaca
+    11881 ctacgctgct ggaaagcaaa tcctga
+//
+LOCUS       LT174604               11838 bp    DNA     linear   BCT 13-JUN-2016
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
+            cluster, type: O3b.
+ACCESSION   LT174604
+VERSION     LT174604.1  GI:1036211103
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
+            Enterobacteriaceae; Klebsiella.
+REFERENCE   1
+  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
+            Holt,K.E. and Thomson,N.R.
+  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
+            antigens
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 11838)
+  AUTHORS   Informatics,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
+            1SA, UNITED KINGDOM
+FEATURES             Location/Qualifiers
+     source          1..11838
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="539"
+                     /serovar="O3b"
+                     /db_xref="taxon:573"
+                     /note="O locus: O3γ"
+                     /note="O type: O3γ"
+                     /note="annotation edited from original by K. Wyres Jan
+                     2018"
+                     /note="Updated from O3b by Tom Stanton in Feb 2025"
+     gene            1..1416
+                     /gene="manC"
+     CDS             1..1416
+                     /gene="manC"
+                     /EC_number="2.7.7.13"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006635421.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mannose-1-phosphate guanylyltransferase"
+                     /protein_id="CZQ25312.1"
+                     /db_xref="GI:1036211104"
+                     /translation="MLLPVIMAGGTGSRLWPMSRELYPKQFLRLFGQNSMLQETITRLS
+                     GLEIHEPMVICNEEHRFLVAEQLRQLNKLSNNIILEPVGRNTAPAIALAALQATRHGDD
+                     PLMLVLAADHIINNQPVFHDAIRVAEQYADEGHLVTFGIVPNAPETGYGYIQRGVALTD
+                     SAHTPYQVARFVEKPDRERAEAYLASGEYYWNSGMFMFRAKKYLSELAKFRPDILEACQ
+                     AAVNAADNGSDFISIPHDIFCECPDESVDYAVMEKTADAVVVGLDADWSDVGSWSALWE
+                     VSPKDEQGNVLSGDAWVHNSENCYINSDEKLVAAIGVENLVIVSTKDAVLVMNRERSQD
+                     VKKAVEFLKQNQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
+                     AEHWVILAGTGQVTVNGKQFLLTENQSTFIPIGAEHSLENPGRIPLEVLEIQSGSYLGE
+                     DDIIRIKDQYGRC"
+                     /locus_tag="O3γ_01_manC"
+     gene            1439..2821
+                     /gene="manB"
+     CDS             1439..2821
+                     /gene="manB"
+                     /EC_number="5.4.2.2"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237527.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="phosphomannomutase"
+                     /protein_id="CZQ25313.1"
+                     /db_xref="GI:1036211105"
+                     /translation="MTQLTCFKAYDIRGELGEELNEDIAYRIGRAYGEFLKPGKIVVGG
+                     DVRLTSESLKLALARGLMDAGTDVLDIGLSGTEEIYFATFHLGVDGGIEVTASHNPMNY
+                     NGMKLVRENAKPISGDTGLRDIQRLAEENQFAPVDPARRGTLRQISVLKEYVDHLMGYV
+                     DLANFTRPLKLVVNSGNGAAGHVIDEVEKRFAAAGAPVTFIKVHHQPDGHFPNGIPNPL
+                     LPECRQDTADAVRAHQADMGIAFDGDFDRCFLFDDEASFIEGYYIVGLLAEAFLQKQPG
+                     AKIIHDPRLTWNTVDIVTRSGGQPVMSKTGHAFIKERMRQEDAIYGGEMSAHHYFRDFA
+                     YCDSGMIPWLLVAELLCLKNSSLKSLVADRQAAFPASGEINRKLGNAAEAIARIRAQYE
+                     PAAAHIDTTDGISIEYPEWRFNLRTSNTEPVVRLNVESRADTALMNEKTAELLNLLKEE
+                     SL"
+                     /locus_tag="O3γ_02_manB"
+     gene            2827..3612
+                     /gene="wzm"
+     CDS             2827..3612
+                     /gene="wzm"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237528.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ABC transporter permease"
+                     /protein_id="CZQ25314.1"
+                     /db_xref="GI:1036211106"
+                     /translation="MFSAIYRYRGFIIDSVKRDFQSRYQTSFLGAAWLILQPIAMISVY
+                     TLIFSELMRARLAGMDGPFAYSIYLCSGVLTWGLFTETLGNLVNVFLTNANILKKLSFP
+                     RICLPIIVTASAFINFLIIFGLFVLFLIVTGNFPGMIFFEIIPVLIVQMLFTLGLGIIL
+                     GVLNVFVRDVGQFVNILLQFWFWFTPIVYVSKTLPEWVSGLLAYNPMATIIGSYQNVML
+                     YHQSPNWLALLPVTVLSVILFLFAWRLFKKHAADIVDEI"
+                     /locus_tag="O3γ_03_wzm"
+     gene            3615..4910
+                     /gene="wzt"
+     CDS             3615..4910
+                     /gene="wzt"
+                     /EC_number="3.6.3.40"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237529.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ABC transporter ATP-binding protein"
+                     /protein_id="CZQ25315.1"
+                     /db_xref="GI:1036211107"
+                     /translation="MSIKVQHVGKAYKYYPSKWNRVIEKLLPGDKPRHSKKWVLKDINF
+                     SIEPGEAVGIVGVNGAGKSTLLKLLTGTTQPTKGSIEIQGRVAALLELGMGFHPDFTGR
+                     QNVYMSGLMMGLSREEIERLMPEIEAFADIGDYIEEPVRIYSSGMQMRLAFAVATASRP
+                     DILIVDEALSVGDSRFQAKCYARIADFKKQGTTLLLVSHSAGDIVKHCDRAIFLKNGDI
+                     CMDGTARDVTNRYLDELFGKADKNSAPKSETATSSASGESQMSLDEIEDVYHTRPGYRP
+                     EEYRWGQGGAKIIDYHIQSAGVDFPPSLTGNQQTDFLMKVVFEYDFDCVVPGLLIKTLD
+                     GLFLYGTNSFLASEGRENISVSRGDVRVFKFSFPVDLNSGDYLLSFGISEGSPQTEMTP
+                     LDRRYDSIILHVTKSMDFWGVIDLKSTFNSYK"
+                     /locus_tag="O3γ_04_wzt"
+     gene            4931..6988
+                     /gene="wbdD"
+     CDS             4931..6988
+                     /gene="wbdD"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237530.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="methyltransferase"
+                     /protein_id="CZQ25316.1"
+                     /db_xref="GI:1036211108"
+                     /translation="MTTNTHKLVSELPEIYQTIFGHPEWDGDAARDCNERLALISEQYD
+                     SLSRELGRPLRVLDLGCAQGFFSLSLASKGASVLGIDFLQQNIDVCQALAEENPHCDVK
+                     FQVGRIEDIVSTLEENQFDLAIGLSVFHHIVHLHGVAEVRSLLERLANLTQAMILELAV
+                     KEEPLYWGKSQPEDPRELIDQCAFYRLIGRFDTHLSNISRPMYIISNHRVILPEFNQPF
+                     TSWRDSPYTGAGFAHKQSRRYYFSSEFICKFYRFSTVSCLLTDKESERNRTELAHEEAF
+                     LKSPPSGLKVPALFTAGGNGEAGWLVMEKIPGELLNDVLASERHIDREKVISDLLDQLV
+                     ILEEHGLYHDDFRTWNVLIDDNDSARLIDFGSIGDVQQDCSWPVNIFQSFIIFVNEIFC
+                     ENKSWRGFWRSAPLSPFQLPEPYSNWLTAFWKHPVGEWSFALLQQLFSTKDALPAASSI
+                     MDASDLWVRAQEPVLLESQTQIRNTDARVVRLESQINELTSLINIMGESIQTFEKREYP
+                     PQDVTTNVQPRIEIEQSKAVDSEEIMRLHTQLNDAQQEIENLRHEIAKIHYSRSWKMTK
+                     WYRYAGLQYYLLRQYGFKQRFKHLLKRVLSNVIYFLRAHPRLKQKVINLLRTIGIYDFA
+                     YRMHRRMNPGSHNPYPNDPQYQSQTEKQILHPELLPPEVNSIFSELKNKR"
+                     /locus_tag="O3γ_05_wbdD"
+     gene            6999..9521
+                     /gene="wbdA"
+     CDS             6999..9521
+                     /gene="wbdA"
+                     /EC_number="2.4.1.246"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237531.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mannosyltransferase A"
+                     /protein_id="CZQ25317.1"
+                     /db_xref="GI:1036211109"
+                     /translation="MHILIDVQGYQSESKFRGVGRSTYEMSRAIIKNAGQHRVSILMNG
+                     MYSIDSINEIKKSWGDILPQEEMFIFSAAGPTALRDCENHPRSVAATLARELAIANINP
+                     DVVFIINFYEGFDDSYTVSIPQTTVPWKTVCVCHDLIPLLNKERYLGEPNFRQYYYDKL
+                     AQYERADAIFAISRSSMQEVIDYTSIPAEKIINISSGVSDSFKIKDYTHDEIKDLRNKY
+                     HLPQEFILSLAMIEPRKNIEALIHAYSLLPHALQQSYPLVLAYKISTDEKERLYRVAEN
+                     YGLSRNQLIFTGFLNDSDLIALYNLCKIFVFPSIHEGFGLPPLEAMRCGAATLGSNVTS
+                     LPEVIGMEEALFNPLDVPDICRVMQRALTDSEFYSALKAHAPAQAAKFTWDHTAQLALK
+                     GFERLVDKASASEPLDITSFTAYTINRIKNIAELSETERLQTAWAIARNSFATHQRKLL
+                     VDISVLVEHDAKTGIQRVSRSILSELLKSGVAGYTVSAVYYRPGECYRYANEYLNTHFN
+                     GAFGPDVPVLFTKDDILVATDLTAHLFPELTVQLDFIRLSGAKVCFVVHDILPLRRPEW
+                     SDEGMQRVFPIWLSCIAQHADRLICVSASVAEDVKAWIAENSHWVKPNPLLTVSNFHLG
+                     ADLDASVPSTGMPDNAQALLAAMAAAPSFIMVGTMEPRKGHAQTLAAFEELWLQGKNYN
+                     LFIIGKQGWHVDDLCERLRHHPQLNKKLFWLQNISDEFLTKLYSQSSALIFASLGEGFG
+                     LPLIEAAQKKLPVIIRDIPVFKEIAQEHAWYFSGEAPADIAKAVEDWLALYEQNAHPRS
+                     ENINWLTWKQSAEFLLKNLPIIAPAAKQ"
+                     /locus_tag="O3γ_06_wbdA"
+     gene            9568..10713
+                     /gene="wbdB"
+     CDS             9568..10713
+                     /gene="wbdB"
+                     /EC_number="2.4.1.57"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237532.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mannosyltransferase B"
+                     /protein_id="CZQ25318.1"
+                     /db_xref="GI:1036211110"
+                     /translation="MKIIFATEPIKYPLTGIGRYSLELVKRLAVAREIEELKLFHGASF
+                     IDQIPQVENKSDTKASNHGRLSAFLRRQPLLIEAYRLLHPRRQAWALRDYKDYIYHGPN
+                     FYLPHRLEHAVTTFHDISIFTCPEYHPKDRVRYMEKSLHESLDSAKLILTVSDFSRSEI
+                     IRLFNYPAERIVTTKLACSSDYIPRSPAECLPVLQKYQLAWQGYALYIGTMEPRKNIRG
+                     LLQAYQLLPMETRMRYPLILSGYRGWEDDVLWQLVERGTREGWIRYLGYVPDEDLPYLY
+                     AAARTFVYPSFYEGFGLPILEAMSCGVPVVCSNVTSLPEVVGDAGLVADPNDVDAISAH
+                     ILQSLQDDSWREIATARGLAQAKQFSWENCTTQTINAYKLL"
+                     /locus_tag="O3γ_07_wbdB"
+     gene            10723..11838
+                     /gene="wbdC"
+     CDS             10723..11838
+                     /gene="wbdC"
+                     /EC_number="2.4.1.11"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237533.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyl transferase family protein"
+                     /protein_id="CZQ25319.1"
+                     /db_xref="GI:1036211111"
+                     /translation="MRVLHVYKTYYPDTYGGIEQVIYQLSQGCARRGIAADVFTFSPDK
+                     ETGPVAYEDHRVIYNKQLFEIASTPFSLKALKRFKQIKDDYDIINYHFPFPFMDMLHLS
+                     ARPDARTVVTYHSDIVKQKRLMKLYQPLQERFLASVDCIVASSPNYVASSQTLKKYQDK
+                     TVVIPFGLEQHDVQHDPQRVAHWRETVGDNFFLFVGAFRYYKGLHILLDAAERSRLPVV
+                     IVGGGPLEAEVRREAQQRGLSNVVFTGMLNDEDKYILFQLCRGVVFPSHLRSEAFGITL
+                     LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPNDSQALVEAMNELWHNDETASRYGE
+                     NSRRRFEEMFTADHMIDAYVNLYTTLLESKS"
+                     /locus_tag="O3γ_08_wbdC"
+ORIGIN
+        1 atgttgcttc ctgtgatcat ggctggtggt accggcagtc gtctctggcc gatgtctcgc
+       61 gagctttacc cgaaacagtt cctccgcctg ttcgggcaga actccatgct gcaggaaacc
+      121 atcacccgac tctcgggcct tgaaatccat gaaccgatgg tcatctgtaa cgaagagcac
+      181 cgcttcctgg tggccgaaca gctgcgccag ctcaacaagc tgtcgaacaa cattattctt
+      241 gagccggtcg ggcgcaacac cgccccggcc atcgccctgg cggccctcca ggccacccgc
+      301 cacggcgacg acccgctgat gctggtcctc gccgccgacc atatcatcaa taaccagccg
+      361 gtcttccacg acgccatccg cgtcgccgag cagtatgccg atgaaggcca tctggtcacc
+      421 ttcggtatcg tgccgaacgc cccggaaacc ggctacggct acatccagcg cggcgtggcc
+      481 ctcaccgaca gcgcccacac cccgtaccag gtggcccgct tcgtggagaa gccggaccgc
+      541 gagcgcgccg aggcctacct cgcctccggg gagtactact ggaacagcgg catgtttatg
+      601 ttccgcgcca aaaaatacct ctccgagctg gccaaattcc gcccggatat cctcgaagcc
+      661 tgccaggccg cggtcaatgc cgccgataac ggcagcgact tcatcagcat cccgcatgac
+      721 attttctgtg agtgcccgga cgagtccgtg gactacgcgg tgatggagaa aaccgccgac
+      781 gcggtggtgg tcggtctcga tgccgactgg agcgacgtcg gctcctggtc cgccctgtgg
+      841 gaggtcagcc cgaaagatga gcagggtaac gtcctcagcg gcgacgcgtg ggtgcacaac
+      901 agcgaaaact gctacatcaa cagcgacgag aagctggtgg cggccatcgg cgtggagaac
+      961 ctggtgattg tcagcaccaa ggacgccgtg ctggtgatga accgtgagcg ttcccaggac
+     1021 gtgaagaagg cggtcgagtt cctcaagcag aaccagcgca gcgagtacaa gcgccaccgc
+     1081 gagatttacc gtccctgggg ccgctgcgac gtggtggtcc agaccccgcg cttcaacgtc
+     1141 aaccgtatta cggtgaaacc gggcggcgcc ttctcgatgc agatgcacca ccaccgtgcc
+     1201 gagcactggg tcattctcgc cggcaccggc caggtgacgg tcaacggcaa gcagttcctg
+     1261 ctgaccgaga accagtccac ctttattccg attggcgccg agcacagcct ggaaaacccg
+     1321 ggccgcattc cgctggaagt gctggagatc cagtcggggt cgtacctcgg cgaggacgac
+     1381 attattcgta ttaaagacca gtatggtcgt tgctaatttt ttcgggacaa aacgcagaat
+     1441 gacacagtta acatgcttta aggcttatga catccgtggt gaactgggcg aggagctgaa
+     1501 cgaggacatc gcctaccgta tcggccgcgc ctatggcgaa tttctgaaac ccgggaagat
+     1561 agtggtgggg ggcgatgtgc gcctcaccag cgagtcgctg aagctggcgc tggcccgcgg
+     1621 gctgatggac gccggcaccg acgtgctgga tattggcctg agcggcacgg aagagattta
+     1681 cttcgccact ttccacctcg gggtggacgg cggtatcgag gtgacggcga gccataaccc
+     1741 gatgaactac aacggcatga agctggtgcg cgagaacgcg aagcccatca gcggcgacac
+     1801 cggcctgcgg gatatccagc gcctggcgga ggagaatcag ttcgcgccgg tagacccggc
+     1861 gcgtcgcggg accctgcgcc agatatcggt gctgaaggag tacgtcgacc acctgatggg
+     1921 ctatgtggac ctggcgaact tcacccgtcc gctgaagctg gtggtgaact ccggcaacgg
+     1981 ggcggcgggg cacgtgattg atgaagtgga gaaacgcttc gcggcggccg gggcgccggt
+     2041 gacctttatc aaggtgcatc accagccgga cggccatttc ccgaacggta tcccgaaccc
+     2101 gctgctgccg gagtgccgcc aggacaccgc cgacgcggtg cgtgcgcatc aggcggacat
+     2161 ggggatcgcc tttgacggcg acttcgaccg ctgcttcctg ttcgatgacg aggcgtcgtt
+     2221 tatcgagggg tactacattg tcggcctgct ggcggaggcg ttcctgcaga aacagccggg
+     2281 ggcgaaaatc attcacgacc cgcgtctgac gtggaacacg gtggacatcg tgacccgcag
+     2341 cggcggccag ccggtgatgt cgaagacggg gcatgcgttc atcaaggagc ggatgcgcca
+     2401 ggaagacgcc atctacggcg gggaaatgag tgcgcaccat tacttccgcg acttcgccta
+     2461 ctgcgacagc gggatgatcc cgtggctgct ggtggcggag ctgctgtgcc tgaagaacag
+     2521 ttcgctgaaa tcgctggtgg cggaccgcca ggcggcgttc ccggcgtcgg gggagatcaa
+     2581 ccgcaagctg gggaatgcgg cggaggcgat agcgcgcatc cgggcgcagt atgagccggc
+     2641 ggccgcacac atcgacacaa cggacggtat cagtattgaa taccctgagt ggcgctttaa
+     2701 cctgcgcacg tccaacacgg agccggtggt gcgtctgaac gttgagtcca gagcggatac
+     2761 tgcgttaatg aatgagaaaa ccgccgagct gctcaacctg ttaaaagagg aatcgctttg
+     2821 agtcctatgt tttcagcgat ctatcgctac cgtggcttta ttattgacag cgtcaaacgg
+     2881 gactttcagt cccgttacca gactagcttc ttaggcgcgg catggctgat cttacagccg
+     2941 atcgccatga tttccgtata tacattaatc ttttctgagt taatgcgtgc ccgcctggcg
+     3001 ggcatggacg gcccttttgc ctacagtatc tacctctgtt ccggggtgtt aacctggggg
+     3061 ctgtttacgg aaacgctcgg caatctggtc aacgtttttc tgaccaacgc caacattctt
+     3121 aaaaagctta gctttccgcg gatctgttta ccgatcattg tcaccgcctc ggcgttcatt
+     3181 aacttcctga tcatttttgg tctgtttgta ctgtttctga tcgtcacggg caatttcccg
+     3241 ggcatgattt tctttgaaat cattccggtg ctgatcgttc agatgctgtt caccctcggc
+     3301 ctcgggatca tcctcggggt gctgaacgtt tttgtccgcg acgtcgggca gttcgtgaat
+     3361 atcctgctgc agttttggtt ctggtttacg cccattgtct acgtgtccaa aacgctgccg
+     3421 gagtgggtct ctggtctgct ggcgtataac ccgatggcga ccattatcgg ttcataccag
+     3481 aacgtgatgc tctatcacca gagccctaac tggctggcgc tgcttccggt cacggtgctg
+     3541 tccgtcattc tgtttttatt tgcctggcgt ttatttaaaa aacatgccgc tgatattgtg
+     3601 gacgagattt aatcatgagt atcaaagttc agcacgtcgg caaggcgtat aaatattatc
+     3661 cctccaaatg gaaccgggtc attgagaaac ttctgccggg cgataagccg cggcacagca
+     3721 agaaatgggt attgaaagat atcaatttca gtattgaacc cggtgaagcg gtcggcattg
+     3781 ttggggtgaa cggcgcaggt aaaagtacgt tactgaagct gctgactggc accactcagc
+     3841 cgaccaaagg cagcattgag atccaggggc gtgtcgctgc gctgctggag ctgggcatgg
+     3901 gcttccatcc tgactttacc ggtcggcaga acgtgtatat gtccgggctg atgatgggcc
+     3961 tgagccggga agagattgag cgcttaatgc cggagatcga agcctttgcg gatatcggtg
+     4021 actacattga agagcccgtg cgcatctact ccagcgggat gcaaatgcgc ctggcgttcg
+     4081 ccgtggccac ggcctcacgc ccggatattc tgatcgtcga tgaagcgctt tccgttggtg
+     4141 actcccgctt tcaggcgaag tgctatgccc gtattgcgga cttcaaaaag cagggcacca
+     4201 cgctgctgct ggtctcccac agcgccgggg atatcgtcaa acactgtgac cgcgccattt
+     4261 tcctcaaaaa tggtgatatc tgtatggacg gcaccgcccg tgacgtgacc aaccgttatc
+     4321 tggatgagct gtttggcaaa gccgacaaaa acagcgcgcc aaaaagcgaa acggcaacct
+     4381 cgtcagccag cggcgaaagt cagatgtctc tcgatgagat tgaagatgtg taccacacgc
+     4441 gcccaggcta ccgtccggaa gagtaccgtt gggggcaggg gggtgcaaaa atcattgatt
+     4501 atcacatcca aagcgccggg gttgattttc cgccttcact gacgggcaat cagcagaccg
+     4561 atttcctgat gaaagtcgta tttgaatatg actttgattg cgtggtaccg ggtttgttaa
+     4621 tcaaaactct ggatggctta tttctatatg gtaccaactc tttcctggcc tcggaaggcc
+     4681 gggaaaacat ttcggtatca cgtggggacg ttagagtatt taaattcagt tttccggttg
+     4741 atttaaatag cggtgactat cttctgtcgt ttggtatttc agagggaagc ccgcaaaccg
+     4801 aaatgacgcc gctcgatcgt cgctatgact ccatcatttt gcatgtaact aagagcatgg
+     4861 atttctgggg agtgattgac ctgaagtcga ctttcaatag ttacaaatga agatgagaaa
+     4921 aaatcattcc atgactacta atacacataa attggttagc gaattacctg aaatttatca
+     4981 gactattttt gggcatcctg agtgggatgg cgatgctgca cgagactgta atgaacggct
+     5041 cgcgctaatt agtgaacaat atgacagctt gtccagagag ttaggaaggc cactacgggt
+     5101 tctcgacctg ggctgtgctc aggggttctt cagtttaagt ttggcaagca agggtgccag
+     5161 cgtattaggt atcgactttt tgcagcagaa cattgatgtt tgtcaggcgc ttgctgaaga
+     5221 aaatccacat tgtgatgtta aatttcaagt cgggcggata gaagacattg tcagcactct
+     5281 ggaagaaaac caatttgatc tcgccattgg actaagtgtt tttcaccaca ttgttcatct
+     5341 gcatggggtt gctgaagtca gatcgctgtt agagcgtttg gcaaatctga cgcaggcgat
+     5401 gattctcgag ctcgctgtca aggaggaacc actctattgg gggaaatctc agcctgaaga
+     5461 tccgcgtgaa cttattgacc aatgtgcttt ctatcgattg attggaagat ttgacactca
+     5521 tctgtctaat atttcacgtc cgatgtatat tatcagtaac cacagggtta ttcttccgga
+     5581 atttaatcag ccttttactt catggcgcga cagtccttac accggagcag gctttgcgca
+     5641 taaacagagc cgtcgctatt atttctcttc ggagttcata tgtaagttct atcgttttag
+     5701 tacagtaagt tgcttactaa ctgataagga gagcgagcgt aatcgtactg aactcgccca
+     5761 tgaagaagct tttcttaaat ctccaccatc tggcttaaaa gtgccggcgt tgtttactgc
+     5821 aggggggaat ggagaagcgg gatggttggt aatggaaaaa attcccggag agctgttaaa
+     5881 cgacgttctg gccagtgaac ggcatattga tcgggaaaaa gttatttccg atctcctcga
+     5941 ccaattagtt attttggaag aacatggtct atatcatgat gatttcagaa catggaatgt
+     6001 tttaattgac gataatgaca gcgctcgttt aatagatttt ggttcgattg gcgatgtaca
+     6061 acaagactgc agctggccag ttaatatttt ccagtcgttc attatttttg taaatgaaat
+     6121 attttgtgaa aataaatcct ggaggggctt ctggcgttcc gcaccattaa gtcctttcca
+     6181 gttgcctgaa ccgtattcaa attggttgac agcattctgg aaacatcctg ttggtgagtg
+     6241 gagttttgct ttactccaac aactcttttc aaccaaagat gctctaccgg ctgcgagttc
+     6301 cattatggac gcttctgatc tatgggtccg ggctcaggag cccgtattgt tggaaagtca
+     6361 aacgcaaata cgcaatacgg atgcgcgggt agtccgtctc gagtcgcaaa tcaatgaact
+     6421 cacctccctg attaatatta tgggtgagag cattcagacg tttgagaagc gtgagtatcc
+     6481 gccacaagac gttactacta atgtacagcc gcgtatcgag attgagcaga gtaaagccgt
+     6541 tgattcagaa gagattatgc gacttcatac gcagctcaat gatgctcagc aagaaataga
+     6601 gaatctacgt catgagattg ctaaaattca ttatagtcgc tcatggaaaa tgaccaagtg
+     6661 gtatcggtac gctggcttac agtactatct gcttcgtcag tacggcttca aacagcgttt
+     6721 taagcattta ctcaaacgag tgcttagcaa cgtaatttat tttttgcgtg cacatccacg
+     6781 actaaagcag aaggtgatca atctactgcg tacaattgga atttatgact ttgcttatcg
+     6841 tatgcatcgt cgtatgaatc ctggttcaca taacccttat ccaaacgacc cacaatacca
+     6901 gtcgcagact gaaaagcaga tcttacatcc agagttattg cctccggaag ttaactcaat
+     6961 ttttagcgag cttaaaaaca aaagataagg tgagtcactt gcatattttg attgacgtac
+     7021 aaggatatca atcggaaagt aaattccgtg gagttggtcg cagcacctat gaaatgagtc
+     7081 gtgcgatcat aaaaaatgct ggccagcatc gagtaagcat tttaatgaat ggcatgtatt
+     7141 cgattgatag tataaatgaa attaaaaaaa gctggggtga tatattaccg caggaagaaa
+     7201 tgtttatttt ttcagctgct ggccctacag ctcttcgcga ctgtgaaaac catccccgga
+     7261 gtgttgccgc cacactagct cgtgaacttg ctattgctaa tatcaatccc gacgttgttt
+     7321 ttattattaa tttctacgaa ggttttgacg atagttatac cgtctcaatt cctcaaacta
+     7381 cagtaccatg gaaaacagtt tgtgtttgtc acgatctaat tccgttactg aataaagaac
+     7441 gctatctggg cgaaccaaac ttccgtcagt attattatga taaactagct caatacgaaa
+     7501 gggcggacgc tatttttgct atttccagat catccatgca ggaagttatc gattacacat
+     7561 cgattccggc agaaaaaatt attaatattt catctggagt aagcgattca tttaaaatta
+     7621 aagattatac tcacgatgaa atcaaagact tacgtaataa atatcatctt cctcaagagt
+     7681 ttattctttc tttggcaatg atagagccac gtaaaaatat tgaagcgctg attcatgcat
+     7741 atagtttatt accgcatgcc ctgcaacaga gttatccctt agttttagcc tataaaatta
+     7801 gcaccgatga aaaggaaagg ctgtaccgag ttgcagagaa ctatggttta tctcgtaatc
+     7861 agcttatttt tacaggcttc ttaaacgata gtgaccttat cgcactttac aatttgtgca
+     7921 aaattttcgt tttcccctct atacatgaag ggtttggcct gccgccacta gaagctatgc
+     7981 gttgtggtgc agctacgctg ggttcaaatg tgaccagctt acccgaggtc atcggtatgg
+     8041 aagaggcttt atttaatcct ctggatgtcc ccgacatttg ccgtgttatg caaagggcct
+     8101 tgactgacag tgagttctac tcagcattaa aagctcatgc tccggcgcag gcggcaaagt
+     8161 tcacatggga tcacaccgcg cagctcgcgt taaagggatt tgagaggctt gtagataagg
+     8221 cttccgcatc agaacctctg gatatcacaa gcttcaccgc atacaccatt aatagaatta
+     8281 aaaatattgc agaattaagt gaaaccgaac gcttacagac agcctgggcg attgctcgta
+     8341 atagctttgc tacacatcag cgcaagctgc tggttgatat ttctgttctt gttgagcatg
+     8401 atgcgaaaac gggaattcaa cgggtttctc gcagtatact tagtgaatta ctgaaatctg
+     8461 gcgttgctgg ttatactgtc agtgcggttt attatcgacc gggtgaatgc tatcgctatg
+     8521 ccaacgaata cctgaatacc cattttaacg gggcgttcgg gcctgatgta cctgtactgt
+     8581 ttaccaaaga tgatattctg gttgctaccg atctaactgc ccatctgttt cctgagctta
+     8641 ctgtccagct ggattttatt cgtctatccg gtgccaaggt ttgttttgtt gtgcatgaca
+     8701 ttttgcctct gagaagaccg gagtggagcg atgagggaat gcaacgcgtg ttccccattt
+     8761 ggttatcttg cattgcgcag cacgcagacc gcttgatttg tgtatcagca agcgttgcag
+     8821 aggatgtaaa agcctggatt gcggaaaaca gccattgggt gaaaccgaac ccgctgctga
+     8881 ccgtcagcaa cttccatctg ggagccgacc tcgatgccag cgtaccgtcc actggcatgc
+     8941 cggataatgc ccaggcgctg ttagcagcga tggccgcggc tccatcattt atcatggtgg
+     9001 gcacgatgga accacgcaaa ggacatgcgc agacgctagc ggcatttgaa gaattgtggt
+     9061 tacagggcaa gaactacaat ctgtttatca ttggtaaaca ggggtggcat gttgatgatt
+     9121 tatgtgaacg tttacgtcac catccacagc taaataaaaa actattttgg ctacaaaaca
+     9181 ttagcgatga gttccttacg aagttgtatt ctcagtctag tgcgttaatc ttcgcatctc
+     9241 tcggagaagg ctttggcctg ccgttgattg aagcggcgca gaaaaagctg ccggtgatta
+     9301 tccgtgacat tccggtgttt aaagagattg ctcaggaaca tgcgtggtat ttctccgggg
+     9361 aagcgccggc cgacatcgcg aaggccgtcg aagactggtt agccctgtat gagcaaaacg
+     9421 cgcatcctcg ttccgagaat atcaactggt taacctggaa gcagagcgcg gaatttctcc
+     9481 tgaaaaacct gccgattatc gcgccagccg cgaagcaata atcgctatca acagggccac
+     9541 cccggtggcc cttgtgatga gttcgttatg aaaattattt ttgctactga gccaattaaa
+     9601 tacccgttaa cgggcatcgg tcggtattcc ctggagctgg ttaagcggct ggcggtcgcc
+     9661 cgcgaaatcg aagagctgaa gctgtttcac ggcgcgtcgt ttatcgatca gatcccccag
+     9721 gtggagaata aaagcgatac caaagccagc aatcatggtc gtttgtcggc gtttctgcgc
+     9781 cgccagccgc tgctgattga ggcgtatcgc ctgctgcacc cgcggcgcca ggcgtgggca
+     9841 ttgcgcgact ataaagatta tatctaccat ggtcccaatt tttacctgcc gcatcgcctg
+     9901 gaacacgccg tgaccacgtt tcatgacatc tccattttta cctgcccgga atatcatcca
+     9961 aaagatcggg ttcgctatat ggagaagtcc ctgcatgaga gcctggattc ggcaaagctg
+    10021 atcctgaccg tctctgactt ctcgcgcagt gaaatcatcc gcctgttcaa ctatccggcg
+    10081 gagcggatcg tcaccaccaa gctggcctgc agcagcgact atattccacg cagcccggcg
+    10141 gagtgcctgc cggtcctgca gaaatatcag ctggcgtggc aggggtatgc gttatatatc
+    10201 ggcaccatgg agccgcgtaa aaatatccgt ggtctgctgc aggcctatca gctgctgccg
+    10261 atggagaccc gcatgcgcta cccgctgatc ctcagcggct atcgcggctg ggaagacgat
+    10321 gtgctgtggc agttagtcga gcgtggtacg cgtgaagggt ggatccgtta cctgggctat
+    10381 gtcccggatg aggacctgcc ttatctgtac gcggcggcca gaacctttgt ttatccctcc
+    10441 ttctatgagg gattcggttt acctattctt gaagcgatgt cttgcggtgt gccggtagta
+    10501 tgttccaatg tcacttcttt gcctgaggtg gttggcgatg ccggcctcgt tgccgatcct
+    10561 aatgatgtag acgcgattag cgcgcatatt ttgcagagcc tgcaggatga tagctggcgg
+    10621 gaaatcgcca ccgcgcgcgg tcttgcccag gcgaaacagt tttcgtggga gaactgtacg
+    10681 acccagacca ttaacgccta taaattactc taagggtgtc agttgagagt tctacacgtc
+    10741 tataagacct actatcccga tacctacggc ggtattgagc aggtcattta tcagctcagt
+    10801 cagggttgcg cccgccgggg gatcgcagcc gatgttttta cttttagccc ggacaaagag
+    10861 acaggtcctg tcgcctacga agaccatcgg gtcatttata ataagcagct ttttgaaatt
+    10921 gcctccacgc cgttttcgtt gaaagcgtta aagcgtttta agcagattaa agatgattac
+    10981 gacatcatca actaccattt tccgtttccc tttatggata tgctgcatct ctcggcgcgg
+    11041 cctgacgcca gaacggtggt gacctatcac tcggatattg tgaaacaaaa acggttgatg
+    11101 aagttgtacc agccgctgca ggagcgattc ctcgccagcg tagactgcat tgttgcctcg
+    11161 tcgcccaact acgtggcctc cagccagacc ctgaaaaaat atcaggataa aacggtggtg
+    11221 atcccgtttg gtctggagca gcatgacgtg cagcacgatc cgcagcgggt ggcgcactgg
+    11281 cgggaaaccg tcggcgataa cttcttcctc ttcgtcggcg ctttccgcta ctacaaaggg
+    11341 ctgcacattc tgctggatgc cgccgagcgt agccggctgc cagtggtgat cgtcgggggc
+    11401 gggccgctgg aggcggaggt gcggcgtgag gcgcagcagc gcggactgag caatgtggtg
+    11461 tttaccggca tgctcaacga cgaagataaa tacattctct tccagctctg ccggggcgtg
+    11521 gtcttcccct cgcatctgcg ctcagaggcg tttggcatta cgttactgga aggcgcgcgc
+    11581 tttgccaggc cgctgatctc ctgcgagatc ggcaccggta cctcgttcat taaccaggac
+    11641 aaagtaaatg gctgcgtgat cccgccgaat gacagtcagg cgctggtgga ggcgatgaat
+    11701 gagctctggc ataacgatga aaccgccagc cgctatggcg aaaactcgcg tcgtcgtttt
+    11761 gaagagatgt ttacagccga ccatatgatt gacgcttacg tcaatctcta cactacgctg
+    11821 ctggaaagca aatcctga
+//
+LOCUS       LT174605                9449 bp    DNA     linear   BCT 13-JUN-2016
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
+            cluster, type: O4.
+ACCESSION   LT174605
+VERSION     LT174605.1  GI:1036211112
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
+            Enterobacteriaceae; Klebsiella.
+REFERENCE   1
+  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
+            Holt,K.E. and Thomson,N.R.
+  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
+            antigens
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 9449)
+  AUTHORS   Informatics,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
+            1SA, UNITED KINGDOM
+FEATURES             Location/Qualifiers
+     source          1..9449
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="AJ214"
+                     /serovar="O4"
+                     /db_xref="taxon:573"
+                     /note="O locus: O4"
+                     /note="O type: O4"
+                     /note="sequence manually trimmed to removed insertion
+                     sequences"
+     gene            complement(1..1797)
+                     /gene="hydrolase"
+     CDS             complement(1..1797)
+                     /gene="hydrolase"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Predicted hydrolase (HAD superfamily)"
+                     /protein_id="CZQ25320.1"
+                     /db_xref="GI:1036211113"
+                     /translation="MLQWVENYISAEQYDTPAIAHELYSWEIEQEKKHIYLDPGIEDFL
+                     AQYPSDKTIFLSDFYTSSTDLTELLVSAGLDQSVISDGVSSIDERLNKRSGRLFDFIQQ
+                     KYQLAGVDWIHIGDNEWSDVQMPTSKGIKSIRYLPAQQHQLREQKEFLWNKNEDLTETI
+                     TNNILNKYAASKDLSVDFQLGLKTTPLIAGFCLKILEQAVISKSEKILFFTREGEFFIK
+                     AMNILISHLKTNIKEIKLPEIDIIEVSRLATFAPSLQEISTKEMMRVWNLYSTQSISSL
+                     FKTLNVAPETFQSFIDKYGIPADEQIQYPWQDSRIQQLFDDSGFKETLWQHVMQQRALL
+                     KNYFATKGLTDDINARICVVDVGWRGTIHDNIALLYPDIHFTGIYLGLQKFLNEQPSNT
+                     SKVAFGPDLNHQLEYPHFLDSVAPIEMITNSPSGSVTGYGLENGKIVAIRSVNDDENSA
+                     WHNFTKTFQEGILAGMESFSAAVLSYGITHDVVRGYALNIWDVLISGSNKSLTDAFNNL
+                     NHNETFGLGGYVKKNHVPTTFEILSSLWNKNNRAALIEFIKANQWSDGIRKRDNLPSLN
+                     KYILALTIDLAVFYKRKFYRKY"
+                     /locus_tag="OL4_01_hydrolase"
+     gene            complement(2037..5365)
+                     /gene="hypothetical"
+     CDS             complement(2037..3227)
+                     /gene="hypothetical"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Uncharacterised protein"
+                     /protein_id="CZQ25321.1"
+                     /db_xref="GI:1036211114"
+                     /translation="MANIAWFIPQLIEGSGGHRTMLQHAAYLEKMGHTCTIYLEDKSGK
+                     TSGAEVIHKLFGLKFKDVIYDWNNAQPCDAAVATIWYSAPFVAALPFDCKRLYFVQDFE
+                     AYFNPVGDAYLMAENSYCYGLKPITIGRWLRYKLQNDFAVESYHFEFGANHNIYKRVPT
+                     IQKEKAVCFIYQPDKPRRCSRIGIEALGIVKHCMPDVKIYLYGTSINDNLWFEHENLGL
+                     LDLPKCNELYNKCSVGLCISSSNPSRIPFEMMNAGLPVVEVWRENNLYDFSEDAMLLCK
+                     QTPESIATGIMKILNDADLAASMSSAGQKFMNGRTLETETEGFYKAFNCVMNEQAYTAE
+                     VISRSYNKPPFEAPLARPDIANTLTFAHQSLLKRIALRLPLFVRTPLSALYFKLKN"
+                     /locus_tag="OL4_02_hypothetical"
+     CDS             complement(3248..5365)
+                     /gene="hypothetical"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Uncharacterised protein"
+                     /protein_id="CZQ25322.1"
+                     /db_xref="GI:1036211115"
+                     /translation="MNDISITDYLGPGVYLLQNYPKETEGLIAEKGYKVHNCADLAQCK
+                     DILNRNKVNFLLTNDKDNNFNEYVKIVRTAARQLVNKIVINIFVEKGNGQSFQDFINIT
+                     DNLGYSIDTVFYLLNPGYDEQFRDDQSLKIVLSYRRQSVVSTDKNILETTIFEKKLVNT
+                     FPYIRPGDRVLVIIKNKNSITNIKNIIAEQTKASEVEIYSLDEIKSVQLNGNGYHFLIT
+                     DKYADDGLNNALKVIISYLVPAGRYVSFHTDKTVVETLSNYNLQPEVYLFYEHGHLKTQ
+                     IHQGEEITLSPELCVFMKSPLARSELPYQETIYGYSHPPKNLLAFARDYTNPWLIRGIV
+                     EFPFRNRSTYHLQQYSHQILEHSAPDSPDYAAALAVLGYQMLSGSDDTADIYAKMLDYC
+                     SNVSQMDNPTPHQYRWLISLSTLLGLICNKNNDKANALIHLSRAANSSIDKFSPSIGTK
+                     ILQSFYLQSVILISLNRISCAEIIVDRGIKRGIQLLYQHPDELVGKISQPFNFVLYIYH
+                     DILDWLIKMVNIKNAIPGRKFNIANFDNGNTWSALLHERMNAINNMSQMIDERDRTIHD
+                     QKCLIDERDRTIHDQKRLIDERDSTVLTQKNLIDERDLVSAQQNQLIEQNNKTIQQQIQ
+                     NVTDLNSQVSSKEQKVDELQNQNIKLISLIDEKDLHIAQLSADLERANTILRKINSTPV
+                     IRHLLRMLNIK"
+                     /locus_tag="OL4_03_hypothetical"
+     gene            complement(5370..6779)
+                     /gene="wzt"
+     CDS             complement(5370..6779)
+                     /gene="wzt"
+                     /EC_number="3.6.3.40"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_001336133.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="O-antigen export-NBD component"
+                     /protein_id="CZQ25323.1"
+                     /db_xref="GI:1036211116"
+                     /translation="MSSDNIAISVSNISKCYNIYQNPRDRLKQFFLPKVQSMVGKPVQR
+                     YYNEFWALNNINFTINKGESAGIIGRNGSGKSTLLQLITGTLTPTTGTIQTKGRIAALL
+                     ELGSGFNPEFTGRENIYLNGAVLGLSRAEIDAKFDAIAGFADIGTHLDQPVKTYSSGMM
+                     VRLAFAVQVQLEPDILIVDEALAVGDALFQKRCFQQIEKLTSNGVTLLFVSHDQESVRT
+                     LTNRAILLDRGTQLSTGLSSEVLLEYRRLLHREESKYFSQLAEEVAAHADATRDINQTP
+                     TAPAKIEISANAETPAVEETSPSRTDKLSFGEGEAEVENVELFTASGERSNAFNPGDKI
+                     RVRVNCKVNKDINHINVGIRIRNKEGVKIYSWGTLNQDMYVRFHQLKDPQFWEREFKAG
+                     ERFYVDMEFECTLGTNLYEIQAAISYEGTPNYFSQRILHWRDEAAFFHVNVLRDEYFFG
+                     GILDLKMTAEW"
+                     /locus_tag="OL4_04_wzt"
+     gene            complement(6769..7500)
+                     /gene="wzm"
+     CDS             complement(6769..7500)
+                     /gene="wzm"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_001336134.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="O-antigen export-TMD component"
+                     /protein_id="CZQ25324.1"
+                     /db_xref="GI:1036211117"
+                     /translation="MGRYKGSFLGLAWSLFNPILMLTVYTFVFSVIFKSRWGSSPDAGH
+                     ADFAIILFTGLIIFNLFAECINRSTSLITSNVNFVKKVVFPIEILPIVNLLAALFHASI
+                     SLIVLFIAILVFKHQLHFTVLLLPVITIPLMLSILGLSWILASLGVFVRDMPQTISIIV
+                     TILMFLSPVFYPLSALPVVFQKIVMLNPLAFMIEEARKVVYWGNEPNWTMLAINMLIGL
+                     VIFAAGFLFFQKTKKGFADVI"
+                     /locus_tag="OL4_05_wzm"
+     gene            complement(7588..8733)
+                     /gene="glycosyltransferase"
+     CDS             complement(7588..8733)
+                     /gene="glycosyltransferase"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006499560.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyl transferase"
+                     /protein_id="CZQ25325.1"
+                     /db_xref="GI:1036211118"
+                     /translation="MRIVYFVNAAWYFELHWLDRSEAAISKGYEVHLVSNFADDAIKNN
+                     LEKKGIKCWDIELNRFSKNVFKNISIFTAFRKICKQIKPDLIHLITIKPILFGGLYARV
+                     AGIPFVVSFVGLGRLFGNKRGWLNKFIFNSVLSIYSLLLSAKSPAQVIFEHNADFAELS
+                     KYIKFDENNIHIIEGAGVDRFRFSYQPEPTQNNFSVLFASRLLWSKGLGEVVEAIGKVK
+                     QNENNTTLYVAGILDDKDPDRIELDQILQWEKEGKIIWLGRRDDIQNLIRNSHVVILPT
+                     KYSEGVPRIIIEACAMGRSCIVGNVPGCKAIIKDNFNGCVLKTHSASEIAEKIEYLRDN
+                     MEIRKKFGLRSAEIVKERFSKEIVIDKTLCVYNKILSTTKR"
+                     /locus_tag="OL4_06_glycosyltransferase"
+ORIGIN
+        1 ttaatacttg cgatagaatt ttcttttata aaaaaccgca aggtcaatcg tcagtgctaa
+       61 aatgtattta tttagcgagg gcagattgtc tcttttacgt atgccatcgc tccattgatt
+      121 tgctttaata aattcaatca atgctgcacg gttgttttta ttccataaag agcttaatat
+      181 ctcgaaggtc gtgggtacat ggtttttctt aacgtatcca cctaagccga atgtttcgtt
+      241 atgatttaaa ttattaaaag cgtcagttag agatttatta ctaccactaa ttagcacatc
+      301 ccaaatattt agggcgtagc cacgtacaac gtcgtgagta atgccataac tcaacactgc
+      361 agcggagaag gattccatac cggccaggat cccttcttga aatgtttttg tgaaattatg
+      421 ccacgcgctg ttttcgtcgt cgttaacact gcgaatagcg actatcttac cattctccag
+      481 cccatagcct gttacgctac ctgaagggga gttggtaatc atttcaatag gagcaacgga
+      541 atcaagaaaa tgaggatact ccagttggtg attcaaatct gggccaaaag caacttttga
+      601 tgtgtttgat ggttgctcgt tgagaaattt ctgcaggccc agatatatgc cggtaaaatg
+      661 aatatcagga taaagaagag caatattatc gtgaatggtg ccacgccagc cgacatcgac
+      721 tacgcaaata cgcgcattga tatcatcagt tagacctttt gtcgcaaaat agttcttcaa
+      781 aagagctctt tgctgcatca catgctgcca gagcgtctct ttgaaaccag agtcgtcaaa
+      841 aagttgctga atacggctgt cctgccatgg atattggatc tgttcatctg caggaatccc
+      901 atatttgtcg atgaaactct ggaatgtttc aggggcaacg ttaagggtct tgaataaaga
+      961 gctaatggac tgtgtgctat ataaattcca aacacgcatc atctcttttg tgctaatttc
+     1021 ttgtagagac ggcgcgaagg tagccagacg gctgacttct ataatatcga tttctggtaa
+     1081 ctttatttct ttaatattag tcttgagatg actaatcaaa atattcattg ctttaatgaa
+     1141 aaactcgcct tcacgagtga aaaagaggat tttttcactt tttgatatga cggcttgttc
+     1201 caaaatttta aggcaaaaac cagcgattaa cggagttgtt ttcaagccaa gctgaaaatc
+     1261 aactgataaa tctttagatg ctgcatattt attaagaata ttattggtga tcgtttccgt
+     1321 gagatcttca tttttattcc agagaaactc tttttgctca cgcagctgat gctgttgggc
+     1381 tgggagatac cgaatacttt ttataccttt tgatgtcggc atttgcacat cggaccattc
+     1441 attatcgcca atatgtatcc agtcaacgcc ggctaactga tatttttgtt gaataaaatc
+     1501 gaagagacgt ccacttctct tgttcagtcg ctcgtcaatt gaagaaacgc catctgatat
+     1561 gacagactga tccaatccag cgctaacgag taactctgtt aaatcagtgg atgaagtata
+     1621 aaaatcggac agaaagattg tcttatcaga gggatattgc gcaagaaagt cctcaatacc
+     1681 tggatccaga tagatgtgct tcttctcttg ctcaatttcc caggaatata gctcatgtgc
+     1741 tatcgctggc gtatcatatt gctctgcaga gatatagttt tctacccatt gaagcattac
+     1801 atcctgaatg agatactcat catcataacc aagatctttg tttttcttac caattaagcg
+     1861 ctctgtttca actcgcttag taaatagctg gtcgacggaa tcaacattgt gtagcgaatg
+     1921 aaatttaagg aaaaaataat atgcagttga ccgctttatg aagtctggat ggcaatcacg
+     1981 acgcagaatt gtatcccata catcaacagt tttgagttta aatttattca tctggattaa
+     2041 ttcttcaact taaaataaag cgcgcttaaa ggtgtgcgca caaataacgg taaacgtaga
+     2101 gcaattctct ttaacagact ctgatgcgcg aatgttaacg tgttggcaat atcaggtctg
+     2161 gcaagagggg cttcaaacgg gggcttatta tacgatcgtg aaatcacttc tgctgtgtat
+     2221 gcctgctcgt tcatcacgca gttgaacgct ttgtaaaagc cttctgtttc cgtttccagg
+     2281 gtacgcccat tcataaactt ttgaccagcc gagctcatac tcgcggctaa atcagcatcg
+     2341 tttagaattt tcataatacc ggtggcaatg ctttcaggtg tctgtttaca caacagcata
+     2401 gcatcttcgc taaaatcata aagattgttt tctcgccaga cttcaacaac gggaaggcct
+     2461 gcattcatca tttcaaaggg gatgcgagag ggatttgaag aactaataca gagtcctacg
+     2521 gagcatttat tatatagctc attacatttc ggcaaatcta ataaacctag attttcatgt
+     2581 tcgaaccaga gattatcatt aattgatgta ccataaagat aaattttaac atctggcatg
+     2641 caatgtttaa ctatacctaa agcctcaata ccaatacgcg aacaacgtcg cggtttatct
+     2701 ggctgataga taaagcaaac cgctttttct ttttgaatgg tgggaactcg cttatagata
+     2761 ttatgattcg ccccaaattc gaagtgatag ctttcaacag caaaatcatt ttgcagttta
+     2821 tatcgtaacc agcgcccaat cgtaattggc tttaagccgt aacagtatga attttcagcc
+     2881 atcaggtaag catcgcccac cgggttgaag taagcttcaa aatcctgaac gaaatataaa
+     2941 cgtttacaat caaatggtag agcggccacg aatggtgcag aataccatat tgttgcaact
+     3001 gcagcatcac atggttgcgc attattccag tcataaatga cgtctttaaa ttttagacca
+     3061 aataatttat gaattacctc tgcaccgctt gttttgccgc ttttatcttc aagataaatt
+     3121 gtacatgtat gacccatttt ttccagataa gcggcatgtt gcagcattgt gcggtgacca
+     3181 ccagaccctt caatgagttg aggtataaac caagcaatat tagccattat aacctttcac
+     3241 aatagaatta ttttatattt agcatgcgta gtagatgcct tattacaggc gtgctattaa
+     3301 tcttacgcag tatggtattt gcacgttcta gatctgcaga gagctgggca atatggagat
+     3361 ctttttcatc gattaatgaa attaatttta tgttttgatt ctgtaattca tcaactttct
+     3421 gttccttaga ggaaacttga ctatttaagt cagttacatt ttggatttgc tgctgaatag
+     3481 ttttattatt ctgctcaatt aattgatttt gctgagcaga gaccaggtca cgctcatcaa
+     3541 ttaaattttt ttgcgtaaga acagtgctgt ctcgctcatc aataaggcgc ttctggtcgt
+     3601 gaatagttct atcgcgttca tcaattaagc atttttgatc atgaattgtt ctgtcacgct
+     3661 catctatcat ttgcgacata ttatttattg cattcatgcg ttcatgaagc aaagccgacc
+     3721 aggtgttacc gttgtcaaaa tttgcaatgt tgaattttct gcctggtatg gcgtttttaa
+     3781 tgttgaccat ctttataagc caatcaagaa tatcatggta aatataaagc acaaaattaa
+     3841 atggttgaga tattttaccc accagttcgt caggatgttg ataaagtagc tgtatacctc
+     3901 ttttaatccc tctatcgacg attatctcgg cacaggagat tctatttaaa gaaattaata
+     3961 taacggactg aagataaaag ctttgtaaaa tcttcgtgcc gatagagggg ctaaatttat
+     4021 caatgctgga gtttgctgca cgagataaat ggattaacgc attagcttta tcattatttt
+     4081 tgttacaaat aagacctaaa agtgtcgata aagatatgag ccaacgatat tgatgtggcg
+     4141 taggattatc catctgcgac acatttgagc agtaatctag catttttgcg taaatgtcag
+     4201 ctgtatcatc actgccgctt agcatttgat aacctaatac tgccaatgca gcggcataat
+     4261 cggggctgtc aggagcactg tgctccaaaa tctgatggct atactgctgt agatgataag
+     4321 ttgacctatt cctgaatggg aattctacga tcccgcgaat aagccacggg ttagtataat
+     4381 ctctggcaaa agctaatagg ttttttggtg gatgcgagta gccataaatc gtttcctgat
+     4441 acggaagctc tgacctagct aaagggcttt tcataaaaac acataattca ggagagagtg
+     4501 taatttcctc tccctgatgt atttgagtct ttaaatggcc atgttcataa aataaataaa
+     4561 cttcaggttg taaattgtaa ttacttaatg tctcaactac agttttatct gtatgaaaac
+     4621 taacgtacct gccagcgggc accaggtaag atataatgac tttgagtgca ttatttagtc
+     4681 catcatcggc atatttatca gtaatgagaa aatggtagcc attgccattt agctgaacac
+     4741 ttttaatttc atccaatgag taaatttcaa cttcagatgc cttggtttgt tctgcaataa
+     4801 tatttttaat gtttgttatc gaatttttat tcttaatgat tacaagtact cgatccccag
+     4861 gacgtatgta gggaaaagta tttacaagtt ttttttcaaa aatagtcgtt tctaagatat
+     4921 ttttgtctgt cgaaactact gactgacgtc tataactcaa aactatcttt aggctttgat
+     4981 catcccgaaa ttgttcatca tagccaggat tgagcaaata aaatacagtg tctatcgaat
+     5041 aaccaagatt gtcagttata ttaataaaat cctggaaact ctgaccgttt cccttttcta
+     5101 caaagatatt aataacgatt ttatttacaa gctgtcttgc agcggttctg acaatcttga
+     5161 catattcatt aaaattatta tctttatcat tggttaaaag gaaattaact ttattgcggt
+     5221 taagaatatc tttacactgc gccagatcag cgcagttgtg caccttataa cccttctctg
+     5281 caatcagacc ctctgtttct tttgggtaat tttgtaataa atacacccca ggcccgagat
+     5341 aatcagttat tgaaatatca ttcatcaact taccactctg cagtcatctt gagatccaga
+     5401 atgccaccaa agaaatattc atcacgcagg acattaacgt gaaaaaacgc ggcttcatca
+     5461 cgccagtgta aaatgcgctg cgagaaataa ttaggtgtcc cctcatagga tatcgccgcc
+     5521 tgtatttcat ataggtttgt tcctaaagta cattcaaatt ccatatcaac ataaaaacgc
+     5581 tcgcctgctt taaactcacg ttcccaaaat tggggatctt taagttgatg gaaacgaaca
+     5641 tacatgtcct ggtttaacgt tccccatgaa taaattttga cgccttcttt attgcgaata
+     5701 cgaatgccaa cgttaatgtg gtttatatct ttatttactt tgcaattaac acgaactctg
+     5761 attttatcac cagggttaaa ggcattgctg cgttcaccag aagccgtaaa caattcaaca
+     5821 ttttcaacct ctgcttcacc ttcaccgaac gatagtttat ctgtacgaga gggcgaggtt
+     5881 tcctctacag caggggtttc agcattagca ctaatttcta tcttagccgg cgcggtgggg
+     5941 gtttgattaa tatcgcgagt ggcgtccgcg tgggcagcaa cttcctctgc taactgagaa
+     6001 aaatacttac tttcttcccg gtgtagtaaa cgacgatatt caagtaaaac ttctgatgat
+     6061 aagccagtac ttaattgcgt cccacgatcg agaagaatag ctctgtttgt taaggtacgc
+     6121 acggactctt gatcgtgtga aacaaacagt aaagttacgc cattgctggt taatttctca
+     6181 atttgttgga aacagcgctt ttgaaaaagt gcgtcgccta cagcaagtgc ttcatctacg
+     6241 atgagaatat ctggctctaa ttgtacctga acggcaaatg caaggcgcac catcattccg
+     6301 ctggagtatg tttttaccgg ctggtcgaga tgggttccta tatcagcaaa accggcaata
+     6361 gcatcaaatt ttgcatctat ttctgcccgc gataatccca gaacggcgcc gttaagatag
+     6421 atgttttccc taccggtaaa ctctgggttg aaaccggagc ctaattccaa gagggcagct
+     6481 attcttccct tggtttgtat cgtgcccgtt gttggagtta gcgtgccggt gattagctgt
+     6541 agtaatgtac ttttgccaga accattgcgt ccaataattc ccgctgactc acctttattg
+     6601 atggtaaagt tgatgttatt taacgcccaa aattcgttat agtagcgttg tacaggtttc
+     6661 ccaaccatac tctggacttt aggtaagaaa aactgtttta acctatctct ggggttttgg
+     6721 taaatgttat agcatttgct aatgttactt acgctaattg caatgttatc agatgacatc
+     6781 ggcaaatcct ttttttgttt tttggaaaaa taaaaaacct gcagcaaaga taactaaacc
+     6841 aataagcata ttaattgcga gcatggtcca gttaggctca tttccccagt aaacaacttt
+     6901 tcttgcttct tcaatcataa atgccagagg attcaacatt acaatttttt ggaaaaccac
+     6961 cggtaatgct gataacggat aaaatacggg agataaaaac attaatattg ttacgatgat
+     7021 actaatagtt tgtggcatat cacgaacaaa aacgcccagt gaggccagga tccagcttaa
+     7081 tccaagtata gagagcataa gtggaatagt aatgactggc agtaacagga cagtaaaatg
+     7141 aagctgatgc ttaaacacca gtattgcgat aaataagact atgaggctaa tgctggcatg
+     7201 aaataaagca gccagcagat ttactatagg taatatctca atagggaaaa caactttttt
+     7261 gacgaagttt acatttgagg tgataaggct ggttgacctg ttaatacatt ctgcaaataa
+     7321 gttaaaaata atcagtccgg taaacaaaat gattgcaaaa tctgcatgcc cggcatctgg
+     7381 actgcttccc caacgagatt tgaatataac cgagaataca aatgtgtaga ctgttaacat
+     7441 caatatgggg ttgaaaagtg accatgccag accaagaaag gatcctttat agcgtcccat
+     7501 aacgtctctt ttagacattt gccagattaa ctcgcgcttc tggataatta tcttcgaaat
+     7561 ttttactaaa gttccaatca ttatttttta ccgctttgtt gtacttagta ttttattgta
+     7621 aacacataac gttttatcta taacaatttc tttgctgaat ctttctttta caatttcggc
+     7681 tgagcgtagg ccaaattttt ttcttatttc catgttatct ctaagatatt caattttctc
+     7741 cgcgatctca ctagcgctat gtgtttttag tacacatcca ttgaaattat ctttaattat
+     7801 ggctttacag ccgggtacat ttccgacaat gcaacttcgg cccatagcac acgcttcaat
+     7861 gattattctt ggcacgcctt ctgaatattt agttggcaaa atcacgacat ggctatttct
+     7921 gattaaattt tggatgtcat ctcttcgacc taaccaaatg atttttcctt ctttttccca
+     7981 ttgcaaaatt tgatctaatt caattctatc cggatctttg tcatcgagaa ttcccgcaac
+     8041 gtataaggtt gtgttatttt cattttgttt aaccttaccg atggcctcga ctacttcacc
+     8101 gagccccttt gaccatagca aacggctggc aaataatacc gagaaattat tctgagttgg
+     8161 ttctggctga taactaaagc gaaacctgtc taccccggct ccttcaatga tatggatgtt
+     8221 attttcatca aatttaatat atttactcag ctcagcaaag tcagcattat gctcaaatat
+     8281 tacttgcgct gggctttttg ctgatagcaa aagactataa attgacagta ctgagttgaa
+     8341 aatgaattta ttcaaccaac ctcgtttatt gccaaacaat ctccctaatc ccacaaagct
+     8401 tacgacaaaa gggatgcctg caacccgggc atacaatcca ccaaaaagga ttggttttat
+     8461 agtaattaga tgaataagat cgggtttaat ttgcttacag atctttctaa atgcagtgaa
+     8521 tattgaaatg tttttaaaca catttttaga aaatctgtta agctcaatat cccaacattt
+     8581 tatacctttt ttttccaggt tatttttgat ggcgtcatca gcaaaattac ttacaagatg
+     8641 aacttcatac cctttgctaa ttgccgcttc tgaccggtcc aaccaatgca gttcgaagta
+     8701 ccacgctgca ttgacaaaat acactatcct cataccattc ctcaacaacc cgcgagatgg
+     8761 tcaatcacgg cttactacat gtaatgtagg cacgctaccg cccttggctc tggctgccaa
+     8821 agggcgaaac tcttgttttg tcaggagtat tgacggccag gctactgacc gctgcaacta
+     8881 cccaatgtct ggtagttaaa taccagcata cacctcactg accacaggtt tccaaactcc
+     8941 cgtgattcgg ctaaaaacca ggctattatg aaatatattc ctgacagcat atgttttgca
+     9001 ttataagagc ataatttctt acgcatttta tgcctactgg atgattccta tagctaactg
+     9061 gttgtttcat aaaaaaatct ataaagtaaa atagttcatg gatttcaaac agatacatcc
+     9121 aactgttact tatttcataa catagcttta catttgagct cactttgaac atttagtgaa
+     9181 tgagaggccg tgtatggtga gtttttatgc atttaatttt tatttaacct tgtgtggaca
+     9241 tgtataaact tagggccggg atcttgaagc cctaaaaggt ttaggcgcaa attatgcgtc
+     9301 ttaccctaca ttgggttaaa tcttccgcgc ccgccaaaac tactattgat cgccattgtc
+     9361 ggatacggtg cctccgtttg atagatttca tggatttatt gagctgctta cgccgctgtg
+     9421 attatattct tttataagaa catttccag
+//
+LOCUS       LT174606               12084 bp    DNA     linear   BCT 13-JUN-2016
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
+            cluster, type: O5.
+ACCESSION   LT174606
+VERSION     LT174606.1  GI:1036211123
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
+            Enterobacteriaceae; Klebsiella.
+REFERENCE   1
+  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
+            Holt,K.E. and Thomson,N.R.
+  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
+            antigens
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 12084)
+  AUTHORS   Informatics,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
+            1SA, UNITED KINGDOM
+FEATURES             Location/Qualifiers
+     source          1..12084
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="AKPRH1202322"
+                     /serovar="O5"
+                     /db_xref="taxon:573"
+                     /note="O locus: OL5"
+                     /note="O type: O5"
+     gene            1..1416
+                     /gene="manC"
+     CDS             1..1416
+                     /gene="manC"
+                     /EC_number="2.7.7.13"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006635421.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mannose-1-phosphate guanylyltransferase"
+                     /protein_id="CZQ25330.1"
+                     /db_xref="GI:1036211124"
+                     /translation="MLLPVIMAGGTGSRLWPMSRELYPKQFLRLYGQNSMLQETITRLS
+                     GLEIHEPMVICNEEHRFLVAEQLRQLNKLSNNIILEPVGRNTAPAIALAALQATRHGDD
+                     PLMLVLAADHIINNQPVFHDAIRVAEQYADEGHLVTFGIVPNAPETGYGYIQRGVALTD
+                     SAHTPYQVARFVEKPDRERAEAYLASGEYYWNSGMFMFRAKKYLSELAKFRPDILEACQ
+                     AAVNAADNGSDFISIPHDIFCECPDESVDYAVMEKTADAVVVGLDADWSDVGSWSALWE
+                     VSPKDEQGNVLSGDAWVHDSENCYINSDEKLVAAIGVENLVIVSTKDAVLVMNRERSQD
+                     VKKAVEFLKQNQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
+                     AEHWVILAGTGQVTVNGKQFLLTENQSTFIPIGAEHSLENPGRIPLEVLEIQSGSYLGE
+                     DDIIRIKDQYGRC"
+                     /locus_tag="OL5_01_manC"
+     gene            1439..2815
+                     /gene="manB"
+     CDS             1439..2815
+                     /gene="manB"
+                     /EC_number="5.4.2.2"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237527.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="phosphomannomutase"
+                     /protein_id="CZQ25331.1"
+                     /db_xref="GI:1036211125"
+                     /translation="MTQLTCFKAYDIRGELGEELNEDIAYRIGRAYGEFLKPGKIVVGG
+                     DVRLTSESLKLALARGLMDAGTDVLDIGLSGTEEIYFATFHLGVDGGIEVTASHNPMNY
+                     NGMKLVRENAKPISGDTGLRDIQRLAEENQFPPVDPARRGTLRQISVLKEYVDHLMGYV
+                     DLANFTRPLKLVVNSGNGAAGHVIDEVEKRFAAAGAPVTFIKVHHQPDGHFPNGIPNPL
+                     LPECRQDTADAVRAHQADMGIAFDGDFDRCFLFDGEASFIEGYYIVGLLAEAFLQKQPG
+                     AKIIHDPRLTWNTVDIVTRSGGQPVMSKTGHAFIKERMRQEDAIYGGEMSAHHYFRDFA
+                     YCDSGMIPWLLVAELLCLKNSSLKSLVADRQAAFPASGEINRKLGNAAEAIARIRAQYE
+                     PAAAHIDTTDGISIEYPEWRFNLRTSNTEPVVRLNVESRADTALMNEKTTELLHLLSGE
+                     "
+                     /locus_tag="OL5_02_manB"
+     gene            2817..3611
+                     /gene="wzm"
+     CDS             2817..3611
+                     /gene="wzm"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237528.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ABC transporter permease"
+                     /protein_id="CZQ25332.1"
+                     /db_xref="GI:1036211126"
+                     /translation="MRDLLTTIYRYRGFIWSSVKRDFQARYQTSMLGALWLVLQPLSMI
+                     LVYTLVFSEVMKARMPDNTGPFAYSIYLCSGVLTWGLFTEMLDKGQSVFINNANLIKKL
+                     SFPKICLPIIVTLSAVLNFAIIFSLFLIFIIVTGNFPGWLFFSVIPVLLLQILFAGGLG
+                     MILGVMNVFFRDVGQLVGVALQFWFWFTPIVYVLNSLPAWAKNLLLYNPMTRIMQSYQS
+                     IFAYHQAPNWYSLWPVLALAIIFCVIGFRMFRKHAADMVDEL"
+                     /locus_tag="OL5_03_wzm"
+     gene            3611..4825
+                     /gene="wzt"
+     CDS             3611..4825
+                     /gene="wzt"
+                     /EC_number="3.6.3.40"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237529.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ABC transporter ATP-binding protein"
+                     /protein_id="CZQ25333.1"
+                     /db_xref="GI:1036211127"
+                     /translation="MSYIRVKNVGKAYRQYHSKTGRLIEWLSPLNTKRHNLKWILSDIN
+                     FEVAPGEAVGIIGINGAGKSTLLKLITGTSRPTTGEIEISGRVAALLELGMGFHSDFTG
+                     RQNVYMSGQLLGLSSEKITELMPQIEEFAEIGDYIDQPVRVYSSGMQVRLAFSVATAIR
+                     PDVLIIDEALSVGDAYFQHKSFERIRKFRLEGTTLLLVSHDKQAIQSICDRAILLNKGH
+                     IEMEGEPEAVMDYYNALLADKQNQSIKQVEHNGKTQTVSGTGEVTISEVHLLDEQGNVT
+                     EFASVGHRISLQVNVEVKADIPELVVGYMIKDRLGQPIFGTNTHHLKQTLTSLKKGEKR
+                     SFLFSFDARLGVGSYSVAVALHTSSTHLGKNYEWRDLAVVFNVVNTEQQEFVGVSWLPP
+                     ELEIS"
+                     /locus_tag="OL5_04_wzt"
+     gene            4825..6102
+                     /gene="wbdD"
+     CDS             4825..6102
+                     /gene="wbdD"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237530.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="methyltransferase"
+                     /protein_id="CZQ25334.1"
+                     /db_xref="GI:1036211128"
+                     /translation="MGSSFYRSFEERHRGSVEDIKNRLSFYLPFLSRLKDLYPEGVIAD
+                     IGCGRGEWLEILTENGIANIGVDLDDGMLARAKEAGLNVQKMDCLQFLQNQADQSLIAL
+                     TGFHIAEHLPFEVLQQLVMHTLRVLKPGGLLILETPNPENVSVGTCSFYMDPTHNHPLP
+                     PPLLEFLPIHYGFNRAITVRLQEKEALKSPDAAVNLVDVLKGVSPDYSIIAQKAAPADV
+                     LERFETLFTQQYGLTLDVLSNRYDAILRQQFSSFASQLETLNQTYTRQLSKMAENIQTL
+                     QGQVDELNHVIGQNNQLHQQVADLHNSRSWRITQPLRWLSLQRQLLRQEGAKVRARRAA
+                     KKILRKGMALSLVFFHRYPKSKVYLFKFLRKTGCYTLLQRLFQRVMLVQSDTMMMQSRR
+                     YDVGTEEMTSRALSIYNELKNKNTEK"
+                     /locus_tag="OL5_05_wbdD"
+     gene            6105..9746
+                     /gene="wbdA"
+     CDS             6105..9746
+                     /gene="wbdA"
+                     /EC_number="2.4.1.246"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237531.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mannosyltransferase A"
+                     /protein_id="CZQ25335.1"
+                     /db_xref="GI:1036211129"
+                     /translation="MRIVIDLQGAQTESRFRGIGRYSIAIARAIIRNNNRHEVFIALSA
+                     MLGESITDVKAQFADLLPADNIVVWHAAGPVRAMDKGNEWRRESAELIREAFLESLRPD
+                     VVFITSLFEGHVDDAATSVHKFSRQYKVAVLHHDLIPLVQAETYLLDDVFKSYYLQKVE
+                     WLKNADLLLTNSAYTAQEAIEHLHLQGDHVQNIAAAADPQFCMAEVTASEKESVLGHYG
+                     IQREFVLYAPGGFDSRKNFKRLIEAYAGLSDALRRSHQLVIVSKLSIGDRQYLESLASG
+                     NGLQQGELVLTGYVPENELIQLYRLCKLFIFASLHEGFGLPVLEAMSCGAPAIGSNVTS
+                     IPEVIGNPEALFDPYSVSSIREKIAQCLNDAPFLARLKEMAQQQARNFSWDNAAVTALE
+                     AFEKIATEDAGTVQVLPEALIQRILAISHCQPDERDLRLCATAIDYNLKTAELYQIDDK
+                     ALTWRVEGPFDSSYSLALVNREFARALSADGVEVLLHSTEGPGDFAPDASFMAQPENSD
+                     LLAFYNQCRTRKSNEKIDILSRNIYPPRVADMDAKVKLLHCYAWEETGFPQPWINEFNR
+                     ELDGVLCTSEHVRKVLIDNGLNVPAFVVGNGCDHWLTTAAETAKDVDEGTFRFLHVSSC
+                     FPRKGVQAMLQAWGRAFTRRDNVILIIKTFNNPHNEIDAWLAHAQAQFADYPKVEIIKE
+                     DMSASRLKGLYESCDVLVAPGCAEGFGLPIAEAMLSGLPAIVTNWSGQLDFVNSQNSWL
+                     VNYQFTRVKTHFGLFASTWASVDIDNLTDALKAAASTDKSVLRDMADAGRELILQQFTW
+                     KAVADRSRQAVKTLRAHIDIAQHRARIGWLTTWNTKCGIATYSQHLLESAPHGADVVFA
+                     PQVSAGDLVCADEEFVLRNWIVGKENNYLENLQPQIDALRLDVIVIQFNYGFFNHRELS
+                     AFIRRQHDAGRAVVMTMHSTVDPLEKEPTWNFRLAEMADALALCDRLLVHSIADMNRLK
+                     DLGLTDNVALFPHGVINYAAGSAARQQQALPLIASYGFCLPHKGLMELVESVHRLKQAG
+                     KPVRLRLVNAEYPVGESRDLVAELKAAAQRLGVNDLIEMHNDFLPDAESLRLLSEADLL
+                     IFAYQNTGESASGAVRYGMATQKPVAVTPLAIFDDLDDAVFKFDGCSVDDISQGIDRIL
+                     HSIREQDAWATRTQQRADAWREQHDYYAVSRRLVNMCQGLAKAKYFK"
+                     /locus_tag="OL5_06_wbdA"
+     gene            9802..10959
+                     /gene="wbdB"
+     CDS             9802..10959
+                     /gene="wbdB"
+                     /EC_number="2.4.1.250"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237532.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mannosyltransferase B"
+                     /protein_id="CZQ25336.1"
+                     /db_xref="GI:1036211130"
+                     /translation="MSFIMKIIFATEPIKYPLTGIGRYSLELVKRLAVAREIEELKLFH
+                     GASFIDQIPQVENKSDTKASNHGRLSAFLRRQPLLIEAYRLLHPRRQAWALRDYKDYIY
+                     HGPNFYLPHRLERAVTTFHDISIFTCPEYHPKDRVRYMEKSLHESLDSAKLILTVSDFS
+                     RSEIIRLFNYPADRIVTTKLACSSDYIPRSPAECLPVLQKYQLAWQGYALYIGTMEPRK
+                     NIRGLLQAYQLLPMETRMRYPLILSGYRGWEDDVLWQLVERGTREGWIRYLGYVPDEDL
+                     PYLYAAARTFVYPSFYEGFGLPILEAMSCGVPVVCSNVTSLPEVVGDAGLVADPNDVDA
+                     ISVHILQSLQDDSWREIATARGLAQAKQFSWENCTTQTINAYKLL"
+                     /locus_tag="OL5_07_wbdB"
+     gene            10969..12084
+                     /gene="wbdC"
+     CDS             10969..12084
+                     /gene="wbdC"
+                     /EC_number="2.4.1.11"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_002237533.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyl transferase family protein"
+                     /protein_id="CZQ25337.1"
+                     /db_xref="GI:1036211131"
+                     /translation="MRVLHVYKTYYPDTYGGIEQVIYQLSQGCARRGIAADVFTFSPDK
+                     ETGPVAYEDHRVIYNKQLFEIASTPFSLKALKRFKQIKDDYDIINYHFPFPFMDMLHLS
+                     ARPDARTVVTYHSDIVKQKRLMKLYQPLQERFLASVDCIVASSPNYVASSQTLKKYQDK
+                     TVVIPFGLEQHDVQHDPQRVAHWRETVGDNFFLFVGAFRYYKGLHILLDAAERSRLPVV
+                     IVGGGPLEAEVRREAQQRGLSNVVFTGMLNDEDKYILFQLCRGVVFPSHLRSEAFGITL
+                     LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPNDSQALVEAMNELWHNDETASRYGE
+                     NSRRRFEEMFTADHMIDAYVNLYTTLLESKS"
+                     /locus_tag="OL5_08_wbdC"
+ORIGIN
+        1 atgttacttc ctgtaattat ggctggtggt accggcagtc gtctctggcc gatgtctcgc
+       61 gagctttacc cgaaacagtt cctccggctg tacgggcaga actccatgct gcaggaaacc
+      121 atcacccgac tctcgggcct tgaaatccat gaaccgatgg tcatctgtaa cgaagagcac
+      181 cgcttcctgg tggccgaaca gctgcgtcag ctcaacaagc tgtcgaacaa cattattctt
+      241 gagccggtcg ggcgcaacac cgccccggcc atcgccctgg cggccctcca ggccacccgt
+      301 cacggcgacg acccgctgat gctggtcctc gccgccgacc atatcatcaa taaccagccg
+      361 gtcttccacg acgccatccg cgtcgccgag cagtacgccg atgaaggcca tctggtcacc
+      421 tttggtatcg tgccgaacgc cccggaaacc ggctacggtt acatccagcg cggcgtggcc
+      481 ctcaccgaca gcgcccacac cccgtaccag gtggcccgct tcgtggagaa gccggaccgc
+      541 gagcgcgccg aggcctacct cgcctccggg gagtactact ggaacagcgg catgtttatg
+      601 ttccgcgcca aaaaatacct ctccgagctg gccaaattcc gcccggatat cctcgaagcc
+      661 tgccaggccg cggtcaatgc cgccgacaac ggcagcgact tcatcagcat tccgcatgac
+      721 attttctgcg agtgcccgga cgagtccgtg gactacgcgg tgatggagaa aaccgccgac
+      781 gcggtggtgg tcggtctcga tgccgactgg agcgacgtcg gctcctggtc cgccctgtgg
+      841 gaggtcagcc cgaaagacga gcagggtaac gtcctcagcg gtgacgcgtg ggtgcatgac
+      901 agcgaaaact gctacatcaa cagcgacgag aagctggtgg cggccattgg cgtggagaac
+      961 ctggtgattg tcagcaccaa ggacgccgtg ctggtgatga accgcgagcg ttcccaggac
+     1021 gtgaagaagg cggtcgagtt cctcaagcag aaccagcgca gcgagtacaa gcgccaccgc
+     1081 gagatttacc gtccctgggg ccgctgcgac gtggtggtcc agaccccgcg cttcaacgtc
+     1141 aaccgtatca ccgtgaaacc gggcggcgcc ttctcgatgc agatgcacca ccaccgcgcc
+     1201 gagcactggg tcattctcgc cggcaccggt caggtgacgg tcaacggcaa gcagttcctg
+     1261 ctgaccgaga accagtccac ctttattccg attggcgccg agcacagcct ggaaaacccg
+     1321 ggccgcattc cgctggaagt gctggagatc cagtcggggt cgtacctcgg cgaggacgac
+     1381 attattcgta ttaaagacca gtatggtcgt tgctaatttt ttcgggacaa aacgcagaat
+     1441 gacacagtta acatgcttta aggcttatga catccgtggt gaactgggcg aggagctgaa
+     1501 cgaggacatc gcctaccgta tcggccgcgc ctacggcgaa tttctgaaac ccgggaagat
+     1561 agtggtgggg ggcgatgtgc gcctcaccag cgagtcgctg aagctggcgc tggcccgcgg
+     1621 gctgatggac gccggcaccg acgtgctgga tatcggcctg agcggcacgg aagagattta
+     1681 cttcgccacc ttccacctcg gggtggacgg cggcatcgag gtgacggcga gccataaccc
+     1741 gatgaactac aacggcatga agctggtgcg cgagaacgcg aagcccatca gcggcgacac
+     1801 cggcctgcgg gatatccagc gcctggcgga ggagaaccag ttcccgccgg tggacccggc
+     1861 gcgtcgcgga accctgcgtc agatttcggt gctgaaggag tacgtcgacc acctgatggg
+     1921 ctacgtggac ctggcgaact tcacccgtcc gctgaagctg gtggtgaact ccggcaacgg
+     1981 ggcggcgggg cacgtgattg atgaggtgga gaaacgcttc gcggcggccg gggcgccggt
+     2041 gacctttatc aaggtgcatc accagccgga cggccatttc ccgaacggta tcccgaaccc
+     2101 gctgctgccg gagtgccgtc aggacaccgc cgatgcggtg cgtgcgcatc aggcggacat
+     2161 gggtatcgcc tttgacggcg acttcgaccg ctgcttcctg ttcgatggcg aggcgtcgtt
+     2221 tatcgagggg tactacattg tcggcctgct ggcggaagcg ttcctgcaga agcagccggg
+     2281 ggcgaaaatc attcacgacc cgcgcctgac gtggaacacg gtggacatcg tgacccgcag
+     2341 cggcggccag ccggtgatgt cgaagacggg gcatgcgttc atcaaggagc ggatgcgcca
+     2401 ggaagacgcc atctacggcg gggagatgag cgcgcaccat tacttccgcg acttcgccta
+     2461 ctgcgacagc gggatgatcc cgtggctgct ggtggcggag ctgctgtgcc tgaagaacag
+     2521 ttcgctgaaa tcgctggtgg cggaccgcca ggcggcgttc ccggcgtcgg gggagatcaa
+     2581 ccgcaagctg ggaaatgcgg cggaggcgat agcgcgcatc cgggcgcagt atgagccggc
+     2641 ggccgcacac atcgacacaa cggacggtat cagtattgaa taccctgagt ggcgctttaa
+     2701 cctgcgcacg tccaataccg agccggtggt gcgtctgaac gtggagtcca gagcggatac
+     2761 tgcgttaatg aatgagaaaa cgaccgagct gttacacctg ttaagcgggg aataaggtga
+     2821 gagatttact aacgacgatt tatcgttatc ggggatttat ctggagcagt gttaagcgtg
+     2881 attttcaggc acgctatcaa accagtatgc tgggcgcgtt atggctcgtt ttacaaccgc
+     2941 tctctatgat cttggtctat accctggtct tttccgaggt gatgaaggcc agaatgcccg
+     3001 acaacaccgg gccgtttgcc tacagtattt atctctgttc tggggtactg acctggggat
+     3061 tgtttacaga gatgctggat aaaggtcaga gcgtattcat caataatgct aatctgatca
+     3121 agaaactaag ttttccgaaa atttgtctgc cgatcatcgt gacgttatca gcagtgctta
+     3181 atttcgcgat tatcttcagc ctgtttctga tttttatcat tgtcactggt aacttccctg
+     3241 gctggctgtt tttctcggtg ataccggttc tgcttttgca gatccttttt gccggtgggc
+     3301 tgggtatgat cctcggtgtg atgaacgtct ttttccggga tgtggggcaa ctggttgggg
+     3361 ttgcactgca attttggttt tggttcactc ccattgttta cgtactgaat tcattaccag
+     3421 catgggcgaa aaatctgctg ctttataatc cgatgactcg aatcatgcaa tcttatcagt
+     3481 ccatcttcgc ctaccatcag gcgcccaact ggtattcgct atggccagta ttggctctcg
+     3541 ccattatttt ctgcgtcatc ggtttcagga tgttccgcaa gcatgcggcg gatatggtgg
+     3601 atgaattata atgagttata tcagagtaaa aaatgtcggt aaggcatatc gccagtatca
+     3661 ctcaaaaact gggcgactga tcgaatggtt atcccctctg aatacaaaac gccataatct
+     3721 taaatggatc ctcagcgaca ttaatttcga agttgctccg ggagaggcgg ttggtattat
+     3781 cggtatcaac ggtgcgggca agagtaccct acttaaactt attaccggta cgtccaggcc
+     3841 aacgaccgga gagattgaaa tctcaggccg tgtcgctgcc ttactcgaac tgggtatggg
+     3901 gtttcattct gatttcactg gccgacagaa cgtttatatg tcagggcaac tgctggggtt
+     3961 atcctctgag aaaattactg agttgatgcc gcaaatcgaa gagtttgcgg agatcgggga
+     4021 ttatatcgac cagccggtgc gcgtctattc cagtggtatg caggttcgat tagcttttag
+     4081 cgtagcgacc gctatccgtc ctgatgtgct gattattgat gaagcgttat ccgttgggga
+     4141 tgcctatttc cagcataaaa gtttcgaacg tatccgtaaa ttccgtctgg aaggaaccac
+     4201 gttgctgctg gtatctcatg ataaacaggc gatccagagc atttgcgacc gggctatttt
+     4261 gttgaacaaa ggccacattg agatggaagg cgagcctgaa gcggtgatgg attattacaa
+     4321 tgcgcttctt gccgataagc aaaatcagtc cattaaacaa gttgagcaca acggtaaaac
+     4381 gcaaactgtt tcaggcactg gtgaagtgac aatctctgag gttcatcttc tcgatgaaca
+     4441 gggcaatgtg actgaatttg cctcggtagg gcatcggatc agcttgcagg ttaatgttga
+     4501 ggttaaggct gatatccctg agctcgtcgt cggttatatg atcaaggatc gacttgggca
+     4561 accgattttc gggaccaata cgcatcatct caaacaaaca ctcaccagcc tgaaaaaagg
+     4621 cgaaaagcgt tcgtttttat tctcttttga tgcgaggttg ggggttggct cctattctgt
+     4681 cgctgtcgcg ttgcatactt ccagtacgca tctcggcaaa aactatgaat ggcgcgatct
+     4741 ggccgtggta ttcaacgtcg ttaacacgga acaacaagag tttgtcggcg tgtcctggtt
+     4801 gccacctgaa ctggagattt cttaatgggt tcgtcgtttt atcgttcatt tgaagaacga
+     4861 cacagaggtt cggttgaaga tatcaagaac cgcctgagtt tttatttacc tttcttgtct
+     4921 cgtctgaagg atctttatcc cgaaggcgtg attgcggata ttggctgtgg acgtggtgaa
+     4981 tggctggaaa tcctgactga aaatggtatt gcgaacatcg gcgtcgatct cgatgatggc
+     5041 atgctggcac gtgccaagga agccgggctg aacgtgcaga aaatggattg tctgcagttt
+     5101 ctgcaaaatc aagcagacca gagtctgata gcgttgactg gtttccatat tgctgagcat
+     5161 ttgccctttg aggtattgca gcagctcgtc atgcatacct tacgggtgct gaaacctggc
+     5221 ggtttgctaa tcctcgaaac gccgaacccg gagaatgtaa gcgtcgggac ctgttcattt
+     5281 tatatggatc caacgcataa tcaccctttg ccgccgccat tgcttgagtt tttacctatt
+     5341 cattatggtt ttaaccgggc aattaccgtt cgtctacagg aaaaagaggc tctcaaatcc
+     5401 ccggacgcag cggttaatct ggtcgatgtg cttaaaggtg ttagccccga ttacagcatc
+     5461 attgctcaga aagcagcgcc tgcagatgtt cttgaacgct ttgaaaccct gtttacccaa
+     5521 caatatggcc tgacgctgga tgtcctgagc aaccgttacg atgcaatttt acgccaacag
+     5581 ttctcatcct ttgcctcaca gctggagacg ttaaaccaga catatacgcg ccagctaagc
+     5641 aaaatggcag agaatattca gacgttgcaa ggccaggttg acgaactaaa tcatgtcatt
+     5701 ggtcagaaca atcagcttca tcagcaagtg gcagatttgc ataacagccg ttcatggcgt
+     5761 atcactcaac ctctacgctg gctgtctttg caacgccaat tactgcgtca ggaaggggct
+     5821 aaagtacgag cccgtcgggc ggcgaaaaaa atattgcgca aagggatggc gctctcgctg
+     5881 gtctttttcc atcgttatcc taagtcaaag gtttatctgt ttaaatttct aagaaaaacc
+     5941 ggctgctaca cattgctaca gcgtttgttc cagcgcgtaa tgctggtgca atctgacacg
+     6001 atgatgatgc agtccagaag atatgatgtg ggtactgaag aaatgacaag tcgcgcgttg
+     6061 agtatttata acgaattaaa aaataaaaat acggagaaat aacgatgcgt attgtcattg
+     6121 atttacaagg cgcgcagacg gaaagccgct ttcgtggcat tggtcgttat agtattgcta
+     6181 tcgccagagc gattattaga aataacaatc gacatgaggt tttcatcgcg ctatccgcta
+     6241 tgctgggtga gtcgattact gatgttaagg cgcaatttgc tgatctcctg ccagcagaca
+     6301 acatagtcgt ctggcatgct gcaggaccag tacgtgcaat ggataaaggt aatgaatggc
+     6361 gtcgggagag cgcagaactg attcgggaag cgtttcttga atcattgcgt ccggatgtcg
+     6421 ttttcattac aagcttgttt gaaggtcatg tcgacgatgc ggccacttcg gtacacaaat
+     6481 ttagtcgtca gtacaaagta gccgtactgc atcacgatct tattcccctg gtgcaggctg
+     6541 agacctatct gctggatgat gtattcaaat cctattattt acagaaagtg gaatggttaa
+     6601 aaaacgctga ccttctgcta actaactccg cttatacggc acaggaagcg attgagcatc
+     6661 tgcatttgca gggcgaccat gtgcagaata ttgcagctgc agccgatcct cagttttgta
+     6721 tggcggaagt gacagcgagc gagaaagagt ccgtccttgg ccattacggt attcagcgcg
+     6781 agtttgtgct gtatgcacca ggtggatttg actccaggaa aaactttaag cgattgattg
+     6841 aggcgtatgc aggactcagt gatgctctac gtcgcagcca tcaattggtt atcgttagta
+     6901 agctgtccat tggggatcgt cagtatctgg aatccctggc gtcaggtaat gggttgcagc
+     6961 agggtgaact ggttctgact ggctacgtgc cggaaaatga gctgattcaa ctctatcgtc
+     7021 tgtgtaagct tttcatcttt gcttcgctgc atgaaggctt tgggctgcct gttctggaag
+     7081 caatgtcgtg cggcgcaccg gccattggct caaatgtcac cagtattcct gaagtcatcg
+     7141 gtaatcctga ggcattattc gacccgtatt ctgtctcttc cattcgggaa aagatcgcgc
+     7201 aatgtctgaa tgatgctcca ttcctggcgc gcctgaagga aatggctcag cagcaagcac
+     7261 gtaatttctc ctgggacaac gctgccgtga cggctctgga agctttcgag aagattgcga
+     7321 cagaagacgc cggcaccgtg caggtcttgc ctgaggcact gattcagcgg atccttgcta
+     7381 tctctcactg tcagccagat gagcgcgatc tgcgtttgtg cgcaacggcc atcgattaca
+     7441 atctgaagac ggctgagctg tatcaaattg atgataaagc gctgacctgg cgtgtggaag
+     7501 gtcccttcga tagctcatat agtctggcgc tggtgaatcg ggagtttgcc cgggcactct
+     7561 cagccgatgg tgtagaagta ctattgcact ccactgaagg gccgggcgat tttgcgccgg
+     7621 atgcctcgtt tatggcacag ccggaaaata gcgatcttct ggcattttat aatcaatgtc
+     7681 gtacccgcaa gagtaacgaa aagatagata ttcttagcag aaatatctat ccaccgcggg
+     7741 ttgccgatat ggatgccaaa gtaaaactcc ttcattgcta tgcctgggaa gaaacgggtt
+     7801 ttccacagcc gtggattaat gaatttaacc gggaacttga cggcgtgctg tgtacttcag
+     7861 aacatgtccg taaggtattg attgacaacg gcttgaatgt gcctgcattt gttgtaggca
+     7921 acggctgcga tcattggctc accacagcag ctgaaacggc aaaagatgtg gatgagggaa
+     7981 ccttccgttt cctgcatgtc tcttcctgct tcccacgaaa aggggtgcag gcaatgcttc
+     8041 aggcttgggg cagggcgttc actcgtcgtg acaatgttat cttgatcatt aagactttta
+     8101 acaatccaca caatgaaatt gacgcgtggc tggcacacgc ccaggctcaa ttcgcggact
+     8161 accccaaagt tgaaataatc aaagaggata tgtcagccag ccggcttaaa gggctttatg
+     8221 aaagctgcga tgttctggtt gctccaggtt gcgccgaagg ctttggttta cctatcgctg
+     8281 aagcaatgct gagtgggctt ccagccatcg tcactaactg gagcggtcaa ctagattttg
+     8341 ttaattcaca aaattcatgg ctggttaact atcagtttac ccgggtaaaa acacactttg
+     8401 gtctgtttgc ctcgacatgg gccagtgtgg acattgacaa cttaacggat gcgttaaaag
+     8461 ctgcagcctc gacggataaa tcagtgctgc gtgacatggc tgatgctggt cgcgagctta
+     8521 ttctgcagca gtttacctgg aaagcggtgg ctgatcgttc tcgtcaggca gttaagacgc
+     8581 tgcgtgcgca tattgatatt gctcagcatc gggcgcgaat tggctggttg acgacctgga
+     8641 acacgaaatg tgggatcgca acctattctc agcatttgct ggagagcgca ccgcatggcg
+     8701 cggatgttgt ttttgctccc caggtcagcg ctggagatct tgtgtgtgca gacgaagagt
+     8761 ttgtactgcg caactggatt gtgggtaaag aaaataacta tcttgaaaat ctccagccac
+     8821 aaattgatgc tctgcgactt gatgtcatcg tgatccagtt taactatgga ttctttaatc
+     8881 atcgcgaact gtcggcgttt attcgtcgcc agcatgacgc cggtcgagcg gttgtcatga
+     8941 cgatgcattc aactgtggat ccgctggaaa aagagccgac ctggaatttc cgccttgccg
+     9001 aaatggcgga tgcgctggcg ctttgtgacc gattgttggt gcattcaatt gccgatatga
+     9061 accgccttaa agatttaggc ttaaccgata atgttgcttt atttccgcat ggtgttatca
+     9121 actacgctgc tgggagcgcc gcgcgtcaac agcaggcttt accgttaatt gcgagctatg
+     9181 gcttctgctt accgcataag ggcctgatgg agctggtaga atccgtccat cgcctcaagc
+     9241 aggcggggaa accggttcgt ttgcgtctgg ttaacgcgga gtatccggtt ggagaatcac
+     9301 gcgatctggt ggcagaactt aaagcggcag ctcagcggct aggtgttaac gatctcattg
+     9361 agatgcataa tgatttcctg cctgatgcgg aaagtttgcg gctgctctca gaagctgatc
+     9421 tactgatttt tgcttaccag aatacgggtg agtcagctag cggagcggta cgttatggca
+     9481 tggcgaccca aaaacctgtt gcggtaacac ccctggcgat atttgatgat ctggacgatg
+     9541 cggtctttaa atttgatgga tgcagcgtcg acgatatcag tcaggggatt gaccggatcc
+     9601 ttcattccat ccgtgaacag gacgcctggg ctaccaggac tcaacaacgt gccgatgcat
+     9661 ggcgtgaaca acatgattat tatgctgttt cacgccgcct ggttaatatg tgtcaaggct
+     9721 tagctaaagc taaatatttt aaataaaaat attccccctt gtattttttg cctttgaata
+     9781 caaggggagc tagatgatga tgtgtcattt attatgaaaa ttatttttgc tactgagcca
+     9841 attaaatacc cattaacggg catcggtcgg tattccctgg agctggttaa gcggctggcg
+     9901 gttgcccgtg aaatcgaaga actgaagctg tttcacggcg cgtcgtttat cgatcagatc
+     9961 ccccaggtgg agaataaaag cgataccaaa gccagcaatc atggtcgtct gtcggcgttt
+    10021 ctgcgccgcc agccgctgct gattgaggcg tatcgcctgc tgcatccgcg gcgccaggcg
+    10081 tgggcattgc gcgattacaa agactacatt taccatggtc ccaatttcta tctgccgcat
+    10141 cgcctggaac gcgccgtgac cacgtttcat gacatctcca tttttacctg cccggaatat
+    10201 catccaaaag atcgggttcg ctatatggag aagtccctgc acgagagcct ggattcggcg
+    10261 aagctgatcc tgaccgtctc cgacttctcg cgcagtgaaa tcatccgcct gttcaactat
+    10321 ccggcggatc ggatcgtcac caccaagctg gcctgcagca gcgactatat tccgcgcagc
+    10381 ccggcggagt gcctgccggt cctgcagaaa tatcagctgg cgtggcaggg gtatgcgtta
+    10441 tatatcggca ccatggagcc gcgtaaaaat atccgcggtc tgctgcaggc ctatcagctg
+    10501 ctgccgatgg agacccgcat gcgctacccg ctgatcctca gcggttatcg cggatgggaa
+    10561 gacgatgtgc tgtggcagtt agtcgagcgc ggtacgcgtg aagggtggat ccgttacctg
+    10621 ggctatgtcc cggatgaaga cctgccttat ctgtacgcgg cggccagaac ctttgtttat
+    10681 ccctccttct atgagggatt cggtttacct attcttgaag cgatgtcttg cggtgtgccg
+    10741 gtagtatgtt ccaatgtcac ttctttgcct gaggtggttg gcgatgccgg cctcgttgcc
+    10801 gatcctaatg atgtagacgc gattagtgtg catattttgc agagcctgca ggatgatagc
+    10861 tggcgggaaa tcgccaccgc gcgcggtctt gcccaggcga aacagttttc gtgggagaac
+    10921 tgtacgaccc agaccattaa cgcctataaa ttactctaag ggtgtcagtt gagagttcta
+    10981 cacgtctata agacctacta tcccgatacc tacggcggta ttgagcaggt catttatcag
+    11041 ctaagtcagg gctgcgcccg ccggggaatc gcagccgatg tttttacttt tagcccggac
+    11101 aaagagacag gtcctgtcgc ctacgaagac catcgggtca tttataataa gcagcttttt
+    11161 gaaattgcct ccacgccgtt ttcgttgaaa gcgttaaagc gttttaagca gattaaagat
+    11221 gattacgaca tcatcaacta ccattttccg tttccattca tggatatgtt gcatctctcg
+    11281 gcgcggcctg acgccagaac ggtggtgacc tatcactcgg atattgtgaa acaaaaacgg
+    11341 ttaatgaagt tgtaccagcc gctgcaggag cgattcctcg ccagcgtaga ctgcatcgtc
+    11401 gcctcgtcgc ccaactacgt ggcctccagc cagaccctga aaaaatatca ggataaaacc
+    11461 gtggtgatcc cgtttggtct ggagcagcat gacgtgcagc acgatccgca gcgggtggcg
+    11521 cactggcggg aaaccgtcgg cgataacttc ttcctcttcg ttggcgcttt ccgctactac
+    11581 aaagggctgc acattctgct ggatgccgcc gagcgtagcc ggctgccggt ggtgatcgtc
+    11641 gggggcgggc cgctggaggc ggaagtgcgt cgtgaagcgc agcagcgcgg gctgagcaat
+    11701 gtggtgttta ccggcatgct caacgacgaa gataaataca ttctcttcca gctctgccgg
+    11761 ggcgtggtct tcccctcgca tctgcgctcc gaggcgtttg gcattacgtt actggaaggc
+    11821 gcgcgcttcg ccaggccgct gatctcctgc gagatcggca ccgggacctc gttcattaac
+    11881 caggacaaag tgaatggctg tgtgatcccg ccgaatgaca gtcaggcgct ggtggaggcg
+    11941 atgaatgagc tctggcataa cgatgaaacc gccagccgct atggcgaaaa ctcgcgtcgt
+    12001 cgttttgaag agatgtttac tgccgaccat atgattgacg cttacgtcaa tctctacact
+    12061 acgctgctgg aaagcaaatc ctga
+//
+LOCUS       LT174598                8048 bp    DNA     linear   BCT 13-JUN-2016
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
+            cluster, type: OL10.
+ACCESSION   LT174598
+VERSION     LT174598.1  GI:1036211050
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
+            Enterobacteriaceae; Klebsiella.
+REFERENCE   1
+  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
+            Holt,K.E. and Thomson,N.R.
+  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
+            antigens
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 8048)
+  AUTHORS   Informatics,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
+            1SA, UNITED KINGDOM
+FEATURES             Location/Qualifiers
+     source          1..8048
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="QMP"
+                     /serovar="rfb_OL10"
+                     /db_xref="taxon:573"
+                     /note="O locus: OL10"
+                     /note="O type: O10"
+                     /note="Updated from OL103 by Tom Stanton in Feb 2025"
+     gene            1..192
+                     /gene="rmlC"
+     CDS             1..192
+                     /gene="rmlC"
+                     /EC_number="5.1.3.13"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006499571.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="dTDP-4-dehydrorhamnose 3"
+                     /protein_id="CZQ25265.1"
+                     /db_xref="GI:1036211051"
+                     /translation="MALSDTVQFVYKATNYYAPQSERSIIWNDPEIGIDWPALGDSALS
+                     LSEKDLQAHTLANAEVYI"
+                     /locus_tag="OL10_01_rmlC"
+     gene            266..1054
+                     /gene="wzm"
+     CDS             266..1054
+                     /gene="wzm"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_001336134.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="O-antigen export-TMD component"
+                     /protein_id="CZQ25266.1"
+                     /db_xref="GI:1036211052"
+                     /translation="MLKYFLKNKTLILKLAKRDIDSKYKGSFIGGFWAVVNPVIMLCVY
+                     SFVFSEVFKAKWGSLEGGKGTFAVVLFAGLIIFNFLAECLSRGPTLFTSNVNYVKKVVF
+                     PLGCLPFSIFLSAVFNFFISFIILLIAQLIVFNSVPWTILFFPLLLIPLFLIGFSLIVI
+                     FSTIGVYFRDIAQAVPIMITFLMFLSPIFYPLSAIPKSFQDVMMYNPLAFLIENTRDVL
+                     IFGKNMSIESYSILYISSIIFYIIAMKIFQKAKKGFADVL"
+                     /locus_tag="OL10_02_wzm"
+     gene            1044..2405
+                     /gene="wzt"
+     CDS             1044..2405
+                     /gene="wzt"
+                     /EC_number="3.6.3.40"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_001336133.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="O-antigen export-NBD component"
+                     /protein_id="CZQ25267.1"
+                     /db_xref="GI:1036211053"
+                     /translation="MSYNSVKCEAVIQVEHITKIFRIYNTPKDRIKEFLANLPRRVAGA
+                     KRIKKHKEFYSLNDVSLTINKGETIGIIGANGAGKSTLLQIICGTLSPTNGNVTVNGRV
+                     AALLELGAGFNPDFTGRENIFISASIMGLTDEQIKERFDSIVEFSEIGEFIEQPVKTYS
+                     SGMFVRLAFSIIAHVDADILIVDEALSVGDAFFVQKCMRFLRAFMEHGTVLFVSHDTAS
+                     IVNLCDRAIWIDHGQKKMEGSAKDVSEAYLAALFKQSNRNVSVKRQNKDVTEVVAYKDM
+                     RTSFINASNLRNDIELFSFNDESKQFGENGAEIYSVRLEDQNGEPLSWVVGGEEVKLRI
+                     SVKCLKSMFSPIIGFYIKDRLGQTLFGDNTYLSYMDTPLSMQPDDNMDSIFEFNMPILP
+                     VGEYSICVAVAEGSQQEHIQHHWIHDAVIFKSHSSSTVTGLVGIPMKNISISVN"
+                     /locus_tag="OL10_03_wzt"
+     gene            2419..6246
+                     /gene="hydrolase"
+     CDS             2419..6246
+                     /gene="hydrolase"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Predicted hydrolase (HAD superfamily)"
+                     /protein_id="CZQ25268.1"
+                     /db_xref="GI:1036211054"
+                     /translation="MTMINKSMLSRPRKLTFPFGWCGHIPFVSWLVEEMKPGTIVELGT
+                     HSGNSYFAICQAVLENNTGSKCYAVDTWQGDEHAGSYSEDVFRDVSAWNQQYFSAFSNL
+                     MRMTFDQANEYFSAGSVNLLHIDGLHTYEAVKHDFESWKSKLADDAVVLFHDTNVRERG
+                     FGVWQLWDELQQQYPSFEFLHSYGLGVLFVGKKSQALYEKLASFGEPALIREAFSRLGE
+                     LITLREEAHNHIQHIESARSVLESQNQELQHQLNKSKEENELYIKRIQEDKNIKNVMAG
+                     RIHELENSQHHISGNVHALEKEIERLINTNSWKITKPLRFMFRVLRGQQKDAMWHIKKE
+                     VRNIAKSAYYRTPYKYREQLLTMAFKVRPSWFTSHPKFMAAHSLISNELEVSDKLIDIN
+                     LLSDDINTQPGRIAVQCHIFYPDLIDEFVAQLSTMPFKFDVYISVTSEEAKQQCNLQFK
+                     KIKNIENLDVRVVPNRGRDIAPVFAEFGSALKQYDFICHIQSKKSLYNEGKTTGWREYL
+                     LNGLFGSESNVKRIFKAFNDDEKLGIVYPQVHHTLPYMAFTWLANKQQGSELCAKMGIA
+                     CPDGYFNFPAGSMFWARVDALSPLFEMNLAWQDFPEEKGQTDGTTAHAIERLLGIVPQA
+                     LNYGSLIIKDCENESKSTFRWDHQYFPRTLESIHQIISDPSKKVIAFDIFDTLLIRPLL
+                     HPDHTKQIIASQLSAEEASEFLSKRPAAEQSARHRAGRDISIDDIYNELQQHYQVEHSV
+                     AKKFRELEERVEIASVSARPDMLEIFEFVKKSGKKIAIVSDMFLPLETIVNMLESNGFT
+                     GWDKIYLSSDKGKRKDTGELYELLFTEYGVSGNEVVMIGDNERSDLQLPCDWFNILGLH
+                     LVRATDLALHIPEFAPVAQQAFKSDLNGELTFGLITKKNLSQICNFSPEKLKLFSSSPY
+                     QIGYNLAGPLLTAFAEWLRKCAAKDGVQDLYFLAREGKIIKAVYDLWCDGAETTPQSHY
+                     LILSRRAVNVPNVTTLDDVLNIAKSTFFANTLEMFLRERYGLTLPEGKLSSLYSSGLWA
+                     KGKLVEVHNEDISEIKPLLEYLLPDILAEAHAEKQGLLQYLQQEGFIKSAHKTVVDVGY
+                     SGTIQKSLINIVTDRVDGYYMATSEVAGKGLNNGSKAHGCFIENSVSLQNDNSLVLRHS
+                     FVLEKLLSSDDTQIVKYILENATVTPVYKQQRPEELITKDIRTELQKGCMDFVRDARDI
+                     RNTLYPDFSPSLTIADSLYSEFISSCNRKENDFVKKMTLDDDYCGRGLVN"
+                     /locus_tag="OL10_04_hydrolase"
+     gene            6301..7221
+                     /gene="spsA"
+     CDS             6301..7221
+                     /gene="spsA"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_005020985.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="WcaA"
+                     /protein_id="CZQ25269.1"
+                     /db_xref="GI:1036211055"
+                     /translation="MNRSVAILMAVRNGQEYLQPQLDSFLNQTYKNWCLYVSDDGSTDS
+                     TAEIVNNFYLSHPEISGFLKKGPCLGFCQNFQSMINDEKIIADYYAFSDQDDIWLPEKI
+                     ENAVRFLDSVPSDTPALYCSATTLIDQAGNIIGESLSPNKALSFANALLHNVASGNTMV
+                     FNHKARELLMAASSEEMVVHDWSLYQIVSACNGRIYFDHTPGVLYRQHSNNVIGDGRNI
+                     FLRVRNFFSSFKGNRADWNKRNKTVLDKIVAHFGENEKQVYYNYNNISKSRFLKRIYFY
+                     IKSGVYHQYKLGTLSTIIYVCVGKM"
+                     /locus_tag="OL10_05_spsA"
+     gene            7233..8048
+                     /gene="wbbL"
+     CDS             7233..8048
+                     /gene="wbbL"
+                     /EC_number="2.4.-.-"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_001336135.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyltransferase"
+                     /protein_id="CZQ25270.1"
+                     /db_xref="GI:1036211056"
+                     /translation="MNILASLVLYKHSFQEIELTLDSLLNEKNIDKLVIVDNGSFCTWL
+                     DDYKHDKVDVIRLTDNEGFGAGHNKVFEHYKNQCSYFLICNPDIYYAQGEVDKLFSFCK
+                     ENSVDLSVPKIIYPNGALQYATKLLPAPFQLFGRRFLSSFFPNINNEYELRNANFNAAF
+                     YAPSMSGCFMMVSNNAILQVQGFDLRFFMYLEDVDFSRRISAGNFNVVYCPDSTVVHLS
+                     QRKSYHSFKFLFYHMTSAIKYFNKWGWFFDKERQQLNKRCLSSLPTRSE"
+                     /locus_tag="OL10_06_wbbL"
+ORIGIN
+        1 atggcgctga gcgacacggt gcagtttgtc tacaaggcga cgaactacta cgcgccgcag
+       61 tcagaacgga gcatcatctg gaacgatccg gagatcggga ttgactggcc ggcgctgggc
+      121 gacagcgcac tgtcgctgtc ggagaaagat ctgcaggcgc acacgctggc caacgcggaa
+      181 gtgtatatct agtgatgacc tggattcggg ctcaaaaaat gaccagagcc tgaatccagt
+      241 atataaatta aggtatgtct aagcgatgct gaagtatttc ttgaaaaaca aaaccctcat
+      301 cttgaaactg gcgaaaagag atattgattc taaatataag ggatctttta tcggcggttt
+      361 ttgggcagtt gttaacccag taattatgtt atgtgtttat tcgtttgtat tttcagaagt
+      421 cttcaaggct aaatggggta gtttagaagg agggaaaggg accttcgcag tagtattgtt
+      481 tgctgggttg attatattca acttcttagc agagtgttta agtcgaggac cgacattatt
+      541 taccagtaat gtaaattacg ttaagaaagt tgtttttcca cttggctgtc ttccgtttag
+      601 catttttctt tcggccgtgt ttaatttctt tataagtttc ataattttgc tcattgctca
+      661 actaattgtc ttcaattcag tgccttggac aattttattc tttccgttgt tgttgattcc
+      721 tttgtttctt atcggttttt cattaattgt tattttttca accattggcg tatattttcg
+      781 agatatagct caggctgtgc caattatgat aacgtttctg atgtttttat ctccgatatt
+      841 ttatccgtta agcgcaattc ctaaaagttt tcaggatgtt atgatgtaca acccgttggc
+      901 gtttttaata gaaaacacac gggatgtatt aatctttggc aaaaacatgt caattgaatc
+      961 atattcaatt ctgtatattt caagtattat attttacatt attgcaatga aaatattcca
+     1021 gaaggctaaa aaaggttttg cagatgtcct ataattcagt taaatgcgaa gctgtcattc
+     1081 aagtagaaca tattacaaaa atttttcgca tctacaacac tccaaaggat cggataaaag
+     1141 aattcctggc aaatttacca cgccgagttg ctggggcaaa gcgtattaag aaacataaag
+     1201 agttctattc acttaatgat gtctccttaa ctattaataa aggagagaca attgggatca
+     1261 ttggtgccaa cggcgcaggt aagtcaaccc tattgcaaat tatttgtggg acgttgtcgc
+     1321 caacgaatgg caatgtaact gtaaatggta gagtggctgc tctattagag cttggtgctg
+     1381 ggtttaaccc tgatttcaca ggtagagaaa atatttttat atcagcatca ataatgggac
+     1441 taactgacga gcaaataaaa gaacgtttcg acagtatcgt tgagttttcc gaaattggag
+     1501 agtttattga gcaaccggta aaaacatatt ctagtggtat gtttgtacgg ttggcatttt
+     1561 caattatcgc tcacgttgat gcagatatct taatcgtaga tgaagcgctt tcggttggtg
+     1621 atgcgttctt tgttcaaaaa tgtatgcgtt ttctacgggc atttatggaa catggtactg
+     1681 tgctcttcgt tagccatgat accgcttcaa ttgtaaactt atgcgatcgt gctatctgga
+     1741 ttgatcatgg gcagaagaag atggaaggtt ctgcgaaaga tgtctcggaa gcttatcttg
+     1801 ctgcattatt taaacagagt aacaggaatg tatccgtcaa gcgtcaaaac aaggatgtta
+     1861 ctgaggttgt agcttataaa gatatgcgta ctagttttat taatgctagt aatttacgta
+     1921 atgatataga actgttttct tttaatgatg aaagtaaaca gtttggtgag aatggcgcag
+     1981 agatctatag tgtaaggcta gaggatcaaa acggtgaacc cttatcatgg gtagttggtg
+     2041 gagaagaagt taagcttaga ataagtgtta agtgcttgaa aagtatgttt agtccaataa
+     2101 tcggcttcta tataaaagac cgacttggac aaacattatt tggtgataat acataccttt
+     2161 cttatatgga tacaccactc agtatgcaac ctgatgacaa tatggatagc attttcgagt
+     2221 ttaacatgcc tatacttcca gtcggtgaat atagtatttg cgtcgcagta gcagaaggta
+     2281 gtcagcaaga acatatccaa catcactgga tacatgatgc ggtaattttt aaatcgcatt
+     2341 cttccagtac ggtgactggg ctagtcggta ttccaatgaa aaatattagt atctcggtga
+     2401 attaagagta attattttat gactatgatt aataaatcaa tgctttccag acctagaaaa
+     2461 ctgactttcc catttggctg gtgcggccat atcccctttg tcagttggct tgttgaggaa
+     2521 atgaaaccgg gtactattgt tgaattaggt acgcattcag gaaattcata ttttgcaatc
+     2581 tgccaggctg tcctggaaaa taataccggt tccaaatgct atgctgttga tacgtggcaa
+     2641 ggggatgagc atgccggtag ctacagtgaa gatgttttca gagatgtaag tgcatggaat
+     2701 cagcagtatt tctctgcatt ttcaaattta atgcgcatga cctttgatca ggcgaacgaa
+     2761 tatttttctg caggcagcgt taatttattg catatcgacg gcttacatac ctatgaagct
+     2821 gttaaacatg actttgaatc ctggaaatca aaattagcag atgatgcggt tgtcctgttc
+     2881 catgacacca atgtccgtga acgaggattt ggtgtatggc agctttggga tgaacttcaa
+     2941 caacagtatc catcttttga atttttgcat tcatatggct tgggtgtgct ttttgtaggc
+     3001 aaaaaaagcc aagctcttta tgaaaagttg gcttcttttg gtgagcctgc tctcattaga
+     3061 gaagcatttt cacgcctagg tgagttaatt actctgcgcg aagaagccca taatcatatc
+     3121 cagcatattg aatcagccag atccgttctt gagagtcaaa accaagaact tcagcatcaa
+     3181 cttaataaat caaaagaaga aaacgaactc tatataaaga gaattcagga agataaaaat
+     3241 attaaaaatg ttatggctgg cagaatccat gaactggaaa acagtcagca tcatatttcc
+     3301 ggcaatgtcc atgcactcga aaaggaaatt gagcggctga ttaatactaa ctcgtggaaa
+     3361 atcactaagc cgctaagatt catgtttcga gtactccgcg gccaacagaa agatgcgatg
+     3421 tggcatatta aaaaagaagt ccgtaatatt gccaagtcag cttattatcg aaccccttat
+     3481 aagtatcgcg aacaactatt aaccatggca tttaaggttc gacctagttg gttcactagt
+     3541 catcctaaat ttatggctgc tcattctctg atatcaaatg aattagaggt aagtgataag
+     3601 cttatcgata ttaatttatt aagtgacgat attaatacac agcctggaag aattgctgtt
+     3661 caatgtcata ttttttatcc agacttaatc gatgaatttg tggcacaatt gtcaacaatg
+     3721 ccgtttaagt tcgatgttta catttcagta acaagtgaag aagccaaaca acaatgcaat
+     3781 ctgcaattta agaagattaa aaatatcgaa aatctcgatg tgcgagtagt acctaatcgc
+     3841 ggtcgtgata ttgctccagt attcgccgag tttggttccg ccttaaaaca atatgatttt
+     3901 atttgtcata ttcaaagtaa gaagtcatta tataatgagg gaaaaacaac cggttggcga
+     3961 gagtatttac tgaatggttt gttcggttcg gaatctaatg taaaacggat atttaaagcc
+     4021 tttaatgatg atgaaaaatt agggattgtc tacccacagg tccatcatac tttaccttat
+     4081 atggcattta cctggctagc caacaaacag caaggcagtg aactttgcgc aaaaatggga
+     4141 atagcctgtc ctgatggata tttcaatttc cccgcagggt caatgttttg ggctcgtgta
+     4201 gacgctttgt ccccgttatt cgagatgaat ttagcgtggc aagattttcc tgaagaaaaa
+     4261 ggacagactg atgggactac agcacatgca attgaacgtt tgttaggtat agtccctcag
+     4321 gctttgaatt atggttcatt aattataaaa gactgtgaga atgagtcaaa atccactttc
+     4381 cgttgggatc atcaatattt ccctagaacg ttagagtcga ttcatcaaat aatttctgat
+     4441 ccaagcaaaa aagttattgc ttttgatatt tttgatactt tgttgattcg tcctttactt
+     4501 catcctgacc atacaaaaca gatcattgcc agccaattgt ctgctgagga agcgtccgag
+     4561 tttctgtcta aaaggcctgc cgcagagcag agtgcaaggc accgcgctgg gcgggatatc
+     4621 agtattgacg atatctataa tgaattgcag caacattatc aggttgaaca ttcagtcgcc
+     4681 aaaaagtttc gtgagctcga agaacgggtt gaaattgctt ctgtttcggc tcggccggat
+     4741 atgttggaaa tttttgagtt tgttaaaaag agtggtaaaa aaatcgctat tgtcagcgat
+     4801 atgtttttac cgcttgaaac tatcgttaat atgctcgaat ctaatggttt taccggatgg
+     4861 gataaaattt atttatcatc agataaaggt aaaagaaagg atacgggtga actgtacgag
+     4921 cttcttttta ccgagtatgg tgtttccggt aatgaagtcg tgatgattgg tgataacgag
+     4981 cgaagtgatt tacagttacc ttgcgattgg tttaacatcc tcggtttgca tcttgtgaga
+     5041 gctacggact tagcacttca tattccggag tttgcaccag tagcacagca ggcctttaag
+     5101 tcagatctta acggagaact tacttttggc cttataacga agaaaaattt gagtcaaatt
+     5161 tgtaattttt ctcccgaaaa acttaagcta ttctcttcta gtccctatca aattggttat
+     5221 aatcttgctg ggcccttgct tactgcattt gctgaatggc ttagaaaatg cgctgcaaaa
+     5281 gacggcgtgc aggacttata ttttcttgcg agagaaggga aaatcattaa agcagtttat
+     5341 gatctttggt gtgatggagc ggaaacgaca cctcaaagtc attatctgat actgtctcgt
+     5401 cgtgcggtta acgtaccaaa tgtgacaaca ttggatgatg tactgaatat agctaagtcg
+     5461 actttttttg ctaatacgct cgagatgttt ttacgtgaac gttacggatt aactcttccg
+     5521 gaaggaaaac tatcttcttt atactcctct gggctgtggg ctaaaggcaa attagtggag
+     5581 gttcataatg aagatatttc tgaaatcaaa ccattactgg aatatctact gccagatatc
+     5641 cttgctgaag cacatgctga aaaacagggc ttattacaat accttcagca agaagggttt
+     5701 ataaagtcag cccacaaaac agttgttgat gtcggatatt ccggtacgat ccagaaatca
+     5761 cttattaata tcgtaactga cagggttgat ggttattata tggcaacatc tgaagttgca
+     5821 ggaaaaggat tgaataacgg aagtaaggcg catggttgtt ttattgagaa ctctgtctcc
+     5881 ctgcagaatg ataattcatt agttttgcgc catagcttcg tactagagaa attgttaagc
+     5941 tcggatgata cccaaattgt taaatatatc ctggaaaacg cgaccgttac gccagtatat
+     6001 aaacaacagc gtccagaaga gcttataaca aaagacatca gaacggagtt acaaaaaggc
+     6061 tgcatggatt tcgttcgtga tgcaagagat atacgaaata cgctttaccc tgatttttcg
+     6121 ccttcattga caatagctga ttctttatat agtgagttca tttcaagttg caatcgaaaa
+     6181 gaaaatgact tcgtgaaaaa aatgacctta gatgatgatt attgtggtcg tggtttagta
+     6241 aattaaatta aaaataaccc ctctatctgc ggatagcaga tagaggggca gggtttcaga
+     6301 atgaaccgaa gtgttgctat tttaatggct gtaagaaatg gtcaggagta ccttcagcct
+     6361 caacttgatt catttcttaa ccaaacatat aagaactggt gtttatatgt ttctgatgat
+     6421 ggctcgaccg attcgacagc cgaaattgtt aataactttt atctttctca tccagagatt
+     6481 tctggttttc taaaaaaagg cccttgtctt ggtttctgcc aaaattttca gtccatgatc
+     6541 aacgatgaaa aaatcattgc tgattattat gctttttctg accaggacga tatttggcta
+     6601 cccgaaaaaa tagaaaatgc agttcgcttt ctggacagtg tcccctcaga tactcctgct
+     6661 ctctattgct cggctactac tcttatcgat caggctggta atattattgg ggaatcactt
+     6721 tcacccaata aggcactcag ttttgccaat gctctgttgc ataatgttgc tagcggcaat
+     6781 actatggtat tcaatcataa agccagagag ttattaatgg ctgcctcgtc tgaagaaatg
+     6841 gtggtacatg attggtcgct ctatcagata gtaagcgcat gcaatggacg catttatttt
+     6901 gatcacaccc ctggagtgtt gtatcgccaa catagtaata atgtgattgg tgatggacgt
+     6961 aatatttttc tacgtgtgcg taatttcttt tcatctttta aaggaaatcg cgcagactgg
+     7021 aataaacgga ataaaaccgt tctcgataag atagtggctc acttcggtga gaatgaaaag
+     7081 caagtttatt ataactataa taatataagt aaaagtaggt ttttgaaaag gatttatttt
+     7141 tacataaaat ctggtgttta ccatcaatat aaactcggta cattatcaac cataatttat
+     7201 gtttgtgttg ggaaaatgta gtaaggtgct atgtgaatat actagcttcg cttgttcttt
+     7261 ataaacattc ttttcaagaa attgagctta cgcttgattc gttattaaat gaaaagaata
+     7321 tcgataaact agttatagtg gataatggtt ctttttgtac ctggttggat gattataagc
+     7381 acgataaagt tgatgtcata agattaactg ataatgaagg ttttggcgca gggcataata
+     7441 aagtttttga acattataaa aaccaatgta gttatttttt gatttgtaat cctgacattt
+     7501 actatgctca gggcgaggtt gataaactgt tttccttttg taaggaaaat tcggtcgacc
+     7561 tttcagtccc taaaatcata tatccaaatg gtgcattgca atatgcgaca aagctattgc
+     7621 cggcaccatt tcaacttttc ggacgtcgat ttctctcatc attttttccc aacataaata
+     7681 atgagtatga attgcgtaac gctaatttta atgctgcatt ctacgcgcca tcgatgtcag
+     7741 gatgttttat gatggtgagc aataacgcca ttctacaagt tcaaggtttc gaccttcgat
+     7801 tcttcatgta tttagaggat gtcgattttt cgcgccgtat cagtgcgggg aattttaatg
+     7861 ttgtttattg tcctgattct acagtcgttc atctatcgca aagaaaatca tatcacagct
+     7921 ttaaattcct gttttatcat atgacctctg cgattaaata tttcaataag tggggttggt
+     7981 tttttgataa agaaagacaa caactcaaca aacgttgtct ttcatcatta cccaccagat
+     8041 cggaataa
+//
+LOCUS       LT174600                9797 bp    DNA     linear   BCT 13-JUN-2016
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
+            cluster, type: O12.
+ACCESSION   LT174600
+VERSION     LT174600.1  GI:1036211066
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
+            Enterobacteriaceae; Klebsiella.
+REFERENCE   1
+  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
+            Holt,K.E. and Thomson,N.R.
+  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
+            antigens
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 9797)
+  AUTHORS   Informatics,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
+            1SA, UNITED KINGDOM
+FEATURES             Location/Qualifiers
+     source          1..9797
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="AKPRH094188"
+                     /serovar="O12"
+                     /db_xref="taxon:573"
+                     /note="O locus: OL12"
+                     /note="O type: O12"
+     gene            1..1065
+                     /gene="rfbB"
+     CDS             1..1065
+                     /gene="rfbB"
+                     /EC_number="4.2.1.46"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006499574.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="dTDP-glucose 4"
+                     /protein_id="CZQ25279.1"
+                     /db_xref="GI:1036211067"
+                     /translation="MKILVTGGAGFIGSAVVRHIIENTLDEVRVMDCLTYAGNLESLAP
+                     VAGSERYSFSQTDITDAAAVAAQFSEFRPDIVMHLAAESHVDRSIDGPAAFIQTNVIGT
+                     FTLLEAARHYWSGLGEAQKQAFRFHHISTDEVYGDLHGTDDLFTEETSYAPSSPYSASK
+                     AGSDHLVRAWNRTYGLPVVVTNCSNNYGPYHFPEKLIPLTILNALAGKPLPVYGNGEQI
+                     RDWLYVEDHARALYKVATEGKSGETYNIGGHNERKNIDVVRTICTILDKVVAQKPGNIT
+                     HFADLITFVTDRPGHDLRYAIDATKIQRDLGWVPQETFESGIEKTVHWYLNNQTWWQRV
+                     LDGSYAGERLGLNK"
+                     /locus_tag="OL12_01_rfbB"
+     gene            1080..1949
+                     /gene="rfbA"
+     CDS             1080..1949
+                     /gene="rfbA"
+                     /EC_number="2.7.7.24"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006499573.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glucose-1-phosphate thymidylyltransferase"
+                     /protein_id="CZQ25280.1"
+                     /db_xref="GI:1036211068"
+                     /translation="MKGIVLAGGSGTRLYPITQGVSKQLLPIYDKPMIFYPVSVLMLAG
+                     IRDILIISTPEDMPSFQRLLGDGSQFGVNFSYAIQPSPDGLAQAFIIGEKFIGNDACAL
+                     VLGDNIYFGQSFGKKLEAAAAKTSGATVFGYQVLDPERFGVVEFDEHFKALSIEEKPLK
+                     PKSNWAVTGLYFYDNNVVEMAKDVKPSARGELEITTLNQMYLERGDLHVELLGRGFAWL
+                     DTGTHDSLMDASQFIHTIEKRQGMKVACLEEIGYRNKWLSAEGVATQAERLKKTEYGAY
+                     LKRLLNER"
+                     /locus_tag="OL12_02_rfbA"
+     gene            1981..2871
+                     /gene="rfbD"
+     CDS             1981..2871
+                     /gene="rfbD"
+                     /EC_number="1.1.1.133"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_005227856.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="dTDP-4-dehydrorhamnose reductase"
+                     /protein_id="CZQ25281.1"
+                     /db_xref="GI:1036211069"
+                     /translation="MKILLIGKNGQVGWELQRSLSTLGDVVAVDYFDKELCGDLTNLEG
+                     IAQTVRIVRPDVVVNAAAHTAVDKAESERELSDLLNDKGVAVLAAESAKLGALMVHYST
+                     DYVFDGAGSHYRREDEATGPLNVYGETKRAGELALEQGNPRHLIFRTSWVYATRGANFA
+                     KTMLRLAGEKETLTIIDDQHGAPTGAELLADCTATAIRETLRNPALAGTYHLVASGETS
+                     WCDYARYVFEVARAHGAELAVQEVKGIPTTAYPTPAKRPLNSRLSNEKFQQAFGVTLPD
+                     WRQGVARVVTEVLGK"
+                     /locus_tag="OL12_03_rfbD"
+     gene            2886..3440
+                     /gene="rfbC"
+     CDS             2886..3440
+                     /gene="rfbC"
+                     /EC_number="5.1.3.13"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006499571.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="dTDP-4-dehydrorhamnose 3"
+                     /protein_id="CZQ25282.1"
+                     /db_xref="GI:1036211070"
+                     /translation="MNIIKTDIPDVLIFEPRVFGDARGFFFESFSSKVFNEAVGRQVEF
+                     VQDNHSQSQKGVLRGLHYQLDPHAQGKLVRCVEGEVFDVAVDIRRSSPTFGKWVGAVLS
+                     AENKRQLWIPEGFAHGFMALSDTVQFVYKATNYYAPQSERSIIWNDPEIGIDWPALSDC
+                     VLSLSEKDLRAHTLATAEVYA"
+                     /locus_tag="OL12_04_rfbC"
+     gene            3531..4361
+                     /gene="wbbL"
+     CDS             3531..4361
+                     /gene="wbbL"
+                     /EC_number="2.4.-.-"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_001336135.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyltransferase"
+                     /protein_id="CZQ25283.1"
+                     /db_xref="GI:1036211071"
+                     /translation="MNYKAMKPKVIASIVLFNHSYDDIKDTFLSLCHEESVEKIIFVDN
+                     GGCQWAASLNEPKVSYIKSPYNCGFGAGHNLAIKASADFDGYFLICNPDISFDKQSLDK
+                     LVSFAWENEYSFVSPQIIYRNGERQYSCRLLPTPGNLFLRRFFPVTAIKYDVKYELKDA
+                     AYDEIFSPPTVSGCFMLLSNVLLQKLNGFDERYFMYLEDVDLCRRALQLTKIYYYPGTT
+                     IVHAFNKGSYKSKLLLWYHIRSAVSYFNKWGWFLDRKRHAYNKQAIYEIPKKII"
+                     /locus_tag="OL12_05_wbbL"
+     gene            4391..5224
+                     /gene="wzm"
+     CDS             4391..5224
+                     /gene="wzm"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_001336134.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="O-antigen export-TMD component"
+                     /protein_id="CZQ25284.1"
+                     /db_xref="GI:1036211072"
+                     /translation="MKNPHQKLSSSPLAVVRSIATHWSIILQMAKRDVVGRYKGSVMGL
+                     LWSFLNPLFMLTVYTFVFSVVFKARWSTGGDESRTQFAIILFVGMIVHGFLSEVVNKAP
+                     LIILGNTNYVKKVIFPLETLPVISLFAALFHTCISLCVLLMAFFIFNGYLHWTIVFLPV
+                     VFFPLIIFCLGISWILASLGVFLRDVSQTTVIITTVLMFLSPVFFPISALPEKYHIWIM
+                     LNPLTFIIEQARTVLIWGGMPNFIGLFLYSLGALVIAWMGFAFFQKTRKGFADVL"
+                     /locus_tag="OL12_06_wzm"
+     gene            5214..6536
+                     /gene="wzt"
+     CDS             5214..6536
+                     /gene="wzt"
+                     /EC_number="3.6.3.40"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_001336133.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="O-antigen export-NBD component"
+                     /protein_id="CZQ25285.1"
+                     /db_xref="GI:1036211073"
+                     /translation="MSSNEIAIQVTNLSKCYQIYARPTDRLKQFFVPKLQQVVRRERNC
+                     YFREFWALDDVSFSIKKGETVGIIGRNGAGKSTLLQIICGTLTPSAGDVRVNGRIAALL
+                     ELGAGFNPEFTGRENVYLNGSVLGLTKEQIAAKFAEIEEFADIGQFIDQPVKTYSSGMY
+                     VRLAFAVQACVEPEILIVDEALAVGDIGFQYKCYKRMEALRAKGVTIIMVTHSTGSILE
+                     YADRCLVMEHGKLIGDTNDVLAAVLAYEKGMILANDKPEPTKLAENRSSETCSLEDLKS
+                     IQLHTANEEIGEKRFGTARAIIKNLTIYKSDGTTLTEKPLIKSGEEVTFDFTILATEEI
+                     KDVALGLSISKAQGGDIWGDSNIGAGSPITLRPGSQRIVYKATLPINSGDYLIHCGLAM
+                     VGNGAREELDQRRPMMKIKFWSARELGGVIHAPLKIITNGE"
+                     /locus_tag="OL12_07_wzt"
+     gene            6540..9797
+                     /gene="wbbB"
+     CDS             6540..9797
+                     /gene="wbbB"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_001336132.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyltransferase"
+                     /protein_id="CZQ25286.1"
+                     /db_xref="GI:1036211074"
+                     /translation="MFAVFLPPYPFRGVKAPYLWLFLKYLHCSNEKILFITSPDYVEVI
+                     NDETQHSRWEFDTASMASLGYSLPDEQSLARHEYLYLDHALYETMLAQHHHDPIKSFTT
+                     FLTESISELENELFSLLTKEIIQRVDAFVSICNCPSLEKVARALNKEVIHLEIGPLRAP
+                     MYRNTAYLDFTGVNGNTEARARYESCQTEIDITCSMNDLHRYFLEAISLPSSSENQVAG
+                     IVLQVEDDSNIIAYSHNFTNISLISYVRQQHALENILVRAHPGSLFRLRDDIFSIDASA
+                     NSLEFIQKCHSIYTINSSVGLEALLCEKKTNILGDCSYAFVAEEASGPNRVNAMAFYLF
+                     AYLVPFELIFNLEYLRFRLDHPAELDIVRKHLQFYSKMPDEREENSHTLSTLINEAISK
+                     DITMRTILENSLAENNKQLEDLKTQLAAEVTEREKLAAAITKLQQTADLAAKDREILVS
+                     ALAVKEDEVDRMRRSLSWKLTMPVRMSGRISRGEFSTIKAMMREYTTSGNNVFSRYILS
+                     GGLLSKSKYKTAIRLLLSGNWSGMVDGFKRVLSRAAIDSSPATPFVDNVTVRILATQHT
+                     LFVAHLIEKNLLDCGIKGHVSTAYSVEQDMGQMHIVVCPQMFKQLPRNYIAFQMEQSVN
+                     SRWFTDEYFSRLNNAVAIFDYSLKNIEYLLDKGIPYQKLFYMPISSFPDYPAHLADNGY
+                     VLDDQKGDIHADVLFYGDPNCERRKAYLQELKKHFNVTVASEVFGDKLTRMVKNAKVVV
+                     NIHYYENALLETTRLYETISLGTPVVSESSSDIVEHEDLQDVIDFCPIGDIPAMVEKIQ
+                     NLLSDKEYYNERKEKIKHFTNVDNKNNYYLRRYLLSIDKLNFSQYKSIFSFEQFQTGDV
+                     PRLCLSLSETPVRRKAFFASPSHGFQFFEGIRYRIGWIGCGMSYKYMLSGMLASKAEMG
+                     IICEDDVIFPVDYDNKLNKIINHLQSTEAKWHIFAGIIAHLHEDTKVLDVKVIDGIEYI
+                     YIDKMTSMVMNIYSRRGMDLISQWDEKNIDAETNTIDRYVESAQDLVVVTTLPFLVGYA
+                     EEQQSTLWGFENSQYTSLIKASEKLLAEKVAEFKKNR"
+                     /locus_tag="OL12_08_wbbB"
+ORIGIN
+        1 atgaagattc ttgtcaccgg gggcgcaggc tttatcggtt ctgccgtggt tcgtcatatc
+       61 attgaaaata ccctggacga agtccgtgtg atggactgcc tgacctacgc cggcaacctc
+      121 gaatccctgg cgccggtggc cgggagtgaa cgctactcgt tttcccagac cgatatcacc
+      181 gatgccgctg ccgtggcggc ccagttcagc gagttccgcc cggatatcgt gatgcacctg
+      241 gcggcagaaa gccatgtgga ccgttccatt gatggcccgg ccgcgtttat ccagaccaac
+      301 gtgatcggca ccttcactct gctggaggcg gcccgtcact actggtccgg gcttggggaa
+      361 gcgcagaagc aggccttccg cttccatcat atctccaccg atgaagtgta tggtgacctg
+      421 cacggcaccg atgacctgtt caccgaagag acttcgtacg ccccgagcag cccgtactcc
+      481 gcctccaaag cgggcagcga ccatctggtt cgcgcctgga accgcaccta cggcctgccg
+      541 gtggtggtga ccaactgctc caacaactat ggtccgtatc acttcccgga aaaactgatc
+      601 ccgctgacta tccttaatgc cctggcgggt aaaccgctgc cggtatatgg caacggggag
+      661 cagatccgtg actggctgta tgttgaggac catgcccgtg cgctgtacaa agtggcgacc
+      721 gaaggcaaga gcggcgagac ctacaacatc ggcggtcata acgagcgtaa aaatatcgat
+      781 gtggtgcgca ccatctgcac cattctcgac aaggtggtgg cgcagaagcc gggaaacatc
+      841 acccactttg ctgacctgat cacttttgtc actgaccgtc cgggacatga cctgcgctac
+      901 gctattgatg ccacgaaaat tcagcgcgat ctgggctggg tgccgcagga aacgttcgag
+      961 agcgggattg agaaaaccgt gcactggtac ctgaacaacc agacctggtg gcagcgtgtg
+     1021 ctggacggct cctatgccgg cgagcgtctt ggcctgaata aataaaaaag gaactgaaga
+     1081 tgaagggcat tgttctggcc ggcggctccg gcacgcgttt atatcccatc acccagggcg
+     1141 tctccaagca gctgctgcct atctacgaca agccgatgat tttctacccg gtgtctgtcc
+     1201 tgatgctggc gggcattcgc gatatcctta tcatctccac gcctgaagac atgccttcct
+     1261 tccagcgcct gctgggtgac gggtcgcagt tcggggtgaa cttcagctac gccatccagc
+     1321 cgtcgccgga cggtctggca caggccttta tcattggcga gaagtttatc ggcaacgatg
+     1381 cctgcgccct ggtgctgggg gataatatct actttggcca gagcttcggt aaaaagctgg
+     1441 aagcagcggc ggcgaagact tctggtgcca cggtgtttgg ttaccaggtg ctggatccgg
+     1501 agcgcttcgg cgtggtggag tttgacgagc acttcaaagc gctgtcaatt gaagagaaac
+     1561 cattaaagcc gaaatcaaat tgggccgtaa ctggtctcta tttctacgac aataacgtgg
+     1621 tggagatggc gaaggacgtg aaaccttcag cacgcgggga actcgagatc accaccctca
+     1681 accagatgta tctggagcgc ggtgacctgc atgtggaact gctggggcgc ggctttgcct
+     1741 ggctggatac aggcactcat gacagcctga tggacgcatc acagttcatt cacaccattg
+     1801 aaaagcgcca ggggatgaag gtcgcgtgcc tggaagagat cggttaccgc aacaaatggt
+     1861 tgtcggcgga aggggtggcg actcaggccg aacgcctgaa gaaaaccgag tacggtgctt
+     1921 atctcaagcg cctgctgaac gagcgttaat gccttcttcg tcaacgacag gatacagaga
+     1981 atgaagattt tactgattgg caagaatggc caggtgggct gggagctgca gcgttccctg
+     2041 tccaccctcg gcgacgtggt cgcggtggat tattttgata aagagctgtg cggtgacctg
+     2101 acgaacctgg aaggcatcgc gcagacggtg cgtatcgtcc gcccggatgt ggtggtgaat
+     2161 gccgccgcgc acacggccgt ggacaaggca gaaagcgagc gggagctctc cgacctgctg
+     2221 aacgacaaag gggtggcggt gctggcggcg gagtcggcga agctcggtgc cctgatggtg
+     2281 cactattcca ccgattatgt gttcgacggc gccggcagcc attatcgccg ggaagatgag
+     2341 gcaaccggcc cgcttaacgt ctacggtgaa accaagcgtg ccggtgagct ggccctggag
+     2401 cagggcaacc cgcgtcacct gattttccgt accagctggg tgtatgccac ccgcggcgcc
+     2461 aactttgcca aaaccatgct ccgcctggcg ggggagaaag agaccctcac catcattgac
+     2521 gaccagcacg gggcgcccac cggcgctgag ctgctggcag actgcacggc gacggcaatc
+     2581 cgtgaaacgc tgcgtaatcc ggcgctggcc ggcacgtatc acctggtggc cagcggtgaa
+     2641 accagctggt gcgactatgc ccgctatgtg tttgaagtgg cgagagcgca cggtgccgag
+     2701 ctggcggtgc aggaagtgaa gggcattccg acgacggcct atccgacgcc ggcgaagcgt
+     2761 ccgctcaact cgcgcctgtc gaatgaaaaa ttccagcagg cattcggggt gactctcccg
+     2821 gactggcgtc agggtgtggc tcgcgtggta acagaagtcc tgggtaaata aacggttagc
+     2881 aaaagatgaa cattattaaa acagatattc ctgacgtgct gatttttgaa ccgcgcgtgt
+     2941 ttggtgatgc gcggggcttc ttctttgaga gcttcagcag caaggtgttt aatgaggcgg
+     3001 tgggccgtca ggtggaattc gtccaggaca accattcaca gtcccagaaa ggcgtattgc
+     3061 gcgggctgca ctatcagctg gatccgcacg ctcagggcaa gctggtccgc tgtgtggaag
+     3121 gtgaggtgtt tgacgtggca gtggatatcc gtcgttcatc gcctaccttt ggtaaatggg
+     3181 ttggagcggt gctcagcgca gagaataaac gtcagctgtg gatccctgaa ggattcgccc
+     3241 acgggtttat ggcgctgagc gacacggtgc agtttgtcta taaggcgacg aactactacg
+     3301 cgccacagtc agaacggagc atcatctgga acgatccgga gatagggatt gactggccgg
+     3361 cactgagcga ctgcgtgctg tcgctgtcgg agaaagacct gcgggcacat actctggcca
+     3421 ctgcggaagt ctacgcttaa gtataaatat tcttgttcga taatggatat cacaagttac
+     3481 tatcaaaaat aataataata aatatttttt atcctaaagg taatcgatta atgaattata
+     3541 aagcaatgaa gcctaaagtt atcgcttcta ttgtattatt taatcattcc tatgatgata
+     3601 ttaaagatac gttcctctca ttatgccatg aagagagcgt tgaaaaaata atcttcgttg
+     3661 ataatggtgg ttgtcagtgg gcggcatcat tgaatgaacc taaggtgagc tacataaagt
+     3721 ctccttacaa ctgtggtttt ggtgctggac ataatcttgc aataaaagca agtgcagact
+     3781 ttgacggtta tttcttgata tgtaatccgg atattagctt tgataagcag tcacttgata
+     3841 aattagtttc gtttgcgtgg gaaaatgagt atagttttgt ttccccgcaa ataatatata
+     3901 gaaatggtga gagacaatat agttgccgtc tactacctac tcccggtaat ctttttttaa
+     3961 gacgtttctt tccagtgact gcaataaagt acgatgttaa atatgaactg aaagatgcag
+     4021 cctatgatga gatattttcc ccaccaacgg tatctggttg tttcatgtta ttaagtaatg
+     4081 tattattaca aaaacttaac ggttttgatg aacgatactt tatgtatctg gaagatgtag
+     4141 atttatgtcg ccgagcatta cagctaacca aaatatatta ttatcctgga acaactattg
+     4201 tccatgcctt taataaaggt tcgtataaaa gcaaattatt actttggtac catattcgct
+     4261 ccgcagtctc ctattttaat aaatggggat ggtttcttga tcgtaaaaga catgcgtata
+     4321 ataagcaagc catatatgaa attcccaaaa aaataattta atattatttg ccataaaata
+     4381 cgagtttaaa atgaaaaacc ctcatcaaaa actttcatca tcaccattag cagtggtgcg
+     4441 cagtattgcc actcactgga gtattattct gcagatggct aaacgtgatg ttgttggaag
+     4501 atataaaggt tctgtgatgg gcctgctttg gtcttttctg aaccctttat ttatgttaac
+     4561 agtatatact tttgtcttct ccgtggtatt caaagccaga tggtcaactg gtggggatga
+     4621 aagcaggaca cagtttgcta taattttatt tgtcggaatg atagttcatg gttttttaag
+     4681 tgaagtggta aataaagcac cgttgattat tttgggaaat acaaactatg tgaagaaagt
+     4741 tatatttcca ttggaaacgc tgcctgttat ctctttattt gcggcattat ttcatacttg
+     4801 tatcagcctt tgtgtgttac tgatggcgtt tttcattttt aatggatatt tacattggac
+     4861 catagtattt ttacctgtgg tctttttccc tttaattatt ttttgccttg gcatttcgtg
+     4921 gatcttagca tcacttggcg tattcctaag agatgtaagt caaactacgg taatcattac
+     4981 tacagtatta atgtttttat caccggtatt cttccctata agcgccttgc ctgaaaagta
+     5041 tcatatctgg atcatgctca atccattaac ctttattatt gaacaagccc gaacggttct
+     5101 tatttggggt ggtatgccta attttatcgg tctgttttta tattctttgg gtgccttagt
+     5161 catagcctgg atgggttttg ccttcttcca gaaaaccagg aagggatttg ctgatgtcct
+     5221 ctaatgaaat tgccattcag gttacaaacc tgagtaaatg ttatcagata tatgcgcgtc
+     5281 caactgatcg tctaaaacag ttttttgtgc cgaaacttca acaggtggtc cgcagagagc
+     5341 gaaactgcta ttttcgtgag ttttgggccc tcgatgacgt ttccttcagt atcaaaaaag
+     5401 gggaaacggt aggtattatt ggacgaaatg gtgccgggaa gtcgactttg ctgcagatta
+     5461 tctgcggcac actaaccccc tccgctggag atgtacgtgt taatgggcgt attgctgcat
+     5521 tacttgaatt aggtgctggg ttcaacccgg agtttaccgg tcgtgagaac gtttatttaa
+     5581 atggttcggt attaggttta accaaagagc agattgcggc taagtttgct gaaattgaag
+     5641 aatttgcaga tatcggccag ttcattgatc aacccgtaaa aacatactct agcggtatgt
+     5701 atgtccgttt agcctttgcc gttcaagcat gtgttgaacc ggaaattttg attgttgatg
+     5761 aggcgttagc tgttggcgat attggcttcc agtataaatg ctataaacgg atggaagcat
+     5821 tacgtgcgaa aggtgtaacc atcattatgg taactcattc aacaggcagc atccttgagt
+     5881 atgctgatcg ctgcctggtg atggaacacg gaaaactaat cggtgatacc aatgatgttc
+     5941 tcgctgcagt tctggcctat gagaaaggga tgatcctggc caacgataaa ccagagccta
+     6001 caaaacttgc agagaaccgc tcttctgaaa cttgcagttt ggaagacctc aaaagcattc
+     6061 agttacatac tgctaatgaa gaaattgggg aaaaacgttt tggtactgcg cgtgctatta
+     6121 ttaaaaacct taccatctac aaatcagatg gtacgacttt gacagagaaa ccactcatca
+     6181 aatcaggtga agaagttaca tttgatttca ccatattagc taccgaagag attaaggatg
+     6241 ttgctcttgg cctttccata tccaaagctc agggagggga tatttgggga gatagtaata
+     6301 ttggcgcagg ttcgccaatt acacttcgtc caggtagtca gcgtatcgtt tataaagcaa
+     6361 cgctgcctat aaattcgggc gattacctaa tacactgcgg cctcgctatg gttggcaacg
+     6421 gtgctcgaga ggagcttgat caacgtcgcc cgatgatgaa aataaagttt tggtcggcca
+     6481 gagagctagg cggggtcatt catgctccgt taaaaatcat tacaaatgga gagtaaagca
+     6541 tgtttgctgt ttttcttcct ccatatccgt tcagaggggt gaaagcccct tatttatggc
+     6601 tttttttaaa gtatttgcat tgttcaaacg aaaagatact atttatcaca agtcctgatt
+     6661 atgttgaagt aataaacgat gaaacgcaac attcccgttg ggagtttgat actgcctcga
+     6721 tggcatcttt aggatattct cttcctgatg aacaaagcct tgccagacat gaatatctgt
+     6781 accttgatca tgctttgtat gaaaccatgt tggctcaaca tcatcatgat cccataaaat
+     6841 catttaccac atttttaacc gaatctattt ccgagcttga aaatgagtta ttctctttac
+     6901 ttacaaagga aataattcaa cgtgttgatg cttttgtctc tatctgcaac tgtccatcgc
+     6961 ttgaaaaagt cgcaagagct ttaaataaag aggttataca ccttgagatc gggccattgc
+     7021 gagccccgat gtatcgcaat acagcatatc tggatttcac cggcgttaat ggtaataccg
+     7081 aggctcgggc acgctatgaa tcttgccaga cggaaattga tattacgtgc tcaatgaatg
+     7141 atttgcatcg ttattttctt gaagcaatct cattaccttc gtcaagtgaa aaccaagttg
+     7201 ctgggattgt gttacaggta gaagacgatt ccaatatcat tgcttacagc cataatttta
+     7261 cgaatatatc tttaatttct tatgttcgtc aacagcatgc tctcgagaat atattggttc
+     7321 gggcgcatcc tgggagtttg tttcgtttac gagatgacat atttagcatt gatgcatcgg
+     7381 caaacagcct cgaatttatt caaaaatgtc attctattta tactattaac tcaagtgttg
+     7441 gcttagaggc gcttttatgc gagaaaaaga ctaatattct cggtgattgt tcctatgctt
+     7501 ttgtcgctga ggaggcctca ggtcccaaca gagtaaatgc catggcattt tatctgtttg
+     7561 cttatctggt gccctttgaa cttatattta atctggaata tttgcgattc aggttggacc
+     7621 atccagcaga gctggatatc gtacgtaaac acctgcaatt ttattctaaa atgccggatg
+     7681 agcgtgaaga aaacagccat acgctgtcaa cattaataaa cgaagcgatt tccaaagata
+     7741 tcaccatgag aaccatttta gaaaactcat tagccgagaa taacaaacaa cttgaagatt
+     7801 tgaaaacgca gcttgctgcc gaggttactg agcgcgaaaa attagctgca gcgattacca
+     7861 aactccagca aacggcagac ttggcagcaa aagacaggga gatattagtt tccgccctgg
+     7921 cagtcaaaga agatgaagta gatcgtatgc gcagaagtct gtcatggaag ttaaccatgc
+     7981 cagttcgtat gtctggtagg atttcccgag gtgaatttag cactataaaa gcaatgatga
+     8041 gggaatacac gacttccggt aataatgttt tttctcgcta tattttatcg ggtggacttc
+     8101 tttcaaaatc gaaatataaa acggcaattc gtcttctatt gtcaggaaac tggtcaggga
+     8161 tggttgatgg ttttaagcgt gttttaagcc gagctgctat cgactcttca ccagctacgc
+     8221 catttgtcga taatgtaacg gtaagaattc ttgctactca gcatacccta ttcgttgcac
+     8281 atttgattga aaagaatctg cttgattgcg gaattaaggg ccatgtcagt actgcttatt
+     8341 ccgttgagca ggatatgggg cagatgcaca ttgtagtttg tccgcaaatg ttcaaacaac
+     8401 tgccccgtaa ctacattgct ttccagatgg agcagtcggt caactcaaga tggtttaccg
+     8461 atgagtattt ttctcgtctc aataatgctg ttgctatttt tgattattcc ttgaaaaata
+     8521 ttgaatattt actggataaa ggcattccgt atcagaaatt gttttatatg ccgatttcca
+     8581 gctttccaga ttacccagcc catttagcag ataacggtta tgtactggat gatcagaaag
+     8641 gtgatataca cgcagatgtt ctattctatg gcgatccaaa ctgtgagcgc cgcaaggcct
+     8701 atcttcagga attgaagaag cattttaatg tcactgtcgc ttcggaagtt ttcggtgata
+     8761 aactcaccag aatggttaag aatgcgaaag tcgtcgtcaa cattcattac tatgaaaatg
+     8821 cgttgcttga aaccacacgt ctatatgaaa cgatttcgct tgggacgcct gtagtgagtg
+     8881 aaagcagttc agatattgta gagcatgaag acctacagga tgtgatcgat ttttgcccca
+     8941 tcggtgatat tccggcaatg gtcgagaaaa ttcagaattt gttatctgat aaagaatatt
+     9001 acaacgaaag aaaagaaaaa attaagcact ttactaatgt agataataaa aataattatt
+     9061 atctgcgacg ttatctgctg tcgattgata aactcaattt ttcacaatac aaaagtattt
+     9121 tctcatttga gcaatttcaa actggagatg tcccacgcct ttgtttatca ttgtctgaaa
+     9181 cacccgtccg ccggaaagct tttttcgcta gtccatccca tggattccaa tttttcgagg
+     9241 ggatccgtta tcgcattggt tggattggtt gtggcatgag ctataaatat atgctttcag
+     9301 gcatgctggc cagtaaggcg gaaatgggga ttatctgtga agatgatgtt atttttccgg
+     9361 ttgattatga taataaatta aataaaatta ttaaccatct acagagtact gaggctaaat
+     9421 ggcatatttt tgctggcata attgcacatc tgcatgagga cacgaaggta ctggatgtta
+     9481 aggtcatcga tggtattgag tatatctaca ttgacaaaat gactagtatg gttatgaata
+     9541 tttattctcg ccgtggtatg gatcttatta gccagtggga tgagaaaaat attgatgccg
+     9601 aaaccaatac tattgaccgc tatgttgaat cagctcaaga tctggtcgtc gtgactacat
+     9661 tacctttcct tgtaggatac gcagaagagc aacagtcaac attatggggc tttgagaact
+     9721 ctcaatatac atcgttaata aaagccagtg aaaaactgtt agctgaaaag gttgcagaat
+     9781 ttaaaaagaa tcgctaa
+//
 LOCUS       LT174596               12064 bp    DNA     linear   BCT 13-JUN-2016
 DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis
             gene cluster, type: O13 (formerly known as OL101).
@@ -422,7 +3515,7 @@ ORIGIN
 //
 LOCUS       LT174597                6874 bp    DNA     linear   BCT 13-JUN-2016
 DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: OL102.
+            cluster, type: OL14.
 ACCESSION   LT174597
 VERSION     LT174597.1  GI:1036211041
 KEYWORDS    .
@@ -446,10 +3539,11 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="K261An"
-                     /serovar="rfb_OL102"
+                     /serovar="rfb_OL14"
                      /db_xref="taxon:573"
-                     /note="O locus: OL102"
+                     /note="O locus: OL14"
                      /note="O type: unknown"
+                     /note="Updated from OL102 by Tom Stanton, March 2025"
      gene            1..525
                      /gene="rfbB"
      CDS             1..525
@@ -466,7 +3560,7 @@ FEATURES             Location/Qualifiers
                      LYVEDHARALYKVATEGRSGETYNIGGHNERKNIDVVRTICAILDNVVEQKPDNISHFA
                      DLITFVKDRPGHDLRYAIDAAKIQRDLGWVPEETFESGIEKTVRWYLNNPTWWQRVLDG
                      SYAGERLGLNN"
-                     /locus_tag="OL102_01_rfbB"
+                     /locus_tag="OL14_01_rfbB"
      gene            540..1409
                      /gene="rfbA"
      CDS             540..1409
@@ -485,7 +3579,7 @@ FEATURES             Location/Qualifiers
                      PKSDWAVTGLYFYDNDVVEMAKQVKPSARGELEITTLNQMYLERGDLQVELLGRGFAWL
                      DTGTHDSLIEASQFIHTIEKRQGMKVACLEEIAYRNQWLSAEGVAAQAERLKKTEYGAY
                      LKRLLNER"
-                     /locus_tag="OL102_02_rfbA"
+                     /locus_tag="OL14_02_rfbA"
      gene            1441..2331
                      /gene="rfbD"
      CDS             1441..2331
@@ -504,7 +3598,7 @@ FEATURES             Location/Qualifiers
                      KTMLRLAGEKESLSIINDQHGAPTGAELLADCTAIAIREEQRNRAVAGTYHLVASGETS
                      WYDYAKYVFEVARAQGAVLAIKDVSGIPTTAYPTPAKRPLNSRLANEKFQQAFGVTLPD
                      WRQGVARVVTEVLGK"
-                     /locus_tag="OL102_03_rfbD"
+                     /locus_tag="OL14_03_rfbD"
      gene            2347..2901
                      /gene="rfbC"
      CDS             2347..2901
@@ -521,7 +3615,7 @@ FEATURES             Location/Qualifiers
                      VQDNHSQSQKGVLRGLHYQLDPHSQGKLVRCIEGEVFDVAVDIRRSSPTFGKWVGAVLS
                      AENKRQLWIPEGFAHGFLALSETVQFVYKATNYYAPQSERSIIWNDPQINIQWPELSDC
                      ALSLSGKDQAAVALSHAEVYN"
-                     /locus_tag="OL102_04_rfbC"
+                     /locus_tag="OL14_04_rfbC"
      gene            3119..4060
                      /gene="wbbL"
      CDS             3119..4060
@@ -539,7 +3633,7 @@ FEATURES             Location/Qualifiers
                      GNTMLFSHGLKKVIETFPADETIVSHDWFLYLVCSALGGEIIYDENPNVLYRQHDDNLV
                      GSNLGINSKLTRLRKIYGGDFKHWNAVNEKNLSFLKDKIAMEKRKIIASYYHANSFSAI
                      SRIRSFIHAGVYRQSVFETMFFMIMSFMGKLR"
-                     /locus_tag="OL102_05_wbbL"
+                     /locus_tag="OL14_05_wbbL"
      gene            4074..5312
                      /gene="rhamnan"
      CDS             4074..5312
@@ -558,7 +3652,7 @@ FEATURES             Location/Qualifiers
                      DAYMKEKYPSEKKADREVNYADVVDFLSSCDYDKLANGHLLKARLLGIYLDDFTRGSQI
                      HNNCIALHHLGLPIIKLDLVYRGVCDLQGIVKLKLQLADEQQDEFMEILTNRLDGNRFL
                      FGFNRKAFNYGIM"
-                     /locus_tag="OL102_06_rhamnan"
+                     /locus_tag="OL14_06_rhamnan"
      gene            5312..6112
                      /gene="wzm"
      CDS             5312..6112
@@ -576,7 +3670,7 @@ FEATURES             Location/Qualifiers
                      QLPVPLHVHVLRVVWKNFIIFLHNIAIFPFVLLAVGKGINWYIFLAIPGFLLLVLNLSW
                      FLMVASMVCARFRDMTQIILSIMQVVFYLTPVIWMPKLLSHRIGQVLLDLNPVYHLIDV
                      VRAPLLGQIPSVTSYIVTAVMAIIGIIFSTIMTSKYKYRVPYWV"
-                     /locus_tag="OL102_07_wzm"
+                     /locus_tag="OL14_07_wzm"
      gene            6119..6874
                      /gene="wzt"
      CDS             6119..6874
@@ -594,7 +3688,7 @@ FEATURES             Location/Qualifiers
                      INPEFTGRENIYIRGALLGLRKKDINSKIDEIINFTDLGDFIDMPVRTYSSGMQMRLGF
                      SVSTIFTPEILLMDEWLSVGDEGFKDKAERRLSDIISSTKILILASHSYELLKTNCTRI
                      LWLEHGGIKMDGKPEDVLHHYFKVDNAHC"
-                     /locus_tag="OL102_08_wzt"
+                     /locus_tag="OL14_08_wzt"
 ORIGIN
         1 gtggtggtga ccaactgctc caacaactac ggtccgtacc atttcccgga aaaactgatc
        61 ccgctgacca tcctcaacgc cctggcgggt aaaccgctgc cggtatatgg caacggggag
@@ -712,298 +3806,9 @@ ORIGIN
      6781 gatattatgg ttggagcacg gtggtattaa aatggatggt aaacccgaag atgttcttca
      6841 ccattacttt aaagtagata acgctcattg ctaa
 //
-LOCUS       LT174598                8048 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: OL103.
-ACCESSION   LT174598
-VERSION     LT174598.1  GI:1036211050
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1
-  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
-            Holt,K.E. and Thomson,N.R.
-  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
-            antigens
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 8048)
-  AUTHORS   Informatics,P.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
-            1SA, UNITED KINGDOM
-FEATURES             Location/Qualifiers
-     source          1..8048
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="QMP"
-                     /serovar="rfb_OL103"
-                     /db_xref="taxon:573"
-                     /note="O locus: OL103"
-                     /note="O type: unknown"
-     gene            1..192
-                     /gene="rmlC"
-     CDS             1..192
-                     /gene="rmlC"
-                     /EC_number="5.1.3.13"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006499571.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="dTDP-4-dehydrorhamnose 3"
-                     /protein_id="CZQ25265.1"
-                     /db_xref="GI:1036211051"
-                     /translation="MALSDTVQFVYKATNYYAPQSERSIIWNDPEIGIDWPALGDSALS
-                     LSEKDLQAHTLANAEVYI"
-                     /locus_tag="OL103_01_rmlC"
-     gene            266..1054
-                     /gene="wzm"
-     CDS             266..1054
-                     /gene="wzm"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_001336134.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="O-antigen export-TMD component"
-                     /protein_id="CZQ25266.1"
-                     /db_xref="GI:1036211052"
-                     /translation="MLKYFLKNKTLILKLAKRDIDSKYKGSFIGGFWAVVNPVIMLCVY
-                     SFVFSEVFKAKWGSLEGGKGTFAVVLFAGLIIFNFLAECLSRGPTLFTSNVNYVKKVVF
-                     PLGCLPFSIFLSAVFNFFISFIILLIAQLIVFNSVPWTILFFPLLLIPLFLIGFSLIVI
-                     FSTIGVYFRDIAQAVPIMITFLMFLSPIFYPLSAIPKSFQDVMMYNPLAFLIENTRDVL
-                     IFGKNMSIESYSILYISSIIFYIIAMKIFQKAKKGFADVL"
-                     /locus_tag="OL103_02_wzm"
-     gene            1044..2405
-                     /gene="wzt"
-     CDS             1044..2405
-                     /gene="wzt"
-                     /EC_number="3.6.3.40"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_001336133.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="O-antigen export-NBD component"
-                     /protein_id="CZQ25267.1"
-                     /db_xref="GI:1036211053"
-                     /translation="MSYNSVKCEAVIQVEHITKIFRIYNTPKDRIKEFLANLPRRVAGA
-                     KRIKKHKEFYSLNDVSLTINKGETIGIIGANGAGKSTLLQIICGTLSPTNGNVTVNGRV
-                     AALLELGAGFNPDFTGRENIFISASIMGLTDEQIKERFDSIVEFSEIGEFIEQPVKTYS
-                     SGMFVRLAFSIIAHVDADILIVDEALSVGDAFFVQKCMRFLRAFMEHGTVLFVSHDTAS
-                     IVNLCDRAIWIDHGQKKMEGSAKDVSEAYLAALFKQSNRNVSVKRQNKDVTEVVAYKDM
-                     RTSFINASNLRNDIELFSFNDESKQFGENGAEIYSVRLEDQNGEPLSWVVGGEEVKLRI
-                     SVKCLKSMFSPIIGFYIKDRLGQTLFGDNTYLSYMDTPLSMQPDDNMDSIFEFNMPILP
-                     VGEYSICVAVAEGSQQEHIQHHWIHDAVIFKSHSSSTVTGLVGIPMKNISISVN"
-                     /locus_tag="OL103_03_wzt"
-     gene            2419..6246
-                     /gene="hydrolase"
-     CDS             2419..6246
-                     /gene="hydrolase"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Predicted hydrolase (HAD superfamily)"
-                     /protein_id="CZQ25268.1"
-                     /db_xref="GI:1036211054"
-                     /translation="MTMINKSMLSRPRKLTFPFGWCGHIPFVSWLVEEMKPGTIVELGT
-                     HSGNSYFAICQAVLENNTGSKCYAVDTWQGDEHAGSYSEDVFRDVSAWNQQYFSAFSNL
-                     MRMTFDQANEYFSAGSVNLLHIDGLHTYEAVKHDFESWKSKLADDAVVLFHDTNVRERG
-                     FGVWQLWDELQQQYPSFEFLHSYGLGVLFVGKKSQALYEKLASFGEPALIREAFSRLGE
-                     LITLREEAHNHIQHIESARSVLESQNQELQHQLNKSKEENELYIKRIQEDKNIKNVMAG
-                     RIHELENSQHHISGNVHALEKEIERLINTNSWKITKPLRFMFRVLRGQQKDAMWHIKKE
-                     VRNIAKSAYYRTPYKYREQLLTMAFKVRPSWFTSHPKFMAAHSLISNELEVSDKLIDIN
-                     LLSDDINTQPGRIAVQCHIFYPDLIDEFVAQLSTMPFKFDVYISVTSEEAKQQCNLQFK
-                     KIKNIENLDVRVVPNRGRDIAPVFAEFGSALKQYDFICHIQSKKSLYNEGKTTGWREYL
-                     LNGLFGSESNVKRIFKAFNDDEKLGIVYPQVHHTLPYMAFTWLANKQQGSELCAKMGIA
-                     CPDGYFNFPAGSMFWARVDALSPLFEMNLAWQDFPEEKGQTDGTTAHAIERLLGIVPQA
-                     LNYGSLIIKDCENESKSTFRWDHQYFPRTLESIHQIISDPSKKVIAFDIFDTLLIRPLL
-                     HPDHTKQIIASQLSAEEASEFLSKRPAAEQSARHRAGRDISIDDIYNELQQHYQVEHSV
-                     AKKFRELEERVEIASVSARPDMLEIFEFVKKSGKKIAIVSDMFLPLETIVNMLESNGFT
-                     GWDKIYLSSDKGKRKDTGELYELLFTEYGVSGNEVVMIGDNERSDLQLPCDWFNILGLH
-                     LVRATDLALHIPEFAPVAQQAFKSDLNGELTFGLITKKNLSQICNFSPEKLKLFSSSPY
-                     QIGYNLAGPLLTAFAEWLRKCAAKDGVQDLYFLAREGKIIKAVYDLWCDGAETTPQSHY
-                     LILSRRAVNVPNVTTLDDVLNIAKSTFFANTLEMFLRERYGLTLPEGKLSSLYSSGLWA
-                     KGKLVEVHNEDISEIKPLLEYLLPDILAEAHAEKQGLLQYLQQEGFIKSAHKTVVDVGY
-                     SGTIQKSLINIVTDRVDGYYMATSEVAGKGLNNGSKAHGCFIENSVSLQNDNSLVLRHS
-                     FVLEKLLSSDDTQIVKYILENATVTPVYKQQRPEELITKDIRTELQKGCMDFVRDARDI
-                     RNTLYPDFSPSLTIADSLYSEFISSCNRKENDFVKKMTLDDDYCGRGLVN"
-                     /locus_tag="OL103_04_hydrolase"
-     gene            6301..7221
-                     /gene="spsA"
-     CDS             6301..7221
-                     /gene="spsA"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_005020985.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="WcaA"
-                     /protein_id="CZQ25269.1"
-                     /db_xref="GI:1036211055"
-                     /translation="MNRSVAILMAVRNGQEYLQPQLDSFLNQTYKNWCLYVSDDGSTDS
-                     TAEIVNNFYLSHPEISGFLKKGPCLGFCQNFQSMINDEKIIADYYAFSDQDDIWLPEKI
-                     ENAVRFLDSVPSDTPALYCSATTLIDQAGNIIGESLSPNKALSFANALLHNVASGNTMV
-                     FNHKARELLMAASSEEMVVHDWSLYQIVSACNGRIYFDHTPGVLYRQHSNNVIGDGRNI
-                     FLRVRNFFSSFKGNRADWNKRNKTVLDKIVAHFGENEKQVYYNYNNISKSRFLKRIYFY
-                     IKSGVYHQYKLGTLSTIIYVCVGKM"
-                     /locus_tag="OL103_05_spsA"
-     gene            7233..8048
-                     /gene="wbbL"
-     CDS             7233..8048
-                     /gene="wbbL"
-                     /EC_number="2.4.-.-"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_001336135.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyltransferase"
-                     /protein_id="CZQ25270.1"
-                     /db_xref="GI:1036211056"
-                     /translation="MNILASLVLYKHSFQEIELTLDSLLNEKNIDKLVIVDNGSFCTWL
-                     DDYKHDKVDVIRLTDNEGFGAGHNKVFEHYKNQCSYFLICNPDIYYAQGEVDKLFSFCK
-                     ENSVDLSVPKIIYPNGALQYATKLLPAPFQLFGRRFLSSFFPNINNEYELRNANFNAAF
-                     YAPSMSGCFMMVSNNAILQVQGFDLRFFMYLEDVDFSRRISAGNFNVVYCPDSTVVHLS
-                     QRKSYHSFKFLFYHMTSAIKYFNKWGWFFDKERQQLNKRCLSSLPTRSE"
-                     /locus_tag="OL103_06_wbbL"
-ORIGIN
-        1 atggcgctga gcgacacggt gcagtttgtc tacaaggcga cgaactacta cgcgccgcag
-       61 tcagaacgga gcatcatctg gaacgatccg gagatcggga ttgactggcc ggcgctgggc
-      121 gacagcgcac tgtcgctgtc ggagaaagat ctgcaggcgc acacgctggc caacgcggaa
-      181 gtgtatatct agtgatgacc tggattcggg ctcaaaaaat gaccagagcc tgaatccagt
-      241 atataaatta aggtatgtct aagcgatgct gaagtatttc ttgaaaaaca aaaccctcat
-      301 cttgaaactg gcgaaaagag atattgattc taaatataag ggatctttta tcggcggttt
-      361 ttgggcagtt gttaacccag taattatgtt atgtgtttat tcgtttgtat tttcagaagt
-      421 cttcaaggct aaatggggta gtttagaagg agggaaaggg accttcgcag tagtattgtt
-      481 tgctgggttg attatattca acttcttagc agagtgttta agtcgaggac cgacattatt
-      541 taccagtaat gtaaattacg ttaagaaagt tgtttttcca cttggctgtc ttccgtttag
-      601 catttttctt tcggccgtgt ttaatttctt tataagtttc ataattttgc tcattgctca
-      661 actaattgtc ttcaattcag tgccttggac aattttattc tttccgttgt tgttgattcc
-      721 tttgtttctt atcggttttt cattaattgt tattttttca accattggcg tatattttcg
-      781 agatatagct caggctgtgc caattatgat aacgtttctg atgtttttat ctccgatatt
-      841 ttatccgtta agcgcaattc ctaaaagttt tcaggatgtt atgatgtaca acccgttggc
-      901 gtttttaata gaaaacacac gggatgtatt aatctttggc aaaaacatgt caattgaatc
-      961 atattcaatt ctgtatattt caagtattat attttacatt attgcaatga aaatattcca
-     1021 gaaggctaaa aaaggttttg cagatgtcct ataattcagt taaatgcgaa gctgtcattc
-     1081 aagtagaaca tattacaaaa atttttcgca tctacaacac tccaaaggat cggataaaag
-     1141 aattcctggc aaatttacca cgccgagttg ctggggcaaa gcgtattaag aaacataaag
-     1201 agttctattc acttaatgat gtctccttaa ctattaataa aggagagaca attgggatca
-     1261 ttggtgccaa cggcgcaggt aagtcaaccc tattgcaaat tatttgtggg acgttgtcgc
-     1321 caacgaatgg caatgtaact gtaaatggta gagtggctgc tctattagag cttggtgctg
-     1381 ggtttaaccc tgatttcaca ggtagagaaa atatttttat atcagcatca ataatgggac
-     1441 taactgacga gcaaataaaa gaacgtttcg acagtatcgt tgagttttcc gaaattggag
-     1501 agtttattga gcaaccggta aaaacatatt ctagtggtat gtttgtacgg ttggcatttt
-     1561 caattatcgc tcacgttgat gcagatatct taatcgtaga tgaagcgctt tcggttggtg
-     1621 atgcgttctt tgttcaaaaa tgtatgcgtt ttctacgggc atttatggaa catggtactg
-     1681 tgctcttcgt tagccatgat accgcttcaa ttgtaaactt atgcgatcgt gctatctgga
-     1741 ttgatcatgg gcagaagaag atggaaggtt ctgcgaaaga tgtctcggaa gcttatcttg
-     1801 ctgcattatt taaacagagt aacaggaatg tatccgtcaa gcgtcaaaac aaggatgtta
-     1861 ctgaggttgt agcttataaa gatatgcgta ctagttttat taatgctagt aatttacgta
-     1921 atgatataga actgttttct tttaatgatg aaagtaaaca gtttggtgag aatggcgcag
-     1981 agatctatag tgtaaggcta gaggatcaaa acggtgaacc cttatcatgg gtagttggtg
-     2041 gagaagaagt taagcttaga ataagtgtta agtgcttgaa aagtatgttt agtccaataa
-     2101 tcggcttcta tataaaagac cgacttggac aaacattatt tggtgataat acataccttt
-     2161 cttatatgga tacaccactc agtatgcaac ctgatgacaa tatggatagc attttcgagt
-     2221 ttaacatgcc tatacttcca gtcggtgaat atagtatttg cgtcgcagta gcagaaggta
-     2281 gtcagcaaga acatatccaa catcactgga tacatgatgc ggtaattttt aaatcgcatt
-     2341 cttccagtac ggtgactggg ctagtcggta ttccaatgaa aaatattagt atctcggtga
-     2401 attaagagta attattttat gactatgatt aataaatcaa tgctttccag acctagaaaa
-     2461 ctgactttcc catttggctg gtgcggccat atcccctttg tcagttggct tgttgaggaa
-     2521 atgaaaccgg gtactattgt tgaattaggt acgcattcag gaaattcata ttttgcaatc
-     2581 tgccaggctg tcctggaaaa taataccggt tccaaatgct atgctgttga tacgtggcaa
-     2641 ggggatgagc atgccggtag ctacagtgaa gatgttttca gagatgtaag tgcatggaat
-     2701 cagcagtatt tctctgcatt ttcaaattta atgcgcatga cctttgatca ggcgaacgaa
-     2761 tatttttctg caggcagcgt taatttattg catatcgacg gcttacatac ctatgaagct
-     2821 gttaaacatg actttgaatc ctggaaatca aaattagcag atgatgcggt tgtcctgttc
-     2881 catgacacca atgtccgtga acgaggattt ggtgtatggc agctttggga tgaacttcaa
-     2941 caacagtatc catcttttga atttttgcat tcatatggct tgggtgtgct ttttgtaggc
-     3001 aaaaaaagcc aagctcttta tgaaaagttg gcttcttttg gtgagcctgc tctcattaga
-     3061 gaagcatttt cacgcctagg tgagttaatt actctgcgcg aagaagccca taatcatatc
-     3121 cagcatattg aatcagccag atccgttctt gagagtcaaa accaagaact tcagcatcaa
-     3181 cttaataaat caaaagaaga aaacgaactc tatataaaga gaattcagga agataaaaat
-     3241 attaaaaatg ttatggctgg cagaatccat gaactggaaa acagtcagca tcatatttcc
-     3301 ggcaatgtcc atgcactcga aaaggaaatt gagcggctga ttaatactaa ctcgtggaaa
-     3361 atcactaagc cgctaagatt catgtttcga gtactccgcg gccaacagaa agatgcgatg
-     3421 tggcatatta aaaaagaagt ccgtaatatt gccaagtcag cttattatcg aaccccttat
-     3481 aagtatcgcg aacaactatt aaccatggca tttaaggttc gacctagttg gttcactagt
-     3541 catcctaaat ttatggctgc tcattctctg atatcaaatg aattagaggt aagtgataag
-     3601 cttatcgata ttaatttatt aagtgacgat attaatacac agcctggaag aattgctgtt
-     3661 caatgtcata ttttttatcc agacttaatc gatgaatttg tggcacaatt gtcaacaatg
-     3721 ccgtttaagt tcgatgttta catttcagta acaagtgaag aagccaaaca acaatgcaat
-     3781 ctgcaattta agaagattaa aaatatcgaa aatctcgatg tgcgagtagt acctaatcgc
-     3841 ggtcgtgata ttgctccagt attcgccgag tttggttccg ccttaaaaca atatgatttt
-     3901 atttgtcata ttcaaagtaa gaagtcatta tataatgagg gaaaaacaac cggttggcga
-     3961 gagtatttac tgaatggttt gttcggttcg gaatctaatg taaaacggat atttaaagcc
-     4021 tttaatgatg atgaaaaatt agggattgtc tacccacagg tccatcatac tttaccttat
-     4081 atggcattta cctggctagc caacaaacag caaggcagtg aactttgcgc aaaaatggga
-     4141 atagcctgtc ctgatggata tttcaatttc cccgcagggt caatgttttg ggctcgtgta
-     4201 gacgctttgt ccccgttatt cgagatgaat ttagcgtggc aagattttcc tgaagaaaaa
-     4261 ggacagactg atgggactac agcacatgca attgaacgtt tgttaggtat agtccctcag
-     4321 gctttgaatt atggttcatt aattataaaa gactgtgaga atgagtcaaa atccactttc
-     4381 cgttgggatc atcaatattt ccctagaacg ttagagtcga ttcatcaaat aatttctgat
-     4441 ccaagcaaaa aagttattgc ttttgatatt tttgatactt tgttgattcg tcctttactt
-     4501 catcctgacc atacaaaaca gatcattgcc agccaattgt ctgctgagga agcgtccgag
-     4561 tttctgtcta aaaggcctgc cgcagagcag agtgcaaggc accgcgctgg gcgggatatc
-     4621 agtattgacg atatctataa tgaattgcag caacattatc aggttgaaca ttcagtcgcc
-     4681 aaaaagtttc gtgagctcga agaacgggtt gaaattgctt ctgtttcggc tcggccggat
-     4741 atgttggaaa tttttgagtt tgttaaaaag agtggtaaaa aaatcgctat tgtcagcgat
-     4801 atgtttttac cgcttgaaac tatcgttaat atgctcgaat ctaatggttt taccggatgg
-     4861 gataaaattt atttatcatc agataaaggt aaaagaaagg atacgggtga actgtacgag
-     4921 cttcttttta ccgagtatgg tgtttccggt aatgaagtcg tgatgattgg tgataacgag
-     4981 cgaagtgatt tacagttacc ttgcgattgg tttaacatcc tcggtttgca tcttgtgaga
-     5041 gctacggact tagcacttca tattccggag tttgcaccag tagcacagca ggcctttaag
-     5101 tcagatctta acggagaact tacttttggc cttataacga agaaaaattt gagtcaaatt
-     5161 tgtaattttt ctcccgaaaa acttaagcta ttctcttcta gtccctatca aattggttat
-     5221 aatcttgctg ggcccttgct tactgcattt gctgaatggc ttagaaaatg cgctgcaaaa
-     5281 gacggcgtgc aggacttata ttttcttgcg agagaaggga aaatcattaa agcagtttat
-     5341 gatctttggt gtgatggagc ggaaacgaca cctcaaagtc attatctgat actgtctcgt
-     5401 cgtgcggtta acgtaccaaa tgtgacaaca ttggatgatg tactgaatat agctaagtcg
-     5461 actttttttg ctaatacgct cgagatgttt ttacgtgaac gttacggatt aactcttccg
-     5521 gaaggaaaac tatcttcttt atactcctct gggctgtggg ctaaaggcaa attagtggag
-     5581 gttcataatg aagatatttc tgaaatcaaa ccattactgg aatatctact gccagatatc
-     5641 cttgctgaag cacatgctga aaaacagggc ttattacaat accttcagca agaagggttt
-     5701 ataaagtcag cccacaaaac agttgttgat gtcggatatt ccggtacgat ccagaaatca
-     5761 cttattaata tcgtaactga cagggttgat ggttattata tggcaacatc tgaagttgca
-     5821 ggaaaaggat tgaataacgg aagtaaggcg catggttgtt ttattgagaa ctctgtctcc
-     5881 ctgcagaatg ataattcatt agttttgcgc catagcttcg tactagagaa attgttaagc
-     5941 tcggatgata cccaaattgt taaatatatc ctggaaaacg cgaccgttac gccagtatat
-     6001 aaacaacagc gtccagaaga gcttataaca aaagacatca gaacggagtt acaaaaaggc
-     6061 tgcatggatt tcgttcgtga tgcaagagat atacgaaata cgctttaccc tgatttttcg
-     6121 ccttcattga caatagctga ttctttatat agtgagttca tttcaagttg caatcgaaaa
-     6181 gaaaatgact tcgtgaaaaa aatgacctta gatgatgatt attgtggtcg tggtttagta
-     6241 aattaaatta aaaataaccc ctctatctgc ggatagcaga tagaggggca gggtttcaga
-     6301 atgaaccgaa gtgttgctat tttaatggct gtaagaaatg gtcaggagta ccttcagcct
-     6361 caacttgatt catttcttaa ccaaacatat aagaactggt gtttatatgt ttctgatgat
-     6421 ggctcgaccg attcgacagc cgaaattgtt aataactttt atctttctca tccagagatt
-     6481 tctggttttc taaaaaaagg cccttgtctt ggtttctgcc aaaattttca gtccatgatc
-     6541 aacgatgaaa aaatcattgc tgattattat gctttttctg accaggacga tatttggcta
-     6601 cccgaaaaaa tagaaaatgc agttcgcttt ctggacagtg tcccctcaga tactcctgct
-     6661 ctctattgct cggctactac tcttatcgat caggctggta atattattgg ggaatcactt
-     6721 tcacccaata aggcactcag ttttgccaat gctctgttgc ataatgttgc tagcggcaat
-     6781 actatggtat tcaatcataa agccagagag ttattaatgg ctgcctcgtc tgaagaaatg
-     6841 gtggtacatg attggtcgct ctatcagata gtaagcgcat gcaatggacg catttatttt
-     6901 gatcacaccc ctggagtgtt gtatcgccaa catagtaata atgtgattgg tgatggacgt
-     6961 aatatttttc tacgtgtgcg taatttcttt tcatctttta aaggaaatcg cgcagactgg
-     7021 aataaacgga ataaaaccgt tctcgataag atagtggctc acttcggtga gaatgaaaag
-     7081 caagtttatt ataactataa taatataagt aaaagtaggt ttttgaaaag gatttatttt
-     7141 tacataaaat ctggtgttta ccatcaatat aaactcggta cattatcaac cataatttat
-     7201 gtttgtgttg ggaaaatgta gtaaggtgct atgtgaatat actagcttcg cttgttcttt
-     7261 ataaacattc ttttcaagaa attgagctta cgcttgattc gttattaaat gaaaagaata
-     7321 tcgataaact agttatagtg gataatggtt ctttttgtac ctggttggat gattataagc
-     7381 acgataaagt tgatgtcata agattaactg ataatgaagg ttttggcgca gggcataata
-     7441 aagtttttga acattataaa aaccaatgta gttatttttt gatttgtaat cctgacattt
-     7501 actatgctca gggcgaggtt gataaactgt tttccttttg taaggaaaat tcggtcgacc
-     7561 tttcagtccc taaaatcata tatccaaatg gtgcattgca atatgcgaca aagctattgc
-     7621 cggcaccatt tcaacttttc ggacgtcgat ttctctcatc attttttccc aacataaata
-     7681 atgagtatga attgcgtaac gctaatttta atgctgcatt ctacgcgcca tcgatgtcag
-     7741 gatgttttat gatggtgagc aataacgcca ttctacaagt tcaaggtttc gaccttcgat
-     7801 tcttcatgta tttagaggat gtcgattttt cgcgccgtat cagtgcgggg aattttaatg
-     7861 ttgtttattg tcctgattct acagtcgttc atctatcgca aagaaaatca tatcacagct
-     7921 ttaaattcct gttttatcat atgacctctg cgattaaata tttcaataag tggggttggt
-     7981 tttttgataa agaaagacaa caactcaaca aacgttgtct ttcatcatta cccaccagat
-     8041 cggaataa
-//
 LOCUS       LT174599               11834 bp    DNA     linear   BCT 13-JUN-2016
 DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: OL104.
+            cluster, type: OL15.
 ACCESSION   LT174599
 VERSION     LT174599.1  GI:1036211057
 KEYWORDS    .
@@ -1027,10 +3832,11 @@ FEATURES             Location/Qualifiers
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="D-026-I-b-1"
-                     /serovar="rfb_OL104"
+                     /serovar="rfb_OL15"
                      /db_xref="taxon:573"
-                     /note="O locus: OL104"
+                     /note="O locus: OL15"
                      /note="O type: unknown"
+                     /note="Updated from OL104 by Tom Stanton, March 2025"
      gene            1..1416
                      /gene="manC"
      CDS             1..1416
@@ -1052,7 +3858,7 @@ FEATURES             Location/Qualifiers
                      VKKVVEYLKANQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
                      AEHWVILAGTGQITVNGKQFLLTENQSTFIPIGAEHCLENPGRIPLEVLEIQSGSYLGE
                      DDIIRIKDQYGRC"
-                     /locus_tag="OL104_01_manC"
+                     /locus_tag="OL15_01_manC"
      gene            1439..2821
                      /gene="manB"
      CDS             1439..2821
@@ -1074,7 +3880,7 @@ FEATURES             Location/Qualifiers
                      YCDSGMIPWLLVAELLCLKNSPLKALVADRQAAFPASGEINRKLENAAAAIARIRERYE
                      PDAVNVDTTDGISIEYPEWRFNLRSSNTEPVVRLNVESKADTALMKEKTAELLNMLKEE
                      SL"
-                     /locus_tag="OL104_02_manB"
+                     /locus_tag="OL15_02_manB"
      gene            2827..3612
                      /gene="wzm"
      CDS             2827..3612
@@ -1091,7 +3897,7 @@ FEATURES             Location/Qualifiers
                      RICLPIIITASAFINFLIIFGLFVLFLLITGNFPGWIFFEIIPVLMIQMLFTLGLGIIL
                      GVLNVFVRDVGQFVNILLQFWFWFTPIVYVSKTLPEWVSGLLAYNPMATIITSYQNVML
                      YHQSPNWMALLPVTILSLILFLFAWRLFKKHSADIVDEI"
-                     /locus_tag="OL104_03_wzm"
+                     /locus_tag="OL15_03_wzm"
      gene            3615..4907
                      /gene="wzt"
      CDS             3615..4907
@@ -1112,7 +3918,7 @@ FEATURES             Location/Qualifiers
                      EYRWGQGGAKIIDYHIQSSGIDYPPSLTGNQQTDFMMKVVFEYDFDCVVPGLLIKTLDG
                      LFLYGTNSFLASEGRENISVSRGDVRVFKFSFPVDLNSGDYLLSFGISEGSPQTDMTPL
                      DRRYDSIILHVTKSMDFWGVIDLKSTFNSYQ"
-                     /locus_tag="OL104_04_wzt"
+                     /locus_tag="OL15_04_wzt"
      gene            4927..6984
                      /gene="wbdD"
      CDS             4927..6984
@@ -1136,7 +3942,7 @@ FEATURES             Location/Qualifiers
                      PQDVITDAQQCVEVEPSQTVDSEEVMQLHTQLNDARQEAENLRHEIAKIHNSRSWKMTK
                      WYRYAGMQYYLLRQYGFRQRCKHLLKRVLGKIFIFLRAHPRLKQRAINLLHKVGIYDFA
                      YRLHRRMNPGSHNPYHNDPQNQSQTEKQILHPELLPPEVNSIFSELKNKR"
-                     /locus_tag="OL104_05_wbdD"
+                     /locus_tag="OL15_05_wbdD"
      gene            7121..9517
                      /gene="wbdA"
      CDS             7121..9517
@@ -1163,7 +3969,7 @@ FEATURES             Location/Qualifiers
                      QTLAAFEELWRQGKNYNLFIIGKQGWHVDDLCERLRHHPQLNKRLFWLQNISDEFLAKL
                      YAQSSALIFASLGEGFGLPLIEAAQKKLPVIIRDIPVFKEIAQEHAFYFSGEQPGDIST
                      AIDEWLELYRKNAHPRSEKINWLTWKQSAEFLVENLPVIKSDANK"
-                     /locus_tag="OL104_06_wbdA"
+                     /locus_tag="OL15_06_wbdA"
      gene            9564..10709
                      /gene="wbdB"
      CDS             9564..10709
@@ -1183,7 +3989,7 @@ FEATURES             Location/Qualifiers
                      LLQAYQLLPMETRMRYPLILSGYRGWEDDALWQIVERGTREGWIRYLGYVPDGDLPYLY
                      AAARTFIYPSFYEGFGLPILEAMSCGIPVVCSNVTSLPEVAGDAGLLSDPNDVDAISSH
                      ILQSLQDEYWREIAVARGFIQAQQFSWETCTAQTIDAYKLL"
-                     /locus_tag="OL104_07_wbdB"
+                     /locus_tag="OL15_07_wbdB"
      gene            10719..11834
                      /gene="wbdC"
      CDS             10719..11834
@@ -1203,7 +4009,7 @@ FEATURES             Location/Qualifiers
                      IVGGGPLEAEVRREAEQRGLNNVIFTGMLDDEDKYILFHLCRGVVFPSHLRSEAFGITL
                      LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPDNSAALVEAMNELWHSDETAARYGA
                      NSRRRFEEMFTAEHMIDAYVNLYSTLLEQKP"
-                     /locus_tag="OL104_08_wbdC"
+                     /locus_tag="OL15_08_wbdC"
 ORIGIN
         1 atgttacttc ctgtgattat ggcggggggc accggtagcc gcctgtggcc gatgtcccgt
        61 gaactctatc caaaacagtt tctccgactg tacgggcaga actccatgtt gcaggaaacc
@@ -1404,3458 +4210,32 @@ ORIGIN
     11761 agatgtttac cgccgaacat atgattgatg cctacgtgaa tctctacagc acgctgctgg
     11821 agcagaaacc ctga
 //
-LOCUS       LT174600                9797 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O12.
-ACCESSION   LT174600
-VERSION     LT174600.1  GI:1036211066
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1
-  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
-            Holt,K.E. and Thomson,N.R.
-  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
-            antigens
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 9797)
-  AUTHORS   Informatics,P.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
-            1SA, UNITED KINGDOM
-FEATURES             Location/Qualifiers
-     source          1..9797
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="AKPRH094188"
-                     /serovar="O12"
-                     /db_xref="taxon:573"
-                     /note="O locus: O12"
-                     /note="O type: O12"
-     gene            1..1065
-                     /gene="rfbB"
-     CDS             1..1065
-                     /gene="rfbB"
-                     /EC_number="4.2.1.46"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006499574.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="dTDP-glucose 4"
-                     /protein_id="CZQ25279.1"
-                     /db_xref="GI:1036211067"
-                     /translation="MKILVTGGAGFIGSAVVRHIIENTLDEVRVMDCLTYAGNLESLAP
-                     VAGSERYSFSQTDITDAAAVAAQFSEFRPDIVMHLAAESHVDRSIDGPAAFIQTNVIGT
-                     FTLLEAARHYWSGLGEAQKQAFRFHHISTDEVYGDLHGTDDLFTEETSYAPSSPYSASK
-                     AGSDHLVRAWNRTYGLPVVVTNCSNNYGPYHFPEKLIPLTILNALAGKPLPVYGNGEQI
-                     RDWLYVEDHARALYKVATEGKSGETYNIGGHNERKNIDVVRTICTILDKVVAQKPGNIT
-                     HFADLITFVTDRPGHDLRYAIDATKIQRDLGWVPQETFESGIEKTVHWYLNNQTWWQRV
-                     LDGSYAGERLGLNK"
-                     /locus_tag="O12_01_rfbB"
-     gene            1080..1949
-                     /gene="rfbA"
-     CDS             1080..1949
-                     /gene="rfbA"
-                     /EC_number="2.7.7.24"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006499573.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glucose-1-phosphate thymidylyltransferase"
-                     /protein_id="CZQ25280.1"
-                     /db_xref="GI:1036211068"
-                     /translation="MKGIVLAGGSGTRLYPITQGVSKQLLPIYDKPMIFYPVSVLMLAG
-                     IRDILIISTPEDMPSFQRLLGDGSQFGVNFSYAIQPSPDGLAQAFIIGEKFIGNDACAL
-                     VLGDNIYFGQSFGKKLEAAAAKTSGATVFGYQVLDPERFGVVEFDEHFKALSIEEKPLK
-                     PKSNWAVTGLYFYDNNVVEMAKDVKPSARGELEITTLNQMYLERGDLHVELLGRGFAWL
-                     DTGTHDSLMDASQFIHTIEKRQGMKVACLEEIGYRNKWLSAEGVATQAERLKKTEYGAY
-                     LKRLLNER"
-                     /locus_tag="O12_02_rfbA"
-     gene            1981..2871
-                     /gene="rfbD"
-     CDS             1981..2871
-                     /gene="rfbD"
-                     /EC_number="1.1.1.133"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_005227856.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="dTDP-4-dehydrorhamnose reductase"
-                     /protein_id="CZQ25281.1"
-                     /db_xref="GI:1036211069"
-                     /translation="MKILLIGKNGQVGWELQRSLSTLGDVVAVDYFDKELCGDLTNLEG
-                     IAQTVRIVRPDVVVNAAAHTAVDKAESERELSDLLNDKGVAVLAAESAKLGALMVHYST
-                     DYVFDGAGSHYRREDEATGPLNVYGETKRAGELALEQGNPRHLIFRTSWVYATRGANFA
-                     KTMLRLAGEKETLTIIDDQHGAPTGAELLADCTATAIRETLRNPALAGTYHLVASGETS
-                     WCDYARYVFEVARAHGAELAVQEVKGIPTTAYPTPAKRPLNSRLSNEKFQQAFGVTLPD
-                     WRQGVARVVTEVLGK"
-                     /locus_tag="O12_03_rfbD"
-     gene            2886..3440
-                     /gene="rfbC"
-     CDS             2886..3440
-                     /gene="rfbC"
-                     /EC_number="5.1.3.13"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006499571.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="dTDP-4-dehydrorhamnose 3"
-                     /protein_id="CZQ25282.1"
-                     /db_xref="GI:1036211070"
-                     /translation="MNIIKTDIPDVLIFEPRVFGDARGFFFESFSSKVFNEAVGRQVEF
-                     VQDNHSQSQKGVLRGLHYQLDPHAQGKLVRCVEGEVFDVAVDIRRSSPTFGKWVGAVLS
-                     AENKRQLWIPEGFAHGFMALSDTVQFVYKATNYYAPQSERSIIWNDPEIGIDWPALSDC
-                     VLSLSEKDLRAHTLATAEVYA"
-                     /locus_tag="O12_04_rfbC"
-     gene            3531..4361
-                     /gene="wbbL"
-     CDS             3531..4361
-                     /gene="wbbL"
-                     /EC_number="2.4.-.-"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_001336135.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyltransferase"
-                     /protein_id="CZQ25283.1"
-                     /db_xref="GI:1036211071"
-                     /translation="MNYKAMKPKVIASIVLFNHSYDDIKDTFLSLCHEESVEKIIFVDN
-                     GGCQWAASLNEPKVSYIKSPYNCGFGAGHNLAIKASADFDGYFLICNPDISFDKQSLDK
-                     LVSFAWENEYSFVSPQIIYRNGERQYSCRLLPTPGNLFLRRFFPVTAIKYDVKYELKDA
-                     AYDEIFSPPTVSGCFMLLSNVLLQKLNGFDERYFMYLEDVDLCRRALQLTKIYYYPGTT
-                     IVHAFNKGSYKSKLLLWYHIRSAVSYFNKWGWFLDRKRHAYNKQAIYEIPKKII"
-                     /locus_tag="O12_05_wbbL"
-     gene            4391..5224
-                     /gene="wzm"
-     CDS             4391..5224
-                     /gene="wzm"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_001336134.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="O-antigen export-TMD component"
-                     /protein_id="CZQ25284.1"
-                     /db_xref="GI:1036211072"
-                     /translation="MKNPHQKLSSSPLAVVRSIATHWSIILQMAKRDVVGRYKGSVMGL
-                     LWSFLNPLFMLTVYTFVFSVVFKARWSTGGDESRTQFAIILFVGMIVHGFLSEVVNKAP
-                     LIILGNTNYVKKVIFPLETLPVISLFAALFHTCISLCVLLMAFFIFNGYLHWTIVFLPV
-                     VFFPLIIFCLGISWILASLGVFLRDVSQTTVIITTVLMFLSPVFFPISALPEKYHIWIM
-                     LNPLTFIIEQARTVLIWGGMPNFIGLFLYSLGALVIAWMGFAFFQKTRKGFADVL"
-                     /locus_tag="O12_06_wzm"
-     gene            5214..6536
-                     /gene="wzt"
-     CDS             5214..6536
-                     /gene="wzt"
-                     /EC_number="3.6.3.40"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_001336133.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="O-antigen export-NBD component"
-                     /protein_id="CZQ25285.1"
-                     /db_xref="GI:1036211073"
-                     /translation="MSSNEIAIQVTNLSKCYQIYARPTDRLKQFFVPKLQQVVRRERNC
-                     YFREFWALDDVSFSIKKGETVGIIGRNGAGKSTLLQIICGTLTPSAGDVRVNGRIAALL
-                     ELGAGFNPEFTGRENVYLNGSVLGLTKEQIAAKFAEIEEFADIGQFIDQPVKTYSSGMY
-                     VRLAFAVQACVEPEILIVDEALAVGDIGFQYKCYKRMEALRAKGVTIIMVTHSTGSILE
-                     YADRCLVMEHGKLIGDTNDVLAAVLAYEKGMILANDKPEPTKLAENRSSETCSLEDLKS
-                     IQLHTANEEIGEKRFGTARAIIKNLTIYKSDGTTLTEKPLIKSGEEVTFDFTILATEEI
-                     KDVALGLSISKAQGGDIWGDSNIGAGSPITLRPGSQRIVYKATLPINSGDYLIHCGLAM
-                     VGNGAREELDQRRPMMKIKFWSARELGGVIHAPLKIITNGE"
-                     /locus_tag="O12_07_wzt"
-     gene            6540..9797
-                     /gene="wbbB"
-     CDS             6540..9797
-                     /gene="wbbB"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_001336132.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyltransferase"
-                     /protein_id="CZQ25286.1"
-                     /db_xref="GI:1036211074"
-                     /translation="MFAVFLPPYPFRGVKAPYLWLFLKYLHCSNEKILFITSPDYVEVI
-                     NDETQHSRWEFDTASMASLGYSLPDEQSLARHEYLYLDHALYETMLAQHHHDPIKSFTT
-                     FLTESISELENELFSLLTKEIIQRVDAFVSICNCPSLEKVARALNKEVIHLEIGPLRAP
-                     MYRNTAYLDFTGVNGNTEARARYESCQTEIDITCSMNDLHRYFLEAISLPSSSENQVAG
-                     IVLQVEDDSNIIAYSHNFTNISLISYVRQQHALENILVRAHPGSLFRLRDDIFSIDASA
-                     NSLEFIQKCHSIYTINSSVGLEALLCEKKTNILGDCSYAFVAEEASGPNRVNAMAFYLF
-                     AYLVPFELIFNLEYLRFRLDHPAELDIVRKHLQFYSKMPDEREENSHTLSTLINEAISK
-                     DITMRTILENSLAENNKQLEDLKTQLAAEVTEREKLAAAITKLQQTADLAAKDREILVS
-                     ALAVKEDEVDRMRRSLSWKLTMPVRMSGRISRGEFSTIKAMMREYTTSGNNVFSRYILS
-                     GGLLSKSKYKTAIRLLLSGNWSGMVDGFKRVLSRAAIDSSPATPFVDNVTVRILATQHT
-                     LFVAHLIEKNLLDCGIKGHVSTAYSVEQDMGQMHIVVCPQMFKQLPRNYIAFQMEQSVN
-                     SRWFTDEYFSRLNNAVAIFDYSLKNIEYLLDKGIPYQKLFYMPISSFPDYPAHLADNGY
-                     VLDDQKGDIHADVLFYGDPNCERRKAYLQELKKHFNVTVASEVFGDKLTRMVKNAKVVV
-                     NIHYYENALLETTRLYETISLGTPVVSESSSDIVEHEDLQDVIDFCPIGDIPAMVEKIQ
-                     NLLSDKEYYNERKEKIKHFTNVDNKNNYYLRRYLLSIDKLNFSQYKSIFSFEQFQTGDV
-                     PRLCLSLSETPVRRKAFFASPSHGFQFFEGIRYRIGWIGCGMSYKYMLSGMLASKAEMG
-                     IICEDDVIFPVDYDNKLNKIINHLQSTEAKWHIFAGIIAHLHEDTKVLDVKVIDGIEYI
-                     YIDKMTSMVMNIYSRRGMDLISQWDEKNIDAETNTIDRYVESAQDLVVVTTLPFLVGYA
-                     EEQQSTLWGFENSQYTSLIKASEKLLAEKVAEFKKNR"
-                     /locus_tag="O12_08_wbbB"
-ORIGIN
-        1 atgaagattc ttgtcaccgg gggcgcaggc tttatcggtt ctgccgtggt tcgtcatatc
-       61 attgaaaata ccctggacga agtccgtgtg atggactgcc tgacctacgc cggcaacctc
-      121 gaatccctgg cgccggtggc cgggagtgaa cgctactcgt tttcccagac cgatatcacc
-      181 gatgccgctg ccgtggcggc ccagttcagc gagttccgcc cggatatcgt gatgcacctg
-      241 gcggcagaaa gccatgtgga ccgttccatt gatggcccgg ccgcgtttat ccagaccaac
-      301 gtgatcggca ccttcactct gctggaggcg gcccgtcact actggtccgg gcttggggaa
-      361 gcgcagaagc aggccttccg cttccatcat atctccaccg atgaagtgta tggtgacctg
-      421 cacggcaccg atgacctgtt caccgaagag acttcgtacg ccccgagcag cccgtactcc
-      481 gcctccaaag cgggcagcga ccatctggtt cgcgcctgga accgcaccta cggcctgccg
-      541 gtggtggtga ccaactgctc caacaactat ggtccgtatc acttcccgga aaaactgatc
-      601 ccgctgacta tccttaatgc cctggcgggt aaaccgctgc cggtatatgg caacggggag
-      661 cagatccgtg actggctgta tgttgaggac catgcccgtg cgctgtacaa agtggcgacc
-      721 gaaggcaaga gcggcgagac ctacaacatc ggcggtcata acgagcgtaa aaatatcgat
-      781 gtggtgcgca ccatctgcac cattctcgac aaggtggtgg cgcagaagcc gggaaacatc
-      841 acccactttg ctgacctgat cacttttgtc actgaccgtc cgggacatga cctgcgctac
-      901 gctattgatg ccacgaaaat tcagcgcgat ctgggctggg tgccgcagga aacgttcgag
-      961 agcgggattg agaaaaccgt gcactggtac ctgaacaacc agacctggtg gcagcgtgtg
-     1021 ctggacggct cctatgccgg cgagcgtctt ggcctgaata aataaaaaag gaactgaaga
-     1081 tgaagggcat tgttctggcc ggcggctccg gcacgcgttt atatcccatc acccagggcg
-     1141 tctccaagca gctgctgcct atctacgaca agccgatgat tttctacccg gtgtctgtcc
-     1201 tgatgctggc gggcattcgc gatatcctta tcatctccac gcctgaagac atgccttcct
-     1261 tccagcgcct gctgggtgac gggtcgcagt tcggggtgaa cttcagctac gccatccagc
-     1321 cgtcgccgga cggtctggca caggccttta tcattggcga gaagtttatc ggcaacgatg
-     1381 cctgcgccct ggtgctgggg gataatatct actttggcca gagcttcggt aaaaagctgg
-     1441 aagcagcggc ggcgaagact tctggtgcca cggtgtttgg ttaccaggtg ctggatccgg
-     1501 agcgcttcgg cgtggtggag tttgacgagc acttcaaagc gctgtcaatt gaagagaaac
-     1561 cattaaagcc gaaatcaaat tgggccgtaa ctggtctcta tttctacgac aataacgtgg
-     1621 tggagatggc gaaggacgtg aaaccttcag cacgcgggga actcgagatc accaccctca
-     1681 accagatgta tctggagcgc ggtgacctgc atgtggaact gctggggcgc ggctttgcct
-     1741 ggctggatac aggcactcat gacagcctga tggacgcatc acagttcatt cacaccattg
-     1801 aaaagcgcca ggggatgaag gtcgcgtgcc tggaagagat cggttaccgc aacaaatggt
-     1861 tgtcggcgga aggggtggcg actcaggccg aacgcctgaa gaaaaccgag tacggtgctt
-     1921 atctcaagcg cctgctgaac gagcgttaat gccttcttcg tcaacgacag gatacagaga
-     1981 atgaagattt tactgattgg caagaatggc caggtgggct gggagctgca gcgttccctg
-     2041 tccaccctcg gcgacgtggt cgcggtggat tattttgata aagagctgtg cggtgacctg
-     2101 acgaacctgg aaggcatcgc gcagacggtg cgtatcgtcc gcccggatgt ggtggtgaat
-     2161 gccgccgcgc acacggccgt ggacaaggca gaaagcgagc gggagctctc cgacctgctg
-     2221 aacgacaaag gggtggcggt gctggcggcg gagtcggcga agctcggtgc cctgatggtg
-     2281 cactattcca ccgattatgt gttcgacggc gccggcagcc attatcgccg ggaagatgag
-     2341 gcaaccggcc cgcttaacgt ctacggtgaa accaagcgtg ccggtgagct ggccctggag
-     2401 cagggcaacc cgcgtcacct gattttccgt accagctggg tgtatgccac ccgcggcgcc
-     2461 aactttgcca aaaccatgct ccgcctggcg ggggagaaag agaccctcac catcattgac
-     2521 gaccagcacg gggcgcccac cggcgctgag ctgctggcag actgcacggc gacggcaatc
-     2581 cgtgaaacgc tgcgtaatcc ggcgctggcc ggcacgtatc acctggtggc cagcggtgaa
-     2641 accagctggt gcgactatgc ccgctatgtg tttgaagtgg cgagagcgca cggtgccgag
-     2701 ctggcggtgc aggaagtgaa gggcattccg acgacggcct atccgacgcc ggcgaagcgt
-     2761 ccgctcaact cgcgcctgtc gaatgaaaaa ttccagcagg cattcggggt gactctcccg
-     2821 gactggcgtc agggtgtggc tcgcgtggta acagaagtcc tgggtaaata aacggttagc
-     2881 aaaagatgaa cattattaaa acagatattc ctgacgtgct gatttttgaa ccgcgcgtgt
-     2941 ttggtgatgc gcggggcttc ttctttgaga gcttcagcag caaggtgttt aatgaggcgg
-     3001 tgggccgtca ggtggaattc gtccaggaca accattcaca gtcccagaaa ggcgtattgc
-     3061 gcgggctgca ctatcagctg gatccgcacg ctcagggcaa gctggtccgc tgtgtggaag
-     3121 gtgaggtgtt tgacgtggca gtggatatcc gtcgttcatc gcctaccttt ggtaaatggg
-     3181 ttggagcggt gctcagcgca gagaataaac gtcagctgtg gatccctgaa ggattcgccc
-     3241 acgggtttat ggcgctgagc gacacggtgc agtttgtcta taaggcgacg aactactacg
-     3301 cgccacagtc agaacggagc atcatctgga acgatccgga gatagggatt gactggccgg
-     3361 cactgagcga ctgcgtgctg tcgctgtcgg agaaagacct gcgggcacat actctggcca
-     3421 ctgcggaagt ctacgcttaa gtataaatat tcttgttcga taatggatat cacaagttac
-     3481 tatcaaaaat aataataata aatatttttt atcctaaagg taatcgatta atgaattata
-     3541 aagcaatgaa gcctaaagtt atcgcttcta ttgtattatt taatcattcc tatgatgata
-     3601 ttaaagatac gttcctctca ttatgccatg aagagagcgt tgaaaaaata atcttcgttg
-     3661 ataatggtgg ttgtcagtgg gcggcatcat tgaatgaacc taaggtgagc tacataaagt
-     3721 ctccttacaa ctgtggtttt ggtgctggac ataatcttgc aataaaagca agtgcagact
-     3781 ttgacggtta tttcttgata tgtaatccgg atattagctt tgataagcag tcacttgata
-     3841 aattagtttc gtttgcgtgg gaaaatgagt atagttttgt ttccccgcaa ataatatata
-     3901 gaaatggtga gagacaatat agttgccgtc tactacctac tcccggtaat ctttttttaa
-     3961 gacgtttctt tccagtgact gcaataaagt acgatgttaa atatgaactg aaagatgcag
-     4021 cctatgatga gatattttcc ccaccaacgg tatctggttg tttcatgtta ttaagtaatg
-     4081 tattattaca aaaacttaac ggttttgatg aacgatactt tatgtatctg gaagatgtag
-     4141 atttatgtcg ccgagcatta cagctaacca aaatatatta ttatcctgga acaactattg
-     4201 tccatgcctt taataaaggt tcgtataaaa gcaaattatt actttggtac catattcgct
-     4261 ccgcagtctc ctattttaat aaatggggat ggtttcttga tcgtaaaaga catgcgtata
-     4321 ataagcaagc catatatgaa attcccaaaa aaataattta atattatttg ccataaaata
-     4381 cgagtttaaa atgaaaaacc ctcatcaaaa actttcatca tcaccattag cagtggtgcg
-     4441 cagtattgcc actcactgga gtattattct gcagatggct aaacgtgatg ttgttggaag
-     4501 atataaaggt tctgtgatgg gcctgctttg gtcttttctg aaccctttat ttatgttaac
-     4561 agtatatact tttgtcttct ccgtggtatt caaagccaga tggtcaactg gtggggatga
-     4621 aagcaggaca cagtttgcta taattttatt tgtcggaatg atagttcatg gttttttaag
-     4681 tgaagtggta aataaagcac cgttgattat tttgggaaat acaaactatg tgaagaaagt
-     4741 tatatttcca ttggaaacgc tgcctgttat ctctttattt gcggcattat ttcatacttg
-     4801 tatcagcctt tgtgtgttac tgatggcgtt tttcattttt aatggatatt tacattggac
-     4861 catagtattt ttacctgtgg tctttttccc tttaattatt ttttgccttg gcatttcgtg
-     4921 gatcttagca tcacttggcg tattcctaag agatgtaagt caaactacgg taatcattac
-     4981 tacagtatta atgtttttat caccggtatt cttccctata agcgccttgc ctgaaaagta
-     5041 tcatatctgg atcatgctca atccattaac ctttattatt gaacaagccc gaacggttct
-     5101 tatttggggt ggtatgccta attttatcgg tctgttttta tattctttgg gtgccttagt
-     5161 catagcctgg atgggttttg ccttcttcca gaaaaccagg aagggatttg ctgatgtcct
-     5221 ctaatgaaat tgccattcag gttacaaacc tgagtaaatg ttatcagata tatgcgcgtc
-     5281 caactgatcg tctaaaacag ttttttgtgc cgaaacttca acaggtggtc cgcagagagc
-     5341 gaaactgcta ttttcgtgag ttttgggccc tcgatgacgt ttccttcagt atcaaaaaag
-     5401 gggaaacggt aggtattatt ggacgaaatg gtgccgggaa gtcgactttg ctgcagatta
-     5461 tctgcggcac actaaccccc tccgctggag atgtacgtgt taatgggcgt attgctgcat
-     5521 tacttgaatt aggtgctggg ttcaacccgg agtttaccgg tcgtgagaac gtttatttaa
-     5581 atggttcggt attaggttta accaaagagc agattgcggc taagtttgct gaaattgaag
-     5641 aatttgcaga tatcggccag ttcattgatc aacccgtaaa aacatactct agcggtatgt
-     5701 atgtccgttt agcctttgcc gttcaagcat gtgttgaacc ggaaattttg attgttgatg
-     5761 aggcgttagc tgttggcgat attggcttcc agtataaatg ctataaacgg atggaagcat
-     5821 tacgtgcgaa aggtgtaacc atcattatgg taactcattc aacaggcagc atccttgagt
-     5881 atgctgatcg ctgcctggtg atggaacacg gaaaactaat cggtgatacc aatgatgttc
-     5941 tcgctgcagt tctggcctat gagaaaggga tgatcctggc caacgataaa ccagagccta
-     6001 caaaacttgc agagaaccgc tcttctgaaa cttgcagttt ggaagacctc aaaagcattc
-     6061 agttacatac tgctaatgaa gaaattgggg aaaaacgttt tggtactgcg cgtgctatta
-     6121 ttaaaaacct taccatctac aaatcagatg gtacgacttt gacagagaaa ccactcatca
-     6181 aatcaggtga agaagttaca tttgatttca ccatattagc taccgaagag attaaggatg
-     6241 ttgctcttgg cctttccata tccaaagctc agggagggga tatttgggga gatagtaata
-     6301 ttggcgcagg ttcgccaatt acacttcgtc caggtagtca gcgtatcgtt tataaagcaa
-     6361 cgctgcctat aaattcgggc gattacctaa tacactgcgg cctcgctatg gttggcaacg
-     6421 gtgctcgaga ggagcttgat caacgtcgcc cgatgatgaa aataaagttt tggtcggcca
-     6481 gagagctagg cggggtcatt catgctccgt taaaaatcat tacaaatgga gagtaaagca
-     6541 tgtttgctgt ttttcttcct ccatatccgt tcagaggggt gaaagcccct tatttatggc
-     6601 tttttttaaa gtatttgcat tgttcaaacg aaaagatact atttatcaca agtcctgatt
-     6661 atgttgaagt aataaacgat gaaacgcaac attcccgttg ggagtttgat actgcctcga
-     6721 tggcatcttt aggatattct cttcctgatg aacaaagcct tgccagacat gaatatctgt
-     6781 accttgatca tgctttgtat gaaaccatgt tggctcaaca tcatcatgat cccataaaat
-     6841 catttaccac atttttaacc gaatctattt ccgagcttga aaatgagtta ttctctttac
-     6901 ttacaaagga aataattcaa cgtgttgatg cttttgtctc tatctgcaac tgtccatcgc
-     6961 ttgaaaaagt cgcaagagct ttaaataaag aggttataca ccttgagatc gggccattgc
-     7021 gagccccgat gtatcgcaat acagcatatc tggatttcac cggcgttaat ggtaataccg
-     7081 aggctcgggc acgctatgaa tcttgccaga cggaaattga tattacgtgc tcaatgaatg
-     7141 atttgcatcg ttattttctt gaagcaatct cattaccttc gtcaagtgaa aaccaagttg
-     7201 ctgggattgt gttacaggta gaagacgatt ccaatatcat tgcttacagc cataatttta
-     7261 cgaatatatc tttaatttct tatgttcgtc aacagcatgc tctcgagaat atattggttc
-     7321 gggcgcatcc tgggagtttg tttcgtttac gagatgacat atttagcatt gatgcatcgg
-     7381 caaacagcct cgaatttatt caaaaatgtc attctattta tactattaac tcaagtgttg
-     7441 gcttagaggc gcttttatgc gagaaaaaga ctaatattct cggtgattgt tcctatgctt
-     7501 ttgtcgctga ggaggcctca ggtcccaaca gagtaaatgc catggcattt tatctgtttg
-     7561 cttatctggt gccctttgaa cttatattta atctggaata tttgcgattc aggttggacc
-     7621 atccagcaga gctggatatc gtacgtaaac acctgcaatt ttattctaaa atgccggatg
-     7681 agcgtgaaga aaacagccat acgctgtcaa cattaataaa cgaagcgatt tccaaagata
-     7741 tcaccatgag aaccatttta gaaaactcat tagccgagaa taacaaacaa cttgaagatt
-     7801 tgaaaacgca gcttgctgcc gaggttactg agcgcgaaaa attagctgca gcgattacca
-     7861 aactccagca aacggcagac ttggcagcaa aagacaggga gatattagtt tccgccctgg
-     7921 cagtcaaaga agatgaagta gatcgtatgc gcagaagtct gtcatggaag ttaaccatgc
-     7981 cagttcgtat gtctggtagg atttcccgag gtgaatttag cactataaaa gcaatgatga
-     8041 gggaatacac gacttccggt aataatgttt tttctcgcta tattttatcg ggtggacttc
-     8101 tttcaaaatc gaaatataaa acggcaattc gtcttctatt gtcaggaaac tggtcaggga
-     8161 tggttgatgg ttttaagcgt gttttaagcc gagctgctat cgactcttca ccagctacgc
-     8221 catttgtcga taatgtaacg gtaagaattc ttgctactca gcatacccta ttcgttgcac
-     8281 atttgattga aaagaatctg cttgattgcg gaattaaggg ccatgtcagt actgcttatt
-     8341 ccgttgagca ggatatgggg cagatgcaca ttgtagtttg tccgcaaatg ttcaaacaac
-     8401 tgccccgtaa ctacattgct ttccagatgg agcagtcggt caactcaaga tggtttaccg
-     8461 atgagtattt ttctcgtctc aataatgctg ttgctatttt tgattattcc ttgaaaaata
-     8521 ttgaatattt actggataaa ggcattccgt atcagaaatt gttttatatg ccgatttcca
-     8581 gctttccaga ttacccagcc catttagcag ataacggtta tgtactggat gatcagaaag
-     8641 gtgatataca cgcagatgtt ctattctatg gcgatccaaa ctgtgagcgc cgcaaggcct
-     8701 atcttcagga attgaagaag cattttaatg tcactgtcgc ttcggaagtt ttcggtgata
-     8761 aactcaccag aatggttaag aatgcgaaag tcgtcgtcaa cattcattac tatgaaaatg
-     8821 cgttgcttga aaccacacgt ctatatgaaa cgatttcgct tgggacgcct gtagtgagtg
-     8881 aaagcagttc agatattgta gagcatgaag acctacagga tgtgatcgat ttttgcccca
-     8941 tcggtgatat tccggcaatg gtcgagaaaa ttcagaattt gttatctgat aaagaatatt
-     9001 acaacgaaag aaaagaaaaa attaagcact ttactaatgt agataataaa aataattatt
-     9061 atctgcgacg ttatctgctg tcgattgata aactcaattt ttcacaatac aaaagtattt
-     9121 tctcatttga gcaatttcaa actggagatg tcccacgcct ttgtttatca ttgtctgaaa
-     9181 cacccgtccg ccggaaagct tttttcgcta gtccatccca tggattccaa tttttcgagg
-     9241 ggatccgtta tcgcattggt tggattggtt gtggcatgag ctataaatat atgctttcag
-     9301 gcatgctggc cagtaaggcg gaaatgggga ttatctgtga agatgatgtt atttttccgg
-     9361 ttgattatga taataaatta aataaaatta ttaaccatct acagagtact gaggctaaat
-     9421 ggcatatttt tgctggcata attgcacatc tgcatgagga cacgaaggta ctggatgtta
-     9481 aggtcatcga tggtattgag tatatctaca ttgacaaaat gactagtatg gttatgaata
-     9541 tttattctcg ccgtggtatg gatcttatta gccagtggga tgagaaaaat attgatgccg
-     9601 aaaccaatac tattgaccgc tatgttgaat cagctcaaga tctggtcgtc gtgactacat
-     9661 tacctttcct tgtaggatac gcagaagagc aacagtcaac attatggggc tttgagaact
-     9721 ctcaatatac atcgttaata aaagccagtg aaaaactgtt agctgaaaag gttgcagaat
-     9781 ttaaaaagaa tcgctaa
-//
-LOCUS       LT174601                8064 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O1/O2, Variant 1.
-ACCESSION   LT174601
-VERSION     LT174601.1  GI:1036211075
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1
-  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
-            Holt,K.E. and Thomson,N.R.
-  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
-            antigens
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 8064)
-  AUTHORS   Informatics,P.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
-            1SA, UNITED KINGDOM
-FEATURES             Location/Qualifiers
-     source          1..8064
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="94"
-                     /serovar="O1/O2 Variant 1"
-                     /db_xref="taxon:573"
-                     /note="O locus: O1α,O2α"
-                     /note="O type: O2α"
-                     /note="Updated from O1/O2v1 by Tom Stanton in Feb 2025"
-     gene            1..768
-                     /gene="wzm"
-     CDS             1..768
-                     /gene="wzm"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002920348.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="lipopolysaccharide O-antigen ABC transport system
-                     transmembrane component"
-                     /protein_id="CZQ25287.1"
-                     /db_xref="GI:1036211076"
-                     /translation="MKYNLGYLFDLLVVITNKDLKVRYKSSMLGYLWSVANPLLFAMIY
-                     YFIFKLVMRVQIPNYTVFLITGLFPWQWFASSATNSLFSFIANAQIIKKTVFPRSVIPL
-                     SNVMMEGLHFLCTIPVIVVFLFVYGMTPSLSWVWGIPLIAIGQVIFTFGVSIIFSTLNL
-                     FFRDLERFVSLGIMLMFYCTPILYASDMIPEKFSWIITYNPLASMILSWRDLFMNGTLN
-                     YEYISILYFTGIILTVVGLSIFNKLKYRFAEIL"
-                     /locus_tag="O1α,O2α_01_wzm"
-     gene            768..1508
-                     /gene="wzt"
-     CDS             768..1508
-                     /gene="wzt"
-                     /EC_number="3.6.3.40"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006499564.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Teichoic acid export ATP-binding protein TagH"
-                     /protein_id="CZQ25288.1"
-                     /db_xref="GI:1036211077"
-                     /translation="MHPVINFSHVTKEYPLYHHIGSGIKDLIFHPKRAFQLLKGRKYLA
-                     IEDVSFTVGKGEAVALIGRNGAGKSTSLGLVAGVIKPTKGTVTTEGRVASMLELGGGFH
-                     PELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGEFIDEPIRVYSSGMLAKLGFSV
-                     ISQVEPDILIIDEVLAVGDIAFQAKCIQTIRDFKKRGVTILFVSHNMSDVEKICDRVIW
-                     IENHRLREVGSADRIIELYKQAMA"
-                     /locus_tag="O1α,O2α_02_wzt"
-     gene            1524..3419
-                     /gene="wbbM"
-     CDS             1524..3419
-                     /gene="wbbM"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006635427.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyltransferase"
-                     /protein_id="CZQ25289.1"
-                     /db_xref="GI:1036211078"
-                     /translation="MNNSVKIYTSHHKPSAFLNAAIIKPLHVGKANSYNEIGCPGDDTG
-                     DNISFKNPFYCELTAHYWVWKNEELADYVGFMHYRRHLNFSEKQTFSEDTWGVVNHPCI
-                     DEEYEKIFGLNEETIQRCVEGIDILLPKKWSVTAAGSKNNYDHYERGEYLHIRDYQAAI
-                     AIVEKLYPEYSTAIKTFNDASDGYYTNMFVMRKDIFVDYSKWLFSILDNLEDAISMNNY
-                     NAQEKRVIGHIAERLFNIYIIKLQQDGELKVKELQRTFVSNETFNGALNPVFDSAVPVV
-                     ISFDDNYAISGGALINSIVRHADKNKNYDIVVLENKVSYLNKTRLVNLTSAHPNISLRF
-                     FDVNAFTEINGVHTRAHFSASTYARLFIPQLFRRYDKVVFIDSDTVVKADLGELLDVPL
-                     GNNLVAAVKDIVMEGFVKFSAMSASDDGVMPAGEYLQKTLNMNNPDEYFQAGIIVFNVK
-                     QMVEENTFAELMRVLKAKKYWFLDQDIMNKVFYSRVTFLPLEWNVYHGNGNTDDFFPNL
-                     KFATYMKFLAARKKPKMIHYAGENKPWNTEKVDFYDDFIENIANTPWEMEIYKRQMSLA
-                     ASIGLTHSEPQQQILFQTKIKNVLMPYVNKYAPIGTPRRNMMTKYYYKVRRAILG"
-                     /locus_tag="O1α,O2α_03_wbbM"
-     gene            3435..4589
-                     /gene="glf"
-     CDS             3435..4589
-                     /gene="glf"
-                     /EC_number="5.4.99.9"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_005955557.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="UDP-galactopyranose mutase"
-                     /protein_id="CZQ25290.1"
-                     /db_xref="GI:1036211079"
-                     /translation="MKSKKILIVGAGFSGAVIGRQLAEQGHQVHIIDQRDHIGGNSYDA
-                     RDAETNVMVHVYGPHIFHTDNETVWNYVNEHAEMMPYVNRVKATVNGQVFSLPINLHTI
-                     NQFFSKTCSPDEARALIAEKGDSTIADPQTFEEQALRFIGKELYEAFFKGYTIKQWGMQ
-                     PSELPASILKRLPVRFNYDDNYFNHKFQGMPKCGYTQMIKSILNHENIKVDLQREFIVE
-                     ERTHYDHVFYSGPLDAFYGYQYGRLGYRTLDFKKFTYQGDYQGCAVMNYCSVDVPYTRI
-                     TEHKYFSPWEQHDGSVCYKEYSRACEENDIPYYPIRQMGEMALLEKYLSLAENEINITF
-                     VGRLGTYRYLDMDVTIAEALKTAEVYLNSLTENQPMPVFTVSVR"
-                     /locus_tag="O1α,O2α_04_glf"
-     gene            4586..5479
-                     /gene="wbbN"
-     CDS             4586..5479
-                     /gene="wbbN"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006635429.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyl transferase"
-                     /protein_id="CZQ25291.1"
-                     /db_xref="GI:1036211080"
-                     /translation="MKYTALIVTFNRLGKLKKTVEETLKLEFTNIVIVNNGSTDGTQAW
-                     LSSIVDTRVIVLTLTENTGGAGGFKTGSQYICEQLASDWVFFYDDDAYPYPDTLKSFSQ
-                     LDKRGCRVFSGLVKDPQGKPCPMNMPFSRVPTSLGDTVRYLRYPGEFIPAANRSMFVQT
-                     VSFVGMVIHRDLLATSLDYIREQLFIYFDDLYFGYQLSLAGEQIMYSPELLFYHDVSIQ
-                     GKLIAPEWKVYYLCRNLILSKKIFQKNGVYSNSAIAIRILKYILILPWQRQKYSYMKFI
-                     LRGISHGIKGISGKYH"
-                     /locus_tag="O1α,O2α_05_wbbN"
-     gene            5492..6625
-                     /gene="wbbO"
-     CDS             5492..6625
-                     /gene="wbbO"
-                     /EC_number="2.4.1.250"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_005227845.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="galactosyl transferase"
-                     /protein_id="CZQ25292.1"
-                     /db_xref="GI:1036211081"
-                     /translation="MRKLCYFINSDWYFDLHWIDRAIASRDAGYEIHIISHFIDDNIIN
-                     KFKTFGFICHNVTLDAQSFNALVFFRTYHDVQKIIKNIKPDLLHCITIKPCLIGGVLAK
-                     KFNLPVIVSFVGLGRVFSSDSMPLKLLRQFTIAAYKYIASNKRCIFMFEHDRDRKKLAK
-                     LVGLEKQQTIVIDGAGINPEIYKYSLEQDNDVPVVLFASRMLWSKGLGDLIEAKKILRS
-                     KNIHFTLNVAGILVENDKDAISLQVIENWHQQGLINWLGRSNNVCDLIEQSNIVALPSV
-                     YSEGVPRILLEASSVGRACIAYDVGGCDSLIIDNDNGIIVKSNSPEELADKLAFLLSNP
-                     KARVEMGIKGRKRIQDKFSSGMIISKTLKTYHDVVEG"
-                     /locus_tag="O1α,O2α_06_wbbO"
-     gene            6748..8064
-                     /gene="kfoC"
-     CDS             6748..8064
-                     /gene="kfoC"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_005227844.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyl transferase family protein"
-                     /protein_id="CZQ25293.1"
-                     /db_xref="GI:1036211082"
-                     /translation="MSERSSSALVSVVIPVHDAAEYISDTLSSILSQSLQDIEVIIIDD
-                     NSADDTLKLLQSFAANDSRIRLLNNSQNIGAGASRNMGLKIASGEYIIFLDDDDYADAN
-                     MLKRMYDHAALLQADVVICRCQSLDLQTHSYAPMPWSVRVDLLPQKELFSSDEITHNFF
-                     DAFIWWPWDKLFRRQAILDTGLQFQDLRTTNDLFFVSAFMLLTKRMAFLDEILISHSIN
-                     RSGSLSVTREKSWHCALDALRALYSFMDSKHLLPSRGRDFNNYAVTFLEWNLNTISGPA
-                     FDSLFTASREFIASLDIDESDFYDDFIKAAHYRLIRLTPEEYLFSLKDRVLHELESSNL
-                     STEKLQASIASQDQVLKAREEEIDELRASVAQKKERIDRLVQRNAYLETEYQKQQEQLT
-                     KLQNELNNAAQRYSALISSLSWKVTRPLRLIKALITRKM"
-                     /locus_tag="O1α,O2α_07_kfoC"
-ORIGIN
-        1 atgaagtaca atttagggta tttatttgat ttacttgttg tgataacaaa taaagatcta
-       61 aaagtgcgct ataagagcag catgctaggc tatttatggt cagtagcaaa tccattgctt
-      121 tttgctatga tttattattt tatatttaag ctggtaatga gagtacaaat tccaaattat
-      181 acagttttcc tcattaccgg cttgtttccg tggcaatggt ttgccagttc ggccactaac
-      241 tcattatttt cattcatcgc taacgctcaa attatcaaga agacagtttt tccccggtcc
-      301 gtgattccgc taagtaatgt gatgatggaa ggcttgcatt ttctttgcac catcccggtt
-      361 attgttgtct ttctttttgt ttatggcatg acgccgtcct tgtcctgggt ttggggtata
-      421 cctctcattg ctattggcca ggtgattttc acctttggtg tttcaatcat cttttcaacg
-      481 ctgaacctgt ttttccgtga cctggagcgc tttgtcagtc tggggattat gctgatgttt
-      541 tattgtacgc cgattttata tgcgtctgat atgattccgg aaaaatttag ctggataatt
-      601 acctacaatc cgctagcgag tatgattctt agttggcgtg atttattcat gaatgggact
-      661 cttaattatg agtatatttc tatactctat tttacgggaa tcattttgac ggttgtcggt
-      721 ttgtctattt tcaataaatt aaaatatcga tttgcagaga tcttgtaatg cacccagtta
-      781 ttaacttcag tcatgttaca aaagagtatc ctctgtacca tcatattggc tcaggaatca
-      841 aagatttaat tttccaccca aaacgcgctt ttcagttgct gaaggggcgg aaatatttag
-      901 ctatcgaaga cgtatccttt acagttggca aaggtgaggc tgttgccctg attggacgta
-      961 atggggcagg aaagagtacc tcgcttggcc tggttgctgg cgtgattaag ccaactaagg
-     1021 gaaccgtcac cactgaagga cgggtggcat cgatgcttga actcggcgga ggctttcatc
-     1081 ctgaacttac cgggcgtgag aatatttacc tgaatgctac tctgctgggc cttaggcgta
-     1141 aagaggtcca gcaacgtatg gaacgtatta ttgaattttc ggaacttgga gaattcatcg
-     1201 acgagcccat cagagtatat tcaagcggaa tgctagctaa gttaggtttt tcggtcatca
-     1261 gtcaggttga accggatatt ttaattattg atgaagttct ggcagtaggt gatatcgctt
-     1321 ttcaggctaa atgtattcag accatcagag attttaagaa aagaggcgtg acgatactct
-     1381 ttgttagcca caatatgagt gacgttgaaa aaatctgcga tagagtcatc tggatcgaaa
-     1441 atcatagact cagagaagtg ggatctgcag atcgaattat tgaactgtac aagcaagcaa
-     1501 tggcttaatc agtgggtaat ataatgaaca atagcgttaa aatctatacc agccaccata
-     1561 agcctagtgc ttttcttaat gctgcaatta tcaaacctct gcatgtcggc aaagcaaatt
-     1621 cttataatga aattggttgc ccaggagatg acactggcga taatatttcc tttaagaatc
-     1681 cgttttattg cgaactaact gcgcattatt gggtttggaa aaacgaagag ctagccgact
-     1741 atgtcggttt tatgcactat cgccgtcatc ttaatttttc cgaaaaacaa actttttctg
-     1801 aggatacctg gggggtagtg aaccatccat gcattgatga agaatatgag aagatctttg
-     1861 gattaaacga agaaacaatt caacggtgtg tcgaaggtat tgatatcttg ctgcccaaaa
-     1921 aatggtctgt cactgcggcg ggaagtaaaa ataattacga tcactatgaa cggggtgaat
-     1981 acttacacat tcgagattat caggctgcca ttgccatcgt tgaaaaacta tatccagagt
-     2041 atagtacagc aataaaaacg tttaatgatg ccagtgatgg ctattacaca aatatgtttg
-     2101 ttatgcgcaa agatattttt gttgattatt ctaagtggct cttttccatt ctggataatc
-     2161 tcgaagatgc catctcgatg aacaattata atgcccagga aaaacgcgtt attgggcata
-     2221 tagctgaacg gctgtttaat atttacataa ttaagttgca acaagatggt gagcttaagg
-     2281 taaaagaatt acagcgtacc tttgtaagta atgaaacatt caatggtgca ctgaatccag
-     2341 tttttgattc tgcggttcca gttgttatca gtttcgatga taattacgca atcagcggtg
-     2401 gcgcattaat taattccatt gtccggcatg cggataaaaa taaaaattat gatatcgtcg
-     2461 tactcgaaaa taaagtaagc tatttgaata aaacacggtt agtaaatcta acctctgctc
-     2521 atccgaatat ttctcttcgt ttttttgacg ttaatgcctt cactgaaata aatggtgtgc
-     2581 atacccgagc gcattttagc gcatcaactt atgcccgtct ttttattcct caactgttca
-     2641 gacgatacga taaagtcgta tttattgatt cggataccgt tgtaaaggct gacctgggtg
-     2701 aactgcttga tgtccctctg ggcaacaatt tagttgcagc ggttaaggat atcgtcatgg
-     2761 aaggttttgt aaaattttct gcaatgtcgg catcagatga tggcgttatg ccggcaggcg
-     2821 aatatttaca gaaaacctta aacatgaata accctgatga atattttcag gcagggatta
-     2881 ttgtttttaa tgtcaaacaa atggtcgaag aaaatacttt tgctgaattg atgcgggtat
-     2941 taaaggcaaa gaaatactgg ttcctcgacc aggatatcat gaataaagta ttttactctc
-     3001 gagtcacatt tctgccatta gagtggaacg tttatcatgg taatggcaac acggatgatt
-     3061 tcttccctaa tcttaagttt gcaacgtata tgaaattttt agcagctcgc aagaagccta
-     3121 aaatgattca ttatgcgggt gagaacaaac catggaatac cgaaaaagtc gatttttatg
-     3181 acgactttat tgagaacatc gctaacactc catgggaaat ggaaatctat aaacgacaga
-     3241 tgtcgttagc ggcttcgatt ggtttaaccc atagcgagcc gcaacaacaa atcttgttcc
-     3301 agaccaaaat caagaacgta ctgatgcctt atgttaataa atatgcacca ataggcacgc
-     3361 caagaagaaa catgatgact aaatattatt acaaagtacg ccgtgctatt cttggataat
-     3421 aaaagagaca acagatgaaa agtaaaaaaa tattgatcgt aggtgcaggc ttctctggtg
-     3481 cagttattgg tcgccagctt gctgagcagg gacatcaagt ccatattatc gatcagcgtg
-     3541 atcatattgg gggaaattcc tatgatgcac gggacgctga aacgaatgtt atggtacatg
-     3601 tttatggacc ccatattttc catactgaca atgaaacagt gtggaactat gtcaacgagc
-     3661 atgcagagat gatgccctat gtgaaccggg ttaaagcgac agttaatggt caggtatttt
-     3721 ccctgcctat taatttgcat accatcaatc agtttttctc aaaaacttgt tcgcctgatg
-     3781 aggccagagc gctcattgct gagaaagggg atagcactat tgctgatcca caaacttttg
-     3841 aagagcaagc gttacgcttt attggtaaag agttatatga ggcctttttt aaaggctata
-     3901 cgattaaaca gtgggggatg caaccctcgg aactgcccgc atctattctt aaacgtcttc
-     3961 ctgttcgttt taactatgat gataattatt ttaaccacaa atttcagggc atgccgaaat
-     4021 gtggttatac gcagatgatt aagtccattc tcaatcatga aaatatcaag gttgacttac
-     4081 agcgggaatt tatcgttgaa gagcgaactc attacgatca cgtattctat agcggtccat
-     4141 tagatgcgtt ttatggctac caatatggcc gtctgggcta tcgaacatta gattttaaaa
-     4201 agtttaccta tcagggtgat taccagggct gcgcagtgat gaactattgt tctgttgatg
-     4261 tcccctatac tcgcatcact gaacataaat atttttctcc ctgggaacaa cacgacggct
-     4321 ctgtttgtta taaagagtat agccgtgctt gcgaagaaaa tgatattcct tactatccta
-     4381 ttcgtcagat gggagagatg gctcttcttg aaaaatattt gtcactggcc gagaatgaaa
-     4441 tcaatatcac ttttgtcggt cgtcttggaa cctaccgtta ccttgatatg gatgtgacca
-     4501 tcgccgaagc attgaaaacg gcagaagtct atttaaattc actcactgaa aatcagccaa
-     4561 tgcctgtgtt tacggtttct gtacgatgaa atatacggca ttgatagtga cattcaatcg
-     4621 gctcggtaaa ctgaaaaaaa ccgttgaaga gaccctcaaa cttgaattca ctaatattgt
-     4681 tattgtcaat aacgggtcca cggatgggac ccaagcctgg ctttcgtcaa ttgttgatac
-     4741 acgagtcatt gtgttaaccc ttaccgagaa taccggtggg gcggggggct ttaaaaccgg
-     4801 tagtcagtat atctgtgaac agctggcaag tgattgggta tttttctacg atgacgatgc
-     4861 ttacccctat ccagacacgt tgaagtcctt ttcacagctg gataagcggg gatgtcgggt
-     4921 atttagtgga ctggtgaaag atccgcaagg aaaaccgtgt ccgatgaata tgccgttctc
-     4981 gcgtgtacca acctcccttg gcgacactgt acgctattta cgctaccctg gagagtttat
-     5041 cccggcagct aatcgttcta tgttcgtaca aacggtttca tttgttggga tggtcataca
-     5101 tcgtgatctg ctcgcgacca gtcttgacta cattcgcgaa cagctcttta tctactttga
-     5161 tgatctttac tttggctatc agctatcatt agctggtgag caaattatgt atagcccgga
-     5221 gttgcttttt tatcatgatg tgagtattca gggcaaactt attgcacctg aatggaaggt
-     5281 ttactatcta tgccgtaatt tgatcctgtc gaagaaaata ttccagaaaa atggcgtgta
-     5341 tagcaattca gcgatagcga tacgcatcct aaaatatata ttaatcctgc catggcaacg
-     5401 tcaaaaatat tcctatatga aatttattct tcgtggaatt tcacatggca taaaaggtat
-     5461 tagtggtaag tatcattaag tgggcatagc aatgagaaaa ttgtgttatt tcataaattc
-     5521 ggattggtac ttcgatttac actggatcga tcgtgccatc gcctcccgtg atgcaggtta
-     5581 tgagattcac atcatcagcc attttattga tgacaacata ataaataaat tcaaaacatt
-     5641 cggctttatt tgccataatg ttactcttga tgctcaatct tttaatgcat tagttttctt
-     5701 tcgtacttac catgatgtgc aaaaaattat taaaaatata aaaccggatc tcttgcattg
-     5761 catcactatc aagccatgtt tgattggtgg tgtgctcgcg aagaaattta atctgccggt
-     5821 catcgtgagt tttgttgggc ttggaagagt attttcttct gacagcatgc ctttaaaatt
-     5881 attgcggcag tttactattg ctgcatataa atatattgct agtaataagc gctgtatatt
-     5941 tatgtttgaa catgaccgcg acagaaaaaa actggctaag ttggttggac tcgaaaaaca
-     6001 acagactatt gttattgatg gtgcaggcat taatccagag atatacaaat attctcttga
-     6061 acaggataac gatgtccctg ttgtattgtt tgccagccgt atgttgtgga gtaaaggact
-     6121 gggcgactta attgaagcga agaaaatatt acgcagtaag aatattcact ttactttgaa
-     6181 tgttgctgga attctggtcg aaaatgataa agatgcgatt tcccttcagg tcattgaaaa
-     6241 ttggcatcag caaggattaa ttaactggtt aggtcgttcg aataacgttt gcgatcttat
-     6301 tgagcaatca aatatcgttg ctttgccgtc agtttattct gaaggtgttc cgcgaattct
-     6361 tctggaagca tcttctgtgg gtcgcgcttg tattgcttat gatgttggtg gttgtgatag
-     6421 ccttattatt gataacgata atggaattat tgttaaaagc aattcacctg aagagctggc
-     6481 tgataaactt gcctttttac ttagcaatcc taaagcacgt gttgaaatgg gtattaaagg
-     6541 acgtaagcgt attcaggata aattctcgag cgggatgatt attagtaaga cgctaaagac
-     6601 ttatcatgat gtggttgagg gatagttgtc gatcaaacgg ttatcctttt ttattaattg
-     6661 ccagatattg tttctttacc atcaaatttt ttttgaagta tattattaac taaaattact
-     6721 gtaacgtgtc acttgggagg cgatcaaatg tctgaaagat cttcaagtgc actggtctct
-     6781 gttgtgatac ctgtgcacga tgctgcagaa tatatatctg atacgctaag ttccatttta
-     6841 tcgcaatcgt tacaggatat tgaagtcatc attattgatg acaattcggc tgatgatacg
-     6901 ttaaagctac tgcagtcctt tgccgctaat gactcgcgta tacgtctttt gaataattcg
-     6961 cagaatatcg gtgcaggtgc atcacgtaac atggggttaa aaatagcaag tggcgaatat
-     7021 atcatttttc ttgatgatga cgattatgcc gatgctaata tgctcaaacg gatgtatgat
-     7081 catgctgcat tgctgcaagc cgatgtggtt atctgccgat gccagtcttt agatctacaa
-     7141 acccattcat atgcaccaat gccatggtct gtgcgcgtag atttactccc ccaaaaagaa
-     7201 ctattttcat cagatgaaat tactcataat ttctttgatg catttatctg gtggccctgg
-     7261 gataagcttt tccgtcgcca ggctatactg gatactgggt tacaattcca ggatttaaga
-     7321 acgactaatg atttattttt tgttagcgct tttatgctac ttaccaaaag aatggcgttc
-     7381 ctggatgaga tcttgatttc tcattccatt aaccgcagtg gttcattatc ggtgaccaga
-     7441 gagaaatcct ggcactgtgc tcttgatgcg ttacgtgccc tctattcctt tatggactca
-     7501 aagcacttgt tgccttcacg tggtagagac tttaataatt atgcagtgac ttttcttgag
-     7561 tggaatttaa atacgatttc tggtccggcg tttgattctt tattcactgc ttcacgcgaa
-     7621 ttcatcgcct cattggatat tgatgaaagc gatttttatg atgattttat caaagcggca
-     7681 cactatcgcc tgattcgatt aacgccggaa gagtatcttt tctcgttaaa agatcgggta
-     7741 ttacatgagc ttgaatcctc taatctatct acagagaagt tgcaagccag tattgcttct
-     7801 caggatcaag ttcttaaagc cagggaagaa gaaattgatg agctaagagc gtccgttgca
-     7861 cagaaaaaag aacgtattga taggttggtc cagcgaaatg catatttaga gactgagtat
-     7921 cagaaacagc aagagcaatt aactaaacta caaaatgaat taaataacgc tgctcaacgt
-     7981 tattcagccc ttatttcatc attgtcatgg aaagttacaa gacctttaag gttaatcaaa
-     8041 gcgttaatca cgaggaaaat gtaa
-//
-LOCUS       LT174602               10812 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O1/O2, Variant 2.
-ACCESSION   LT174602
-VERSION     LT174602.1  GI:1036211083
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1
-  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
-            Holt,K.E. and Thomson,N.R.
-  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
-            antigens
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 10812)
-  AUTHORS   Informatics,P.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
-            1SA, UNITED KINGDOM
-FEATURES             Location/Qualifiers
-     source          1..10812
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="441"
-                     /serovar="O1/O2 Variant 2"
-                     /db_xref="taxon:573"
-                     /note="O locus: O1α,O2β"
-                     /note="O type: O2β"
-                     /note="Updated from O1/O2v2 by Tom Stanton in Feb 2025"
-     gene            1..768
-                     /gene="wzm"
-     CDS             1..768
-                     /gene="wzm"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002920348.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="lipopolysaccharide O-antigen ABC transport system
-                     transmembrane component"
-                     /protein_id="CZQ25294.1"
-                     /db_xref="GI:1036211084"
-                     /translation="MKYNLGYLFDLLVVITNKDLKVRYKSSMLGYLWSVANPLLFAMIY
-                     YFIFKLVMRVQIPNYTVFLITGLFPWQWFASSATNSLFSFIANAQIIKKTVFPRSVIPL
-                     SNVMMEGLHFLCTIPVIVVFLFVYGMTPSLSWVWGIPLIAIGQVIFTFGVSIIFSTLNL
-                     FFRDLERFVSLGIMLMFYCTPILYASDMIPEKFSWIITYNPLASMILSWRDLFMNGTLN
-                     YEYISILYFTGIILTVVGLSIFNKLKYRFAEIL"
-                     /locus_tag="O1α,O2β_01_wzm"
-     gene            768..1508
-                     /gene="wzt"
-     CDS             768..1508
-                     /gene="wzt"
-                     /EC_number="3.6.3.40"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006499564.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Teichoic acid export ATP-binding protein TagH"
-                     /protein_id="CZQ25295.1"
-                     /db_xref="GI:1036211085"
-                     /translation="MHPVINFSHVTKEYPLYHHIGSGIKDLIFHPKRAFQLLKGRKYLA
-                     IEDVSFTVGKGEAVALIGRNGAGKSTSLGLVAGVIKPTKGTVTTEGRVASMLELGGGFH
-                     PELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGEFIDEPIRVYSSGMLAKLGFSV
-                     ISQVEPDILIIDEVLAVGDIAFQAKCIQTIKDFKKRGVTILFVSHNMSDVEKICDRVIW
-                     IENHRLREVGSAERIIELYKQAMA"
-                     /locus_tag="O1α,O2β_02_wzt"
-     gene            1524..3419
-                     /gene="wbbM"
-     CDS             1524..3419
-                     /gene="wbbM"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006635427.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyltransferase"
-                     /protein_id="CZQ25296.1"
-                     /db_xref="GI:1036211086"
-                     /translation="MNNSVKIYTSHHKPSAFLNAAIIKPLHVGKANSCNEIGCPGDDTG
-                     DNISFKNPFYCELTAHYWVWKNEELADYVGFMHYRRHLNFSEKQTFSEDTWGVVNHPCI
-                     DEEYEKIFGLNEETIQRCVEGIDILLPKKWSVTAAGSKNNYDHYERGEYLHIRDYQAAI
-                     AIVEKLYPEYSAAIKTFNDASDGYYTNMFVMRKDIFVDYSEWLFSILDNLEDAISMNNY
-                     NAQEKRVIGHIAERLFNIYIIKLQQDGELKVKELQRTFVSNETFNGALNPVFDSAVPVV
-                     ISFDDNYAVSGGALINSIVRHADKNKNYDIVVLENKVSYLNKTRLVNLTSAHPNISLRF
-                     FDVNAFTEINGVHTRAHFSASTYARLFIPQLFRRYDKVVFIDSDTVVKADLGELLDVPL
-                     GNNLVAAVKDIVMEGFVKFSAMSASDDGVMPAGEYLQKTLNMNNPDEYFQAGIIVFNVK
-                     QMVEENTFAELMRVLKAKKYWFLDQDIMNKVFYSRVTFLPLEWNVYHGNGNTDDFFPNL
-                     KFATYMKFLAARKKPKMIHYAGENKPWNTEKVDFYDDFIENIANTPWEMEIYKRQMSLA
-                     ASIGLTHSEPQQQILFQTKIKNVLMPYVNKYAPIGTPRRNMMTKYYYKVRRAILG"
-                     /locus_tag="O1α,O2β_03_wbbM"
-     gene            3435..4589
-                     /gene="glf"
-     CDS             3435..4589
-                     /gene="glf"
-                     /EC_number="5.4.99.9"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_005955557.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="UDP-galactopyranose mutase"
-                     /protein_id="CZQ25297.1"
-                     /db_xref="GI:1036211087"
-                     /translation="MKSKKILIVGAGFSGAVIGRQLAEKGHQVHIIDQRDHIGGNSYDA
-                     RDAETNVMVHVYGPHIFHTDNETVWNYVNKHAEMMPYVNRVKATVNGQVFSLPINLHTI
-                     NQFFSKTCSPDEARALIAEKGDSTIADPQTFEEQALRFIGKELYEAFFKGYTIKQWGMQ
-                     PSELPASILKRLPVRFNYDDNYFNHKFQGMPKCGYTQMIKSILNHENIKVDLQREFIVD
-                     ERTHYDHVFYSGPLDAFYGYQYGRLGYRTLDFKKFTYQGDYQGCAVMNYCSVDVPYTRI
-                     TEHKYFSPWEQHDGSVCYKEYSRACEENDIPYYPIRQMGEMALLEKYLSLAENETNITF
-                     VGRLGTYRYLDMDVTIAEALKTAEVYLNSLTDNQPMPVFTVSVR"
-                     /locus_tag="O1α,O2β_04_glf"
-     gene            4586..5479
-                     /gene="wbbN"
-     CDS             4586..5479
-                     /gene="wbbN"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006635429.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyl transferase"
-                     /protein_id="CZQ25298.1"
-                     /db_xref="GI:1036211088"
-                     /translation="MKYTALIVTFNRLGKLKKTVEETLKLEFTNIVIVNNGSTDGTQAW
-                     LSSIVDTRVIVLTLTENTGGAGGFKTGSQYICEQLASDWVFFYDDDAYPYPDTLKSFSQ
-                     LDKRGCRVFSGLVKDPQGKPCPMNMPFSRVPTSLGDTVRYLRYPGEFIPAANRSMFVQT
-                     VSFVGMVIHRDLLATSLDHIHEQLFIYFDDLYFGYQLSLAGEKIMYSTELLFYHDVSIQ
-                     GKLIAPEWKVYYLCRNLILSKKIFQKNAVYSNSAIAIRILKYILILPWQRQKYSYMKFI
-                     LRGISHGIKGISGKYH"
-                     /locus_tag="O1α,O2β_05_wbbN"
-     gene            5492..6622
-                     /gene="wbbO"
-     CDS             5492..6622
-                     /gene="wbbO"
-                     /EC_number="2.4.1.21"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_005227845.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="galactosyl transferase"
-                     /protein_id="CZQ25299.1"
-                     /db_xref="GI:1036211089"
-                     /translation="MRKLCYFINSDWYFDLHWIDRAIASRDAGYEIHIISHFIDDNIIN
-                     KFKTFGFICHNVTLDAQSFNALVFFRTYHDVQKIIKNIKPDLLHCITIKPCLIGGVLAK
-                     KFNLPVIVSFVGLGRVFSSDSMPLKLLRQFTIAAYKYIASNKRCIFMFEHDRDRKKLAK
-                     LVGLEEQQTIVIDGAGINPEIYKYSLEQDHDVPVVLFASRMLWSKGLGDLIEAKKILRS
-                     KNIHFTLNVAGILVENDKDAISLQVIENWHQQGLINWLGRSNNVCDLIEQSNIVALPSV
-                     YSEGVPRILLEASSVGRACIAYDVGGCDSLIIDNDNGIIVKSNSPEELADKLAFLLSNP
-                     KARVEMGIKGRKRIQDKFSSVMIIDKTLQIYHDVVR"
-                     /locus_tag="O1α,O2β_06_wbbO"
-     gene            6718..7926
-                     /gene="kfoC"
-     CDS             6718..7926
-                     /gene="kfoC"
-                     /EC_number="2.4.1.212"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006635431.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="capsular polysaccharide biosynthsis protein"
-                     /protein_id="CZQ25300.1"
-                     /db_xref="GI:1036211090"
-                     /translation="MAHEKSDIIVSVVIPVYNAEEYIADTLKNIVSQSLYEIEIIIIND
-                     HSSDNTLDILKEIASSDERIRIIDNAVNIGAGISRNIGLSEAKGEYIIFLDDDDYVDTN
-                     MLKHMSDCAELSGADIVVCRSRSFNLQSLQYAPMPDSIRKDLLPEKAVFSPGDIERDFF
-                     RAFIWWPWDKLFRREFIIQHSLSYQDLRTSNDLFFVCASMLSAEKVTILDEILITHTIN
-                     RKTSLSSTRSVSYHCALDALVALRDFLFKNGMMQKRQRDFYNYIVVFLEWHLNTLSGEA
-                     FNKLFQDVKLFISSFDINNEDFYDEFILSAYRRIADMSAEEYLFSLKDRVLNELENAQR
-                     NILTLQNEVEEIKQQLQQKDEMIASMNRENLAIKADNKILENYNEELKTVQTKFLKLLS
-                     SKD"
-                     /locus_tag="O1α,O2β_07_kfoC"
-     gene            complement(7996..9456)
-                     /gene="gmlC"
-     CDS             complement(7996..9456)
-                     /gene="gmlC"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Uncharacterised protein"
-                     /protein_id="CZQ25301.1"
-                     /db_xref="GI:1036211091"
-                     /translation="MQNLINPLAEGNKKNVYIFYFFLLMLTFSPVIFFSYAFSDDWSTL
-                     FDAITRNGSSFQWDVQSGRPVYAVFRYYGKMLINDISSFSYLRLFNILSLVVLSCFIYN
-                     FIDSRKIFDNPVFKIIFPLLICLLPAFQVYASWATCFPFTISVLLAGISYNKCFPHSKQ
-                     RSSLPEKLASIVVLWVAFAIYQPTAITFLFFFMLDSCIKKESSLTVKKVATCFIILVIG
-                     VAGSFIMSKVLPVWLYGESLSRAELTADIGGKMKWFINESLINAVNNYNIQPVKIYSWF
-                     SSFAILIGLYTIFVGKTGRWKTFIVITIGIGSYAPNLATKENWAAFRSLVALELIISTL
-                     FLIGINSLVSRISKQAFVWPLIALTIMIIAQYNIINGFIIPQRSEIQALAAEITNKIPK
-                     NYTGKLMFDLTDPAYNAFTKTQRYDEFGNISLAAPWALKGMAEEIRIMKGFNFKLSNNV
-                     IISETNRCIDDCMVIKTSDAMRRSTINY"
-                     /locus_tag="O1α,O2β_08_gmlC"
-     gene            complement(9458..10438)
-                     /gene="gmlB"
-     CDS             complement(9458..10438)
-                     /gene="gmlB"
-                     /EC_number="2.4.-.-"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006635432.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyltransferase"
-                     /protein_id="CZQ25302.1"
-                     /db_xref="GI:1036211092"
-                     /translation="MTTSTDIKSTPSLAIVVPCYNEQEAFPFCLEKLSNVLNSLIARNK
-                     INNNSYLLFVDDGSRDNTWAQIKDASTAYHYVRGIKLSRNKGHQIALMAGLRSVDTDVT
-                     ISIDADLQDDVNCIEKMIDAYSQGYDIVYGVRGNRDSDTFFKRTTANAFYAIMSHLGVN
-                     QTPNHADYRLLSNRALEALKQYKEQNIYLRGLVPLVGYPSIEVQYSREERIAGESKYPI
-                     KKMLALALEGITSLSVTPLRIIAMTGFITCIISTIAAIYALIQKTTGTTVEGWTSVMIA
-                     IFFLGGVQMLSLGIIGEYVGKIYIETKNRPKYFIDESVGNDSNGK"
-                     /locus_tag="O1α,O2β_09_gmlB"
-     gene            complement(10435..10812)
-                     /gene="gmlA"
-     CDS             complement(10435..10812)
-                     /gene="gmlA"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_005020797.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="GtrA-like protein"
-                     /protein_id="CZQ25303.1"
-                     /db_xref="GI:1036211093"
-                     /translation="MPSSGPLWQLMKYGLVGIVNTLITAVVIFLLMHLGLGIYLSNAMG
-                     YVVGIVFSFIANTIFTFTQPISINRLIKFLCVCFICYVANIIVIKIFFVFMPEKIYSAQ
-                     ILGMFTYTITGFILNKFWAMK"
-                     /locus_tag="O1α,O2β_10_gmlA"
-ORIGIN
-        1 atgaagtaca atttagggta tttatttgat ttacttgttg tcataacaaa taaagatcta
-       61 aaagtgcgct ataagagcag catgctaggc tatttatggt cagtagcaaa tccattgctt
-      121 tttgccatga tttattattt tatatttaag ctggtaatga gagtacaaat tccaaattat
-      181 actgttttcc tcattaccgg cttgtttccg tggcaatggt ttgccagttc ggccactaac
-      241 tcattatttt cattcatcgc taacgctcaa attatcaaga agacagtttt tccccggtcc
-      301 gtgattccgc taagtaatgt aatgatggaa gggttgcatt ttctttgcac catcccggtt
-      361 attgtagtct ttctttttgt ttatggcatg acgccgtcct tgtcctgggt ttggggtata
-      421 cctctcattg ctattggcca ggtgattttc acctttggtg tttcaatcat cttttcaacg
-      481 ctgaacctgt ttttccgtga cctggagcgc tttgtcagtc tagggattat gctgatgttt
-      541 tattgtacgc cgattttata tgcgtctgat atgattccgg aaaaatttag ctggataatt
-      601 acctacaatc cgctagcgag tatgattctt agttggcgtg atttattcat gaatgggact
-      661 cttaattatg agtatatttc tatactctat tttacgggaa tcattttgac ggttgtcggt
-      721 ttgtctattt tcaataaatt aaaatatcga tttgcagaga tcttgtaatg cacccagtta
-      781 ttaacttcag tcatgttaca aaagagtatc ctctgtacca tcatattggc tcaggaatca
-      841 aagatttaat tttccatccg aaacgcgctt ttcagttgct gaaggggcgg aaatatttag
-      901 ctatcgaaga cgtatccttt acagttggca aaggtgaggc tgttgccctg attggacgta
-      961 atggggcagg aaagagtacc tctcttggcc tggttgccgg cgtgattaag ccaactaagg
-     1021 gaaccgtcac cactgaagga cgggtggcat cgatgcttga actcggcgga ggctttcatc
-     1081 ctgaacttac cgggcgtgag aatatttacc tgaatgctac tctgctgggc cttcggcgta
-     1141 aagaggtcca gcaacgtatg gaacgtatta ttgaattttc ggaactggga gaattcatag
-     1201 acgagccaat cagagtgtac tcaagcggaa tgctagctaa gttaggtttt tcggtcatca
-     1261 gtcaggttga accggatatt ttaattattg atgaagttct ggcagtaggt gatatcgctt
-     1321 ttcaggcaaa atgtattcag accatcaaag attttaagaa aagaggcgtg acaatattgt
-     1381 ttgttagcca caatatgagt gacgttgaaa aaatctgcga cagagtcatc tggatcgaaa
-     1441 atcataggct cagagaagtg gggtctgcag agcgaatcat tgaactgtac aagcaagcaa
-     1501 tggcttaatc agtgggtaat ataatgaaca atagcgttaa aatctatacc agccaccata
-     1561 agcctagtgc ttttcttaat gctgcaatta tcaaacctct gcatgtcggc aaagctaatt
-     1621 cttgtaatga aattggttgt ccaggagatg acactggcga taatatttcc tttaagaatc
-     1681 cgttttattg cgaacttact gcgcattatt gggtttggaa aaacgaagag ctggcagact
-     1741 atgtcggttt catgcactat cgccgtcatc ttaatttttc cgaaaaacaa actttttctg
-     1801 aggatacgtg gggggtcgtg aaccatccat gcattgatga agaatatgag aagatctttg
-     1861 gattaaacga agaaacaatt caacggtgtg tcgaaggtat tgacatcttg ctgcccaaaa
-     1921 aatggtctgt cactgcggcg ggaagtaaaa ataattacga tcactatgaa cgaggtgaat
-     1981 acttacatat tcgtgattat caggctgcca ttgccatcgt tgaaaaacta tatccagagt
-     2041 atagcgcggc aataaaaacg tttaatgatg ccagtgatgg ctattacaca aatatgtttg
-     2101 tcatgcgcaa agatattttt gttgactatt ctgagtggct cttttccatt ctggataatc
-     2161 tcgaagatgc tatctcgatg aacaattata atgctcagga aaaacgcgtt attgggcata
-     2221 tagcagaacg gctgtttaat atttacatta ttaagttgca acaagatggt gagcttaagg
-     2281 taaaagaatt acagcgtact tttgtcagca atgaaacatt caatggtgca ctgaatccag
-     2341 tttttgattc tgcggttcca gtggttatca gtttcgatga taattacgca gtcagcggtg
-     2401 gtgcattaat taattccatt gtccggcatg cggataaaaa taaaaattat gatatcgtcg
-     2461 tactcgaaaa caaagtaagc tatttgaata aaacgcggtt agtaaatcta acctcggctc
-     2521 atccgaatat ttctcttcgt ttttttgacg ttaatgcttt cactgaaata aacggtgtgc
-     2581 atacccgagc gcattttagc gcatcaacgt atgcccgtct ttttattcct caactgttca
-     2641 gacgatacga taaagtcgta tttattgatt cggataccgt tgtaaaggct gacctgggcg
-     2701 aactgcttga tgtccctctg ggcaacaatt tagttgcagc ggttaaggat atcgtcatgg
-     2761 aaggttttgt aaaattttct gcaatgtcgg catcagatga tggcgttatg ccggcaggcg
-     2821 aatatttaca gaaaacctta aacatgaata accctgatga atattttcag gcagggatta
-     2881 ttgtttttaa tgtcaaacaa atggtcgaag aaaatacttt tgctgaattg atgcgggtat
-     2941 taaaggcaaa aaaatactgg ttcctcgacc aggatatcat gaataaagtt ttctactctc
-     3001 gagtcacatt tctgccatta gagtggaacg tttatcatgg taatggcaac acggatgatt
-     3061 tcttccctaa tcttaagttt gcaacgtata tgaaattttt agcagctcgc aagaagccta
-     3121 aaatgattca ttatgcgggt gagaacaaac catggaatac cgaaaaagtc gatttttatg
-     3181 acgactttat tgaaaacatc gctaacactc catgggagat ggaaatctat aaacgtcaga
-     3241 tgtcgttagc ggcttcgatt ggtttaaccc atagcgagcc gcaacaacaa atcttgttcc
-     3301 agaccaaaat caagaacgta ctgatgcctt atgttaataa atatgcacca ataggcacgc
-     3361 caagaagaaa catgatgact aaatattatt acaaagtacg ccgtgctatt cttggataat
-     3421 aaaagagaca acagatgaaa agtaaaaaaa tattgatcgt aggtgctggc ttctctggtg
-     3481 cagttatcgg tcgccaactt gctgagaagg gacatcaagt ccatattatc gatcagcgtg
-     3541 atcatattgg ggggaattcc tatgatgcac gggacgctga aacgaatgtg atggtacatg
-     3601 tttatggacc ccatattttc catactgaca atgaaacagt gtggaactat gtcaacaagc
-     3661 atgcagagat gatgccctat gtgaaccggg ttaaagcgac agttaatggt caggtatttt
-     3721 ccctgcctat taatttgcat actatcaatc agtttttctc aaaaacttgt tcgcctgatg
-     3781 aggccagagc gctcattgct gagaaagggg acagcactat tgctgatcca caaacttttg
-     3841 aagagcaagc gttacgcttt attggtaaag agttatatga ggcctttttt aaaggatata
-     3901 cgattaaaca gtgggggatg caaccctcgg aactgcccgc atctattctt aaacgtcttc
-     3961 ctgttcgttt taactatgat gataattatt ttaaccacaa atttcagggc atgccgaaat
-     4021 gtggttatac gcagatgatt aagtccattc tcaatcatga aaatatcaag gttgacttac
-     4081 agcgggaatt tatcgttgac gagcgaactc attacgatca cgtattctat agcggtccat
-     4141 tagatgcgtt ttatggctac caatatggcc gtctgggcta tcgaacatta gattttaaaa
-     4201 agtttaccta tcagggtgat taccagggct gcgcagtgat gaactattgt tctgttgatg
-     4261 tcccctatac tcgcatcact gaacataaat atttttctcc ctgggaacaa cacgacggct
-     4321 ctgtttgtta taaagagtat agccgtgctt gtgaagaaaa tgatattcct tactatccta
-     4381 ttcgccagat gggagagatg gctcttcttg aaaaatattt gtcactggcc gagaatgaaa
-     4441 ccaatatcac ttttgtcggt cgtcttggaa cctaccgtta cctcgacatg gatgtgacca
-     4501 tcgccgaagc attgaaaacg gcagaagtct atttaaattc actcactgat aatcagccaa
-     4561 tgcctgtgtt tacggtttct gtacgatgaa atatacggca ttgatagtga cattcaatcg
-     4621 tctcggcaaa ctgaaaaaaa ccgttgaaga gaccctcaaa cttgaattca ctaatattgt
-     4681 tattgtcaat aacgggtcca cggatgggac ccaagcctgg ctttcgtcaa ttgttgatac
-     4741 acgagtcatt gtattaaccc tcaccgagaa taccggtggg gcggggggct ttaaaaccgg
-     4801 tagtcagtat atctgtgaac agctggcaag tgattgggta tttttctacg atgatgatgc
-     4861 ttacccctat ccagacacgt tgaagtcctt ttcacagctg gataagcggg gatgtcgggt
-     4921 atttagtgga ctggtgaaag atccgcaagg aaaaccgtgt ccgatgaata tgccgttctc
-     4981 gcgtgtgcca acttcacttg gcgacactgt acgctattta cgctaccctg gagagtttat
-     5041 cccggcagct aatcgttcta tgttcgtaca aacggtttca tttgttggga tggtcataca
-     5101 tcgtgatctg ctcgcgacca gtcttgacca catccatgaa cagcttttta tctactttga
-     5161 tgatctttac tttggctatc agctatcact agctggtgag aaaattatgt atagcacgga
-     5221 gttgcttttt tatcatgatg tgagtattca gggcaaactt attgcacctg aatggaaggt
-     5281 ttactatctc tgccgtaatt tgatcctgtc gaagaaaata ttccagaaaa atgccgtgta
-     5341 tagcaattca gcgatagcga tacgcatcct aaaatatata ttaatcctgc catggcaacg
-     5401 tcaaaaatat tcctatatga aatttattct tcgtggaatt tcacatggca taaaaggtat
-     5461 tagtggtaag tatcattaag tgggcatagc aatgagaaaa ttgtgttatt tcataaattc
-     5521 ggattggtac ttcgatttac actggatcga tcgtgccatc gcctcccgtg atgcaggtta
-     5581 tgagattcac atcatcagcc attttattga tgacaacata ataaataaat tcaaaacatt
-     5641 tggctttatt tgccataatg ttactcttga tgctcaatct tttaatgcat tagttttctt
-     5701 tcgtacttac catgatgtgc aaaaaattat taaaaatata aaaccggatc tcttgcattg
-     5761 catcactatc aagccatgtt tgattggtgg tgtgctcgcg aagaaattta atctgccggt
-     5821 catcgtaagt tttgttgggc ttggaagagt attttcttct gacagcatgc ctttaaaatt
-     5881 attgcggcag tttactattg ctgcatataa atatattgcc agtaataagc gctgtatatt
-     5941 tatgtttgaa catgaccgcg acagaaaaaa actggctaag ttggttggac tcgaagaaca
-     6001 acagactatt gttattgatg gtgcaggcat taatccagag atatacaaat attctcttga
-     6061 acaggatcac gatgtccctg ttgtattgtt tgccagccgt atgttgtgga gtaaaggact
-     6121 gggcgactta attgaagcga agaaaatatt acgcagtaag aatattcact ttactttgaa
-     6181 tgttgctgga attctggtcg aaaatgataa agatgcaatt tcccttcagg tcattgaaaa
-     6241 ttggcatcag caaggattaa ttaactggtt aggtcgttcg aataatgttt gcgatcttat
-     6301 tgagcaatca aatatcgttg ctttgccgtc agtttattct gaaggtgttc cgcgaattct
-     6361 tctggaagca tcttctgtgg gtcgcgcttg tattgcttat gatgttggtg gttgtgatag
-     6421 ccttattatt gataacgata atggaattat tgttaaaagc aattcacctg aagagctggc
-     6481 tgataaactt gcctttttac ttagcaatcc taaagcacgc gttgaaatgg gtattaaggg
-     6541 gaggaaacgt atacaagata aattttctag tgttatgatt atcgataaaa cattgcaaat
-     6601 atatcatgat gtagttcgat gatgtgtaag tttcacattt attattgcga aaaaccttca
-     6661 tattgataat agtaatgttt atataatgta attcaattta ctactaatgg tatttttatg
-     6721 gctcatgaaa aaagtgatat aattgtttcg gtcgttattc ctgtttacaa cgccgaagag
-     6781 tatattgcag atactctaaa aaacattgtt tcacagtcat tgtatgaaat tgaaattata
-     6841 ataatcaatg atcattcgag tgataataca ttagatatcc ttaaggagat tgcatccagc
-     6901 gatgaaagaa tacgaattat tgataacgct gtaaatattg gagctggcat atcacgtaat
-     6961 ataggtcttt cagaagcaaa gggagaatat ataatatttc ttgatgacga tgattatgtc
-     7021 gatacgaaca tgttgaagca catgtctgat tgtgcggagc tatcaggggc agatatcgtt
-     7081 gtatgcagaa gccgctcatt taatctacaa tctctccagt atgctccaat gccagattca
-     7141 attcgaaaag atttattacc tgaaaaagca gttttctcgc ctggagatat tgagcgagac
-     7201 tttttcaggg catttatatg gtggccatgg gacaaactat tccgacgtga atttattatt
-     7261 cagcactcgt tgagctacca agatttaaga acatcaaatg atctgttttt tgtgtgtgca
-     7321 tctatgctta gtgccgaaaa ggtaactatt cttgatgaaa tattgattac tcatacgatt
-     7381 aatcgaaaaa catcattgtc ttcaactcgc tccgtttcct atcattgcgc acttgatgct
-     7441 cttgttgctc taagggattt tctttttaaa aatggcatga tgcaaaagcg acaaagggat
-     7501 ttttataatt acattgtcgt attccttgag tggcacttaa atacgctatc gggtgaagcc
-     7561 tttaataaac tgtttcaaga tgtcaaatta ttcatcagca gttttgatat caataatgaa
-     7621 gacttttatg atgagtttat tctttctgct tatcgacgaa tcgctgatat gtctgctgaa
-     7681 gagtatcttt tttcattaaa agatcgggtt cttaatgaat tagagaatgc ccaacgaaat
-     7741 attttgacct tacaaaacga agttgaggag ataaaacagc agcttcaaca aaaggacgaa
-     7801 atgattgctt ctatgaatag ggaaaattta gctattaaag cagataataa aattctcgaa
-     7861 aattacaatg aagaactaaa gactgttcag acaaagtttc ttaaactact ctcaagtaaa
-     7921 gactagtatt taaaagcgta ttttatgatt actgtaatag cgcccccata aaaaatgagg
-     7981 gcggcataga aattactaat aatttatcgt tgaccttcgc attgcatctg acgttttaat
-     8041 aaccatacaa tcatcaatac atcgattggt ctcagaaatt ataacgttgt tagatagttt
-     8101 gaaattaaat cctttcataa ttctgatctc ttcagccata cctttgagcg cccagggcgc
-     8161 tgctaatgaa atattcccaa actcatcata tctctgtgtt tttgtaaagg cattgtaagc
-     8221 aggatctgtg agatcgaaca ttaattttcc tgtgtaattc ttaggtattt tattagttat
-     8281 ttccgcagca agtgcctgaa tttcagagcg ttgaggaata ataaatccat ttataatatt
-     8341 atactgagct attatcataa ttgttaaagc gataagaggc cagacaaatg cttgcttaga
-     8401 aattctactg acaaggctat ttatgccaat aagaaataga gttgatataa taagttctaa
-     8461 ggccactaac gagcggaatg ctgcccaatt ttcttttgtc gctaaatttg gagcgtagga
-     8521 acctatcccg atcgttatga ctatgaacgt tttccatctg cctgtttttc ccacaaaaat
-     8581 agtgtataag ccgattaaaa ttgcaaatga ggagaaccaa gaatatattt ttactggttg
-     8641 tatgttatag ttatttacag cgtttattag tgattcattt atgaaccatt tcatctttcc
-     8701 accgatatct gcggttaact cggctctcga taatgattcc ccatatagcc agacaggaag
-     8761 tacttttgac atgataaaac tgcctgcaac accgataact aaaatgataa aacatgtcgc
-     8821 aacttttttc acagttaaac tactttcttt ttttatgcaa ctatcaagca taaaaaagaa
-     8881 taagaatgta attgctgtcg gttgatatat tgcaaatgcc acccataaga caacaatgga
-     8941 tgctaatttt tctggcaatg acgaccgctg cttcgaatgt gggaaacatt tattataact
-     9001 aatacctgcc agcaatactg aaatagtgaa cgggaaacat gttgcccatg aagcataaac
-     9061 ttgaaacgca gggagtaagc aaattaacag cggaaatatt attttgaata cggggttatc
-     9121 aaatattttt ctgctgtcta tgaagttgta aataaaacaa cttaagacaa caagacttaa
-     9181 tatattaaaa agccgcaaat acgaaaatga agaaatatca ttaattaaca tttttccata
-     9241 gtaacggaac acagcataaa cgggacgacc agattggaca tcccactgaa acgaagagcc
-     9301 gtttcttgtt atagcatcaa agagtgttga ccagtcgtct gaaaatgcat atgaaaagaa
-     9361 aattaccggt gaaaatgtta acataagcaa aaagaaataa aaaatgtaaa cgtttttttt
-     9421 atttccctct gctaaaggat tgatcagatt ttgcatgtta ttttccattg ctatcattac
-     9481 ctacgctttc gtcaatgaaa tatttaggtc tatttttcgt ctctatataa atttttccga
-     9541 catattctcc tataatacct aaagaaagca tttgcacgcc gccaagaaag aatatagcga
-     9601 tcatgactga tgtccatccc tcaactgtag tacctgttgt tttttgaatt aaagcataaa
-     9661 tcgcagcgat ggtagatatg atgcaagtta taaaacctgt catagctata attcgtaacg
-     9721 gtgtaactga taatgaggta attccctcga gagccagcgc aagcattttt ttaattggat
-     9781 attttgattc accggcaatt ctttcttcac ggctatattg cacctcgatc gaggggtatc
-     9841 ccacaagagg cactaatcca cgtaaatata tattttgctc tttatattgt ttaagagcct
-     9901 ccaatgctcg attacttaat aatcgataat ctgcatgatt tggagtttga tttactccca
-     9961 agtgggacat tattgcgtaa aatgcattag ctgttgtacg tttaaaaaac gtgtcactgt
-    10021 ctcgattacc tcttacgccg tatactatgt catatccctg gctgtaagcg tcaatcattt
-    10081 tttcgatgca atttacatcg tcttgtagat ccgcatcgat gctaatggtt acgtctgtat
-    10141 cgaccgagcg taaccctgcc atcaacgcaa tttgatgtcc tttatttctt gataatttta
-    10201 ttcctcgcac atagtgataa gcggtcgagg catctttaat ttgtgcccaa gtattgtcac
-    10261 gactaccatc atcgacaaac aaaagataac tattgttatt aattttattt ctggctatca
-    10321 atgaatttag tacattcgaa agcttttcga gacagaaagg aaaagcctct tgttcattat
-    10381 agcaaggtac cacaatagct aaagaaggag tgctttttat atcagttgag gttgtcattt
-    10441 catcgcccag aacttgttta aaataaaacc tgtgatagtg tatgtgaaca tcccaaggat
-    10501 ttgtgctgaa tatatttttt ctggcataaa aacgaaaaat atttttatga caatgatatt
-    10561 tgccacataa caaatgaagc aaacacataa aaattttatt agtctattga tactgattgg
-    10621 ttgcgtaaat gtaaatattg tgtttgctat aaagctgaaa acaataccta caacataacc
-    10681 catcgcattg gacagataaa tgccaagacc caaatgcatt agcaggaaaa ttacaactgc
-    10741 tgtaattagt gtattgacta tcccaactaa cccatatttc attagttgcc ataatgggcc
-    10801 tgaacttggc at
-//
-LOCUS       LT174603               11906 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O3/O3a.
-ACCESSION   LT174603
-VERSION     LT174603.1  GI:1036211094
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1
-  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
-            Holt,K.E. and Thomson,N.R.
-  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
-            antigens
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 11906)
-  AUTHORS   Informatics,P.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
-            1SA, UNITED KINGDOM
-FEATURES             Location/Qualifiers
-     source          1..11906
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="AKPRH077088"
-                     /serovar="O3/O3a"
-                     /db_xref="taxon:573"
-                     /note="O locus: O3α"
-                     /note="O type: O3α"
-                     /note="annotation edited from original by K. Wyres Jan
-                     2018"
-                     /note="Updated from O3/O3a by Tom Stanton in Feb 2025"
-     gene            1..1416
-                     /gene="manC"
-     CDS             1..1416
-                     /gene="manC"
-                     /EC_number="2.7.7.13"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006635421.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="mannose-1-phosphate guanylyltransferase"
-                     /protein_id="CZQ25304.1"
-                     /db_xref="GI:1036211095"
-                     /translation="MLLPVIMAGGTGSRLWPMSRELYPKQFLRLYGQNSMLQETITRLS
-                     GLEIHEPMVICNEEHRFLVAEQLRQLNKLSNNIILEPVGRNTAPAIALAALQATRHGDD
-                     PLMLVLAADHIINNQPVFHDAIRVAEQYADEGHLVTFGIVPNAPETGYGYIQRGVALTD
-                     SAHTPYQVARFVEKPDRERAEAYLASGEYYWNSGMFMFRAKKYLSELAKFRPDILEACQ
-                     AAVNAADNGSDFISIPHDIFCECPDESVDYAVMEKTADAVVVGLDADWSDVGSWSALWE
-                     VSPKDEQGNVLSGDAWVHNSENCYINSDEKLVAAIGVENLVIVSTKDAVLVMNRERSQD
-                     VKKAVEFLKQNQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
-                     AEHWVILAGTGQVTVNGKQFLLTENQSTFIPIGAEHSLENPGRIPLEVLEIQSGSYLGE
-                     DDIIRIKDQYGRC"
-                     /locus_tag="O3α_01_manC"
-     gene            1439..2821
-                     /gene="manB"
-     CDS             1439..2821
-                     /gene="manB"
-                     /EC_number="5.4.2.2"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237527.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="phosphomannomutase"
-                     /protein_id="CZQ25305.1"
-                     /db_xref="GI:1036211096"
-                     /translation="MTQLTCFKAYDIRGELGEELNEDIAYRIGRAYGEFLKPGKIVVGG
-                     DVRLTSESLKLALARGLMDAGTDVLDIGLSGTEEIYFATFHLGVDGGIEVTASHNPMNY
-                     NGMKLVRENAKPISGDTGLRDIQRLAEENQFPPVDPARRGTLRQISVLKEYVDHLMGYV
-                     DLANFTRPLKLVVNSGNGAAGHVIDEVEKRFAAAGAPVTFIKVHHQPDGHFPNGIPNPL
-                     LPECRQDTADAVRAHQADMGIAFDGDFDRCFLFDDEASFIEGYYIVGLLAEAFLQKQPG
-                     AKIIHDPRLTWNTVDIVTRSGGQPVMSKTGHAFIKERMRQEDAIYGGEMSAHHYFRDFA
-                     YCDSGMIPWLLVAELLCLKNSSLKSLVADRQAAFPASGEINRKLGNAAEAIARIRAQYE
-                     PAAAHIDTTDGISIEYPEWRFNLRTSNTEPVVRLNVESRADTALMNEKTAELLNLLKEE
-                     SL"
-                     /locus_tag="O3α_02_manB"
-     gene            2827..3612
-                     /gene="wzm"
-     CDS             2827..3612
-                     /gene="wzm"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237528.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="ABC transporter permease"
-                     /protein_id="CZQ25306.1"
-                     /db_xref="GI:1036211097"
-                     /translation="MFSAIYRYRGFIIDSVKRDFQSRYQTSFLGAAWLILQPIAMISVY
-                     TLIFSELMRARLAGMDGPFAYSIYLCSGVLTWGLFTETLGNLVNVFLTNANILKKLSFP
-                     RICLPIIVTASAFINFLIIFGLFVLFLIVTGNFPGMIFFEIIPVLIVQMLFTLGLGIIL
-                     GVLNVFVRDVGQFVNILLQFWFWFTPIVYVSKTLPEWVSGLLAYNPMATIIGSYQNVML
-                     YHQSPNWMALLPVTVVSVILFLFAWRLFKKHAADIVDEI"
-                     /locus_tag="O3α_03_wzm"
-     gene            3615..4910
-                     /gene="wzt"
-     CDS             3615..4910
-                     /gene="wzt"
-                     /EC_number="3.6.3.40"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237529.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="ABC transporter ATP-binding protein"
-                     /protein_id="CZQ25307.1"
-                     /db_xref="GI:1036211098"
-                     /translation="MSIKVQHVGKAYKYYPSKWNRVIEKLLPGDKPRHSKKWVLKDINF
-                     SIEPGEAVGIVGVNGAGKSTLLKLLTGTTQPTKGSIEIQGRVAALLELGMGFHPDFTGR
-                     QNVYMSGLMMGLGREEIERLMPEIEAFADIGDYIEEPVRIYSSGMQMRLAFAVATASRP
-                     DILIVDEALSVGDSRFQAKCYARIADFKKQGTTLLLVSHSAGDIVKHCDRAIFLKNGDI
-                     CMDGTARDVTNRYLDELFGKPDKDSATKSATAISSASGESQMSLDEIEDVYHTRPGYRP
-                     EEYRWGQGGAKIIDYHIQSAGVDFPPSLTGNQQTDFLMKVVFEYDFDCVVPGILIKTLD
-                     GLFLYGTNSFLASEGRENISVSRGDVRVFKFSLPVDLNSGDYLLSFGISAGNPQTDMTP
-                     LDRRYDSIILHVTKSMDFWGVIDLKSSFTSYQ"
-                     /locus_tag="O3α_04_wzt"
-     gene            4930..7056
-                     /gene="wbdD"
-     CDS             4930..7056
-                     /gene="wbdD"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237530.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="methyltransferase"
-                     /protein_id="CZQ25308.1"
-                     /db_xref="GI:1036211099"
-                     /translation="MTKDLNTLVSELPEIYQTIFGHPEWDGDAARDCNQRLDLITEQYD
-                     NLSRALGRPLNVLDLGCAQGFFSLSLASKGATIVGIDFQQENINVCRALAEENPDFAAE
-                     FRVGRIEEVIAALEEGEFDLAIGLSVFHHIVHLHGIDEVKRLLSRLADVTQAVILELAV
-                     KEEPLYWGVSQPDDPRELIEQCAFYRLIGEFDTHLSPVPRPMYLVSNHRVLMNDFNQPF
-                     QHWQNQPYAGAGLAHKRSRRYFFGEDYVCKFFYYDMPHGILTAEESQRNKHELHNEIKF
-                     LAQPPAGFDAPALLAHGENAQSGWLVMEKLPGRLLSDMLAAGEEIDREKILGSLLRSLA
-                     ALEKQGFWHDDVRPWNVMVDARQHARLIDFGSIVTTPQDCSWPTNLVQSFFVFVNELFA
-                     ENKSWTGFWRSAPVHPFNLPQPWSNWLYAVWQEPVERWNFALLLALFEKKAKLPSAEQQ
-                     RGATEQWIIAQETVLLELQSRVRHESAGSEALRGQIHTLEQQMAQLQAAQDAFVEKAQQ
-                     PVEVSHELTWLGENMEQLAALLQTAQAHAQADVQPELPPETAELLQRLEAANREIHHLS
-                     NENQQLRQEIEKIHRSRSWRMTKGYRYLGLQIHLLRQYGFVQRCKHFIKRVLRFVFSFM
-                     RKHPQVKHTAVNGLHKLGLYQPAYRLYRRMNPLPHSQYQADAQILSQTELQVMHPELLP
-                     PEVYEIYLKLTKNK"
-                     /locus_tag="O3α_05_wbdD"
-     gene            7067..9589
-                     /gene="wbdA"
-     CDS             7067..9589
-                     /gene="wbdA"
-                     /EC_number="2.4.1.246"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237531.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="mannosyltransferase A"
-                     /protein_id="CZQ25309.1"
-                     /db_xref="GI:1036211100"
-                     /translation="MHILIDVQGYQSESKFRGIGRSTLAMSRAIIENAGEHRVSILING
-                     MYPIDNINDVKMAYRDLLTDEDMFIFSAVAPTAYCNIENHGRSKAAQAARDIAIANIAP
-                     DIVYVISFFEGHGDSYTVSIPADNVPWKTVCVCHDLIPLLNKERYLGDPNFREFYMNKL
-                     AEFERADAIFAISQSAAQEVIEYTDIASDRVLNISSAVGEEFAVIDYSAERIQSLKDKY
-                     SLPDEFILTLAMIEPRKNIEALIHAYSMLPAELQQRYPMVLAYKVHPEDLERILRLAES
-                     YGLSRSQLIFTGFLTDDDLIALYNLCKLFVFPSLHEGFGLPPLEAMRCGAATLGSNITS
-                     LPEVIGWEDAMFNPHDVQDIRRVMEKALTDEAFYRELKAHALAQSAKFSWANTAHLAIE
-                     GFTRLLQSSQEANAGQAESVTASRIQTMQKIDALSEVDRLGLAWAVARNSFKRHSRKLL
-                     VDISVLAKHDAKTGIQRVSRSILSELLKSGVPGYEVSAVYYTPGECYRYANQYLSSHFP
-                     GEFGADEPVLFSKDDVLIATDLTAHLFPEVVTQIDSMRAAGAFACFVVHDILPLRRPEW
-                     SIEGIQREFPIWLSCLAEHADRLICVSASVAEDVKAWIAENRHWVKPNPLLTVSNFHLG
-                     ADLDASVPSTGMPDNAQALLATMAAAPSFIMVGTMEPRKGHAQTLAAFEELWREGKDYN
-                     LFIVGKQGWNVDSLCEKLRHHPQLNKKLFWLQNISDEFLAELYARSRALIFASQGEGFG
-                     LPLIEAAQKKLPVIIRDIPVFKEIAQEHAWYFSGEAPSDIAKAVEEWLALYEQNAHPRS
-                     ENINWLTWKQSAEFLLKNLPIIAPAAKQ"
-                     /locus_tag="O3α_06_wbdA"
-     gene            9636..10781
-                     /gene="wbdB"
-     CDS             9636..10781
-                     /gene="wbdB"
-                     /EC_number="2.4.1.250"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237532.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="mannosyltransferase B"
-                     /protein_id="CZQ25310.1"
-                     /db_xref="GI:1036211101"
-                     /translation="MKIIFATEPIKYPLTGIGRYSLELVKRLAVAREIEELKLFHGASF
-                     IDQIPQVENKSDTKASNHGRLSAFLRRQPLLIEAYRLLHPRRQAWALRDYKDYIYHGPN
-                     FYLPHRLERAVTTFHDISIFTCPEYHPKDRVRYMEKSLHESLDSAKLILTVSDFSRSEI
-                     IRLFNYPADRIVTTKLACSSDYIPRSPAECLPVLQKYQLAWQGYALYIGTMEPRKNIRG
-                     LLQAYQLLPMETRMRYPLILSGYRGWEDDVLWQLVERGTREGWIRYLGYVPDEDLPYLY
-                     AAARTFVYPSFYEGFGLPILEAMSCGVPVVCSNVTSLPEVVGDAGLVADPNDVDAISAH
-                     ILQSLQDDSWREIATARGLAQAKQFSWENCTTQTINAYKLL"
-                     /locus_tag="O3α_07_wbdB"
-     gene            10791..11906
-                     /gene="wbdC"
-     CDS             10791..11906
-                     /gene="wbdC"
-                     /EC_number="2.4.1.11"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237533.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyl transferase family protein"
-                     /protein_id="CZQ25311.1"
-                     /db_xref="GI:1036211102"
-                     /translation="MRVLHVYKTYYPDTYGGIEQVIYQLSQGCARRGIAADVFTFSPDK
-                     ETGPVAYEDHRVIYNKQLFEIASTPFSLKALKRFKQIKDDYDIINYHFPFPFMDMLHLS
-                     ARPDARTVVTYHSDIVKQKRLMKLYQPLQERFLASVDCIVASSPNYVASSQTLKKYQDK
-                     TVVIPFGLEQHDVQHDPQRVAHWRETVGDNFFLFVGAFRYYKGLHILLDAAERSRLPVV
-                     IVGGGPLEAEVRREAQQRGLSNVVFTGMLNDEDKYILFQLCRGVVFPSHLRSEAFGITL
-                     LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPNDSQALVEAMNELWHNDETASRYGE
-                     NSRRRFEEMFTADHMIDAYVNLYTTLLESKS"
-                     /locus_tag="O3α_08_wbdC"
-ORIGIN
-        1 atgttacttc ctgtaattat ggctggtggt accggcagtc gtctctggcc gatgtctcgc
-       61 gagctttacc cgaaacagtt cctccggctg tacgggcaga actccatgct gcaggaaacc
-      121 atcacccgac tctcgggcct tgaaatccat gaaccgatgg tcatctgtaa cgaagagcac
-      181 cgcttcctgg tggctgaaca gctgcgccag ctcaacaagc tgtccaacaa cattattctt
-      241 gagccggtcg ggcgcaacac cgccccggcc atcgccctgg cggccctcca ggccacccgt
-      301 cacggcgacg acccgctgat gctggtcctc gccgccgacc atatcatcaa taaccagccg
-      361 gtcttccacg acgccatccg cgtcgccgag cagtatgccg atgaaggcca tctggtcacc
-      421 ttcggtatcg tgccgaacgc cccggaaacc ggctacggtt acatccagcg cggcgtggcc
-      481 ctcaccgaca gcgcccacac cccgtaccag gttgcccgct tcgtggagaa gccggaccgc
-      541 gagcgcgccg aggcctacct cgcctccggg gagtactact ggaacagcgg catgtttatg
-      601 ttccgcgcca aaaaatacct ctccgagctg gccaaattcc gcccggatat cctcgaagcc
-      661 tgccaggccg cggtcaatgc cgccgacaac ggcagcgact tcatcagcat tccgcatgac
-      721 attttctgcg agtgcccgga cgagtccgtg gactacgcgg tgatggagaa aaccgccgac
-      781 gcggtggtgg tcggtctcga tgccgactgg agcgacgtcg gctcctggtc cgccctgtgg
-      841 gaggtcagcc cgaaagacga gcagggtaac gtcctcagcg gtgacgcgtg ggtgcataac
-      901 agcgaaaact gctacatcaa cagcgacgag aagctggtgg cggccatcgg cgtggaaaac
-      961 ctggtgattg tcagcaccaa ggacgccgtg ctggtgatga accgcgagcg ttcccaggac
-     1021 gtgaagaagg cggtcgagtt cctcaagcag aaccagcgca gcgagtacaa gcgccaccgc
-     1081 gagatttacc gtccctgggg ccgctgcgac gtggtggtcc agaccccgcg cttcaacgtc
-     1141 aaccgcatca ccgtgaaacc gggcggcgcc ttctcgatgc agatgcacca ccaccgcgcc
-     1201 gagcactggg tcattctcgc cggcaccggc caggtgacgg tgaacggcaa gcagttcctg
-     1261 ctgaccgaga accagtccac ctttattccg attggcgccg agcacagcct ggaaaacccg
-     1321 ggccgtattc cgctggaagt gctggagatc cagtcggggt cgtacctcgg cgaggacgac
-     1381 attattcgta ttaaagacca gtatggtcgt tgctaatttt ttcgggacaa aacgcagaat
-     1441 gacacagtta acatgcttta aggcttatga catccgtggt gaactgggcg aggagctgaa
-     1501 cgaggacatc gcctaccgta tcggccgcgc ctatggcgaa tttctgaaac ccgggaagat
-     1561 agtggtgggg ggcgatgtgc gcctcaccag cgagtcgctg aagctggcgc tggcccgcgg
-     1621 gctgatggac gccggcaccg acgtgctgga tatcggcctg agcggcaccg aagagattta
-     1681 cttcgccacc ttccacctcg gggtggacgg cggcatcgag gtgacggcga gccataaccc
-     1741 gatgaactac aacggcatga agctggtgcg cgagaacgcg aagcccatca gcggcgacac
-     1801 cggcctgcgg gatatccagc gcctggcgga ggagaaccag ttcccgccgg tggacccggc
-     1861 gcgtcgcgga accctgcgcc agatatcggt gctgaaggag tacgtcgacc acctgatggg
-     1921 ctacgtggac ctggcgaact tcacccgtcc gctgaagctg gtggtgaact ccggcaacgg
-     1981 ggcggcgggg cacgtgattg atgaggtgga gaaacgcttc gcggcggccg gggcgccggt
-     2041 gacctttatc aaggtgcatc accagccgga cggccatttc ccgaacggta tcccgaaccc
-     2101 gctgctgccg gagtgccgcc aggacaccgc cgacgcggtg cgtgcgcatc aggcggacat
-     2161 gggtatcgcc tttgacggcg acttcgaccg ctgcttcctg ttcgatgacg aggcgtcgtt
-     2221 tatcgagggg tactacattg tcggcctgct ggcggaagcg ttcctgcaga agcagccggg
-     2281 ggcgaaaatc attcacgacc cgcgtctgac atggaacacg gtggacatcg tgacccgcag
-     2341 cggcggccag ccggtgatgt cgaagacggg gcatgcgttc atcaaggagc ggatgcgcca
-     2401 ggaagacgcc atctacggcg gggagatgag cgcgcaccat tacttccgcg acttcgccta
-     2461 ctgcgacagc gggatgatcc cgtggctgct ggtggcggag ctgctgtgcc tgaagaacag
-     2521 ctcgctgaaa tcgctggtgg cggaccgcca ggcggcgttc ccggcgtcgg gggagatcaa
-     2581 ccgcaagctg gggaacgcgg cggaggcgat agcgcgcatc cgggcgcagt atgagccggc
-     2641 ggccgcacac atcgacacaa cggacggtat cagtattgaa taccctgagt ggcgctttaa
-     2701 cctgcgcacg tccaataccg agccggtggt gcgtctgaac gttgagtcca gagcggatac
-     2761 tgcgttaatg aatgagaaaa ccgccgagct gctcaacctg ttaaaagagg aatcgctttg
-     2821 agtcctatgt tttcagcgat ctatcgctac cgtggcttta ttattgacag cgttaaacgg
-     2881 gactttcagt cccgttacca gaccagtttt ttaggcgcgg catggttgat cttacagccg
-     2941 atcgccatga tttccgtcta tacattaatt ttttcagagt taatgcgtgc ccgcctggcg
-     3001 gggatggatg gtccttttgc ctacagtatc tacctctgtt ccggggtatt aacctggggg
-     3061 ttgtttacgg aaacgctcgg caatctggtc aacgtttttc tgaccaatgc caatatcctc
-     3121 aagaaactga gctttccgcg gatctgttta ccgatcattg tcaccgcctc ggcgttcatt
-     3181 aacttcctga tcatttttgg tctgtttgta ctgtttctga tcgtcacggg caatttcccg
-     3241 ggcatgattt tctttgaaat cattccggtg ctgatcgtcc agatgctgtt tactcttggc
-     3301 ctggggatta tcctcggggt gctgaacgtt tttgtccgcg acgtcgggca gttcgtcaat
-     3361 atcctgctgc agttttggtt ctggtttacg ccgattgttt acgtatccaa aacgctgccg
-     3421 gaatgggtat caggtctgct ggcatataac ccgatggcga caattatcgg ttcctaccag
-     3481 aacgtgatgc tctatcacca gagccctaac tggatggcgc tgcttccggt cacagtggtg
-     3541 tcggtcattc tgtttttatt tgcctggcgt ttatttaaaa aacatgccgc tgatattgtg
-     3601 gacgagattt aatcatgagt atcaaagttc agcacgtcgg caaggcgtat aaatattatc
-     3661 catctaaatg gaaccgggtc attgagaaac tactgccggg cgataagccg cggcacagca
-     3721 agaaatgggt attgaaagat atcaatttca gcattgaacc cggtgaagcg gtcggcattg
-     3781 ttggggtgaa cggcgcaggt aaaagtacgt tactgaagct gctgactggc accactcagc
-     3841 ccaccaaagg cagcattgaa atccaggggc gcgtcgccgc gctgctggag ctgggcatgg
-     3901 gcttccatcc tgactttacc ggccggcaga acgtgtatat gtccgggctg atgatgggcc
-     3961 tgggccggga agagatcgag cgcttaatgc cggagatcga agccttcgcc gatattggcg
-     4021 actacattga agagcccgtg cgcatctatt ccagcggtat gcaaatgcgc ctggcgttcg
-     4081 ctgtcgccac ggcctcccgg ccggatattc tgatcgtcga tgaagcgctc tccgtgggtg
-     4141 actcccgttt tcaggcgaaa tgctatgctc gcatcgcgga cttcaaaaag caggggacca
-     4201 cgctgctact ggtttcccac agcgccgggg atatcgtcaa gcactgcgac cgcgccattt
-     4261 tcctcaaaaa tggtgacatc tgcatggacg gtaccgcccg cgacgtgacc aaccgttacc
-     4321 tggatgagct gtttggcaaa ccggataaag acagcgcgac aaaaagcgca acggctatct
-     4381 cgtcagccag tggcgaaagc cagatgtctc tcgatgagat tgaagatgtg taccacacgc
-     4441 gcccaggcta ccgtccggaa gaatatcgct gggggcaggg tggcgcgaaa atcatcgatt
-     4501 atcatatcca gagcgccggg gttgattttc ctccctcact gacgggcaat cagcagaccg
-     4561 attttctgat gaaggtcgtg tttgaatacg attttgattg cgtggtgcca ggcatcctga
-     4621 ttaagaccct cgatggctta ttcctctacg gaaccaactc tttcctcgcc tctgaagggc
-     4681 gggaaaatat ttcggtttcc cgcggcgatg ttcgggtctt taaatttagc cttccggttg
-     4741 atttaaacag tggcgattac ctgctgtcat ttggtatctc tgccggcaac ccacagacgg
-     4801 atatgacgcc gctggacaga cgttacgact ccattatttt acatgtgacc aagagcatgg
-     4861 atttctgggg tgtcatcgat cttaagtcgt cctttactag ctaccaatga cgttgagaaa
-     4921 aacgattcca tgactaaaga cttaaacacg ctggttagcg aattacctga gatttatcaa
-     4981 actatttttg gccatcccga atgggatggc gacgccgctc gtgattgtaa tcaacgcctc
-     5041 gatttgatta ccgaacagta cgataactta tcccgtgcac tggggcgccc gcttaacgtt
-     5101 ctcgatctgg gctgcgcgca gggctttttt agcctgagtc tggcaagcaa aggcgcgact
-     5161 atcgttggta tcgatttcca gcaggaaaat attaacgtgt gccgcgcgct ggccgaagag
-     5221 aaccccgatt ttgccgccga gttccgggta ggcagaattg aagaggtgat cgccgcgctg
-     5281 gaagaggggg agtttgatct ggccattggc ttaagcgtgt ttcaccatat tgttcacctt
-     5341 catggtatcg atgaagttaa acgtctgctc tcgcgcctgg ccgatgtcac ccaggcggtg
-     5401 atccttgagc tggcggtgaa agaagaaccg ctttactggg gcgtttctca gccggacgac
-     5461 ccgcgcgaac tgattgagca gtgcgcgttt tatcgcctga tcggtgagtt tgatacccat
-     5521 ttatcccccg taccgcgccc gatgtacctg gtcagcaacc accgggtgct gatgaacgat
-     5581 tttaatcagc cgttccagca ctggcagaat cagccctatg ccggggccgg cctcgcgcat
-     5641 aagcgcagcc gtcgctactt ctttggcgaa gattatgtat gcaagttttt ctattacgac
-     5701 atgccccacg gcatcctgac ggcggaagag agccagcgta ataaacatga actgcataat
-     5761 gaaataaagt tcctggcgca accgccagcg ggctttgacg cgcccgcatt actggcccac
-     5821 ggcgaaaatg ctcagtctgg ctggctggtg atggaaaaac tcccgggtcg tttgctgagc
-     5881 gatatgctgg cagccgggga ggagatcgat cgtgaaaaaa tcctcggtag cttgcttcgt
-     5941 tccttagcgg cgctggagaa acaagggttc tggcatgacg atgtacgccc gtggaacgtg
-     6001 atggtcgatg cccgacagca tgcccgctta atcgacttcg gctctatcgt taccacgccg
-     6061 caggactgca gctggccgac gaaccttgtc cagtcgttct tcgtgtttgt gaatgagctg
-     6121 tttgccgaaa acaaaagctg gactggtttc tggcgctcgg cgcctgttca tccgtttaat
-     6181 ctaccccagc cgtggtctaa ctggctgtat gcggtctggc aggagccggt tgaacgctgg
-     6241 aactttgccc tgctgttggc gctgttcgag aagaaagcga agctgccttc agctgaacag
-     6301 cagcgcgggg cgacggaaca gtggatcatc gctcaggaga cggtgctgct ggagctccag
-     6361 tcccgggtgc gtcatgaaag cgccggctca gaagcgttgc gcggccaaat ccataccctg
-     6421 gagcagcaga tggctcagct gcaggccgct caggatgcgt tcgtcgagaa agctcaacag
-     6481 ccagtggaag tcagccatga actcacctgg cttggtgaga atatggagca gctggcggcg
-     6541 ctgttgcaga cggcgcaagc gcacgcccag gctgacgttc agcccgagtt gccacctgaa
-     6601 accgctgagc tactgcagcg actggaagcc gctaaccggg agatccacca tttaagcaac
-     6661 gaaaaccagc agcttcgcca ggaaattgaa aaaatccatc gcagccgttc ctggagaatg
-     6721 accaagggtt atcgttatct gggcctgcag atccatttgc tgaggcagta tggtttcgtg
-     6781 cagcggtgta aacattttat taagcgcgtc ctgcggtttg ttttctcgtt tatgagaaaa
-     6841 catccgcagg taaaacatac cgcggtaaat ggtttacata agctgggcct ttatcagccg
-     6901 gcctaccgtt tgtatcgtcg tatgaatcca ctgccgcaca gtcagtatca ggctgatgcg
-     6961 cagattttat cgcagactga actgcaagtg atgcatccgg agcttttacc tccggaggtt
-     7021 tatgaaattt atctcaaact aacgaaaaat aaataaggag attaacttgc atattttgat
-     7081 tgatgtccag ggttaccagt cggaaagtaa attccgcggt atcggtcgca gtaccctggc
-     7141 catgagccgc gccattattg aaaatgccgg tgagcatcgc gtcagtattt tgatcaatgg
-     7201 tatgtacccc attgataata tcaatgatgt caaaatggcc tatcgggacc tgctgacgga
-     7261 tgaagatatg ttcatcttct cagccgttgc gccaacggcc tattgcaaca tcgaaaacca
-     7321 cggtcgcagc aaggcagccc aggcggcccg cgatatcgct atcgccaata tcgcgcctga
-     7381 tatcgtctat gttattagct tcttcgaagg ccatggggat agttataccg tgtctattcc
-     7441 ggcggataat gtgccctgga agacggtgtg tgtatgccac gatctgatcc cgctgttaaa
-     7501 taaagagcgt tacctcggcg atccgaattt ccgtgagttt tatatgaaca agctggcgga
-     7561 atttgagcgg gcagacgcga tcttcgctat ttcgcagtcg gcagctcagg aagtgatcga
-     7621 atataccgac atcgccagcg atcgggtact gaacatctcc tcggcggtgg gcgaagagtt
-     7681 tgcggtgatc gattattctg ctgagcgtat tcagtcttta aaagacaaat acagcctgcc
-     7741 ggatgagttt atcctaacgc tggcgatgat cgagccgcgg aaaaacattg aagcgcttat
-     7801 tcatgcttac agcatgctgc ctgccgaact gcagcagcgc tatccgatgg tgctcgcgta
-     7861 taaggtgcat cctgaagatc tggagcgtat tctgcgtctg gcggaaagct atggcctgtc
-     7921 acgcagccag cttatcttta ccggcttcct gaccgacgac gatctgattg ccttgtacaa
-     7981 cctttgcaaa ctgtttgtgt tcccgtcgct gcatgaggga ttcggcctgc cgccgctgga
-     8041 agcgatgcgc tgtggggccg cgaccctggg ttcaaacatc accagcctgc cggaagtcat
-     8101 tggctgggaa gatgccatgt tcaatccgca tgatgtgcag gacattcgcc gggtcatgga
-     8161 gaaggcgctg accgatgagg cgttttatcg tgagctgaaa gcgcatgctc tcgcgcagtc
-     8221 ggccaaattc tcctgggcca ataccgccca tctggcgatc gagggtttca ctcgtctgct
-     8281 gcagtcgtcc caagaggcga atgccgggca ggcggaaagc gtgaccgcct cccgtatcca
-     8341 gacgatgcag aaaatcgatg cgctgagcga agtcgaccgt cttggtctgg catgggcggt
-     8401 tgcgcgcaat agctttaagc gccattcccg caagctgctg gtggacattt cggttctggc
-     8461 gaaacatgac gcgaagaccg ggatccagcg cgtctcgcgc agtatcctca gcgaattact
-     8521 gaaatctggc gtgccgggtt acgaggtttc cgctgtctac tacacccctg gcgagtgtta
-     8581 tcgctacgcc aaccaatatc tgtccagtca tttcccgggc gaatttggcg ctgacgaacc
-     8641 ggtgctgttc agcaaagacg atgtgcttat cgccaccgat ctgaccgcgc atctcttccc
-     8701 ggaggtggtg acgcaaattg acagcatgcg cgccgccggg gcgttcgcct gcttcgtggt
-     8761 gcatgatatt ctgccattac gccgcccgga gtggagtatc gaaggcattc agcgtgaatt
-     8821 cccgatctgg ctgtcctgcc tcgcagagca cgccgatcgg ctgatctgcg tctctgccag
-     8881 cgttgccgag gatgtgaaag cgtggattgc ggaaaatcgc cattgggtga aaccgaaccc
-     8941 gctgctgacc gtcagcaact tccatctggg agccgacctc gatgccagcg taccgtccac
-     9001 tggcatgccg gataatgcac aggcgctgtt agcaacgatg gctgcagccc cgtcatttat
-     9061 catggtgggt accatggagc cgcgcaaagg ccatgcccag acgctggccg ccttcgagga
-     9121 actgtggcgc gagggcaaag actacaactt gtttatcgtc ggcaaacagg gctggaacgt
-     9181 tgacagcttg tgcgaaaaat tacgccatca tccgcagctg aacaaaaagc tcttctggct
-     9241 gcagaatatc agcgacgagt ttttggccga gctatacgct cgttcacgcg cgctgatctt
-     9301 tgcctcgcag ggagaaggct ttggcctgcc attgattgaa gcggcgcaga aaaagctgcc
-     9361 agtgattatt cgcgacattc cagtgtttaa agagattgct caggaacatg cctggtattt
-     9421 ctccggtgaa gcgccgtccg atatcgcgaa ggcggtagaa gagtggttag ccctgtacga
-     9481 gcaaaacgcg catcctcgtt ccgaaaatat caactggtta acctggaaac agagcgcgga
-     9541 atttctcctg aaaaacctgc cgattatcgc gccagccgcg aagcaataat cgctatcaac
-     9601 agggctactc cggtggccct tgtgatgagt tcgttatgaa aattattttt gctactgagc
-     9661 caattaaata cccattaacg ggcatcggtc ggtattccct ggagctggtt aagcggctgg
-     9721 cggttgcccg tgaaatcgaa gagctgaagc tgtttcacgg cgcgtcgttt atcgatcaga
-     9781 tcccccaggt ggagaataaa agcgatacca aagccagcaa tcatggtcgt ctgtcggcgt
-     9841 ttctgcgtcg ccagccgctg ctgattgagg cgtatcgcct gctgcatccg cggcgccagg
-     9901 cgtgggcatt gcgcgattac aaagactaca tttaccatgg tcccaatttc tatctgccgc
-     9961 atcgcctgga acgcgccgtg accacgtttc atgacatctc catttttacc tgcccggaat
-    10021 atcatccaaa agatcgggtt cgctatatgg agaagtccct gcacgagagc ctggattcgg
-    10081 cgaagctgat cctgaccgtc tccgacttct cgcgcagtga aatcatccgc ctgttcaact
-    10141 atccggcgga tcggatcgtc accaccaagc tggcctgcag cagcgactat attccgcgca
-    10201 gcccggcgga gtgcctgccg gtcctgcaga aatatcagct ggcgtggcag gggtatgcgt
-    10261 tatatatcgg caccatggag ccgcgtaaaa atatccgagg tctgctgcag gcctatcagc
-    10321 tgctgccgat ggagacccgc atgcgctacc cgctgatcct cagcggttat cgcggatggg
-    10381 aagacgatgt gctgtggcag ttagtcgagc gcggtacgcg tgaagggtgg atccgttacc
-    10441 tgggctatgt cccggatgaa gacctgcctt atctgtacgc ggcggccaga acctttgttt
-    10501 atccctcctt ctatgaggga ttcggtttac ctattcttga agcgatgtct tgcggtgtgc
-    10561 cggtagtatg ttccaatgtc acttctttgc ctgaggtggt tggcgatgcc ggcctcgttg
-    10621 ccgatcctaa tgatgtagac gcgattagcg cgcatatttt gcagagcctg caggatgata
-    10681 gctggcggga aatcgccacc gcgcgcggtc ttgcccaggc gaaacagttt tcgtgggaga
-    10741 actgtacgac ccagaccatt aacgcctata aattactcta agggtgtcag ttgagagttc
-    10801 tacacgtcta taagacctac tatcccgata cctacggcgg tattgagcag gtcatttatc
-    10861 agctaagtca gggctgcgcc cgccggggaa tcgcagccga tgtttttact tttagcccgg
-    10921 acaaagagac aggtcctgtc gcctacgaag accatcgggt catttataat aagcagcttt
-    10981 ttgaaattgc ctccacgccg ttttcgctga aagcgttaaa gcgttttaag cagattaaag
-    11041 atgattacga catcatcaac taccattttc cgtttccatt catggatatg ttgcatctct
-    11101 cggcgcggcc tgacgccaga acggtggtga cctatcactc ggatattgtg aaacaaaaac
-    11161 ggttaatgaa gttgtaccag ccgctgcagg agcgattcct cgccagcgta gactgcatcg
-    11221 tcgcctcgtc gcccaactac gtggcctcca gccagaccct gaaaaaatat caggataaaa
-    11281 ccgtggtgat cccgtttggt ctggagcagc atgacgtgca gcacgatccg cagcgggtgg
-    11341 cgcactggcg ggaaaccgtc ggcgataact tcttcctctt cgttggcgct ttccgctact
-    11401 acaaagggct gcacattctg ctggatgccg ccgagcgtag ccggctgccg gtggtgatcg
-    11461 tcgggggcgg gccgctggag gcggaagtgc gtcgtgaagc gcagcagcgc gggctgagca
-    11521 atgtggtgtt taccggcatg ctcaacgacg aagataaata cattctcttc cagctctgcc
-    11581 ggggcgtggt cttcccctcg catctgcgct ccgaggcgtt tggcattacg ttactggaag
-    11641 gcgcgcgctt cgccaggccg ctgatctcct gcgagatcgg caccgggacc tcgttcatta
-    11701 accaggacaa agtgaatggc tgcgtgatcc cgccgaatga cagtcaggcg ctggtggagg
-    11761 cgatgaatga gctctggcat aacgatgaaa ccgccagccg ctatggcgaa aactcgcgtc
-    11821 gtcgttttga agagatgttt actgccgacc atatgattga cgcttacgtc aatctctaca
-    11881 ctacgctgct ggaaagcaaa tcctga
-//
-LOCUS       LT174604               11838 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O3b.
-ACCESSION   LT174604
-VERSION     LT174604.1  GI:1036211103
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1
-  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
-            Holt,K.E. and Thomson,N.R.
-  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
-            antigens
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 11838)
-  AUTHORS   Informatics,P.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
-            1SA, UNITED KINGDOM
-FEATURES             Location/Qualifiers
-     source          1..11838
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="539"
-                     /serovar="O3b"
-                     /db_xref="taxon:573"
-                     /note="O locus: O3β"
-                     /note="O type: O3β"
-                     /note="annotation edited from original by K. Wyres Jan
-                     2018"
-                     /note="Updated from O3b by Tom Stanton in Feb 2025"
-     gene            1..1416
-                     /gene="manC"
-     CDS             1..1416
-                     /gene="manC"
-                     /EC_number="2.7.7.13"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006635421.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="mannose-1-phosphate guanylyltransferase"
-                     /protein_id="CZQ25312.1"
-                     /db_xref="GI:1036211104"
-                     /translation="MLLPVIMAGGTGSRLWPMSRELYPKQFLRLFGQNSMLQETITRLS
-                     GLEIHEPMVICNEEHRFLVAEQLRQLNKLSNNIILEPVGRNTAPAIALAALQATRHGDD
-                     PLMLVLAADHIINNQPVFHDAIRVAEQYADEGHLVTFGIVPNAPETGYGYIQRGVALTD
-                     SAHTPYQVARFVEKPDRERAEAYLASGEYYWNSGMFMFRAKKYLSELAKFRPDILEACQ
-                     AAVNAADNGSDFISIPHDIFCECPDESVDYAVMEKTADAVVVGLDADWSDVGSWSALWE
-                     VSPKDEQGNVLSGDAWVHNSENCYINSDEKLVAAIGVENLVIVSTKDAVLVMNRERSQD
-                     VKKAVEFLKQNQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
-                     AEHWVILAGTGQVTVNGKQFLLTENQSTFIPIGAEHSLENPGRIPLEVLEIQSGSYLGE
-                     DDIIRIKDQYGRC"
-                     /locus_tag="O3β_01_manC"
-     gene            1439..2821
-                     /gene="manB"
-     CDS             1439..2821
-                     /gene="manB"
-                     /EC_number="5.4.2.2"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237527.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="phosphomannomutase"
-                     /protein_id="CZQ25313.1"
-                     /db_xref="GI:1036211105"
-                     /translation="MTQLTCFKAYDIRGELGEELNEDIAYRIGRAYGEFLKPGKIVVGG
-                     DVRLTSESLKLALARGLMDAGTDVLDIGLSGTEEIYFATFHLGVDGGIEVTASHNPMNY
-                     NGMKLVRENAKPISGDTGLRDIQRLAEENQFAPVDPARRGTLRQISVLKEYVDHLMGYV
-                     DLANFTRPLKLVVNSGNGAAGHVIDEVEKRFAAAGAPVTFIKVHHQPDGHFPNGIPNPL
-                     LPECRQDTADAVRAHQADMGIAFDGDFDRCFLFDDEASFIEGYYIVGLLAEAFLQKQPG
-                     AKIIHDPRLTWNTVDIVTRSGGQPVMSKTGHAFIKERMRQEDAIYGGEMSAHHYFRDFA
-                     YCDSGMIPWLLVAELLCLKNSSLKSLVADRQAAFPASGEINRKLGNAAEAIARIRAQYE
-                     PAAAHIDTTDGISIEYPEWRFNLRTSNTEPVVRLNVESRADTALMNEKTAELLNLLKEE
-                     SL"
-                     /locus_tag="O3β_02_manB"
-     gene            2827..3612
-                     /gene="wzm"
-     CDS             2827..3612
-                     /gene="wzm"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237528.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="ABC transporter permease"
-                     /protein_id="CZQ25314.1"
-                     /db_xref="GI:1036211106"
-                     /translation="MFSAIYRYRGFIIDSVKRDFQSRYQTSFLGAAWLILQPIAMISVY
-                     TLIFSELMRARLAGMDGPFAYSIYLCSGVLTWGLFTETLGNLVNVFLTNANILKKLSFP
-                     RICLPIIVTASAFINFLIIFGLFVLFLIVTGNFPGMIFFEIIPVLIVQMLFTLGLGIIL
-                     GVLNVFVRDVGQFVNILLQFWFWFTPIVYVSKTLPEWVSGLLAYNPMATIIGSYQNVML
-                     YHQSPNWLALLPVTVLSVILFLFAWRLFKKHAADIVDEI"
-                     /locus_tag="O3β_03_wzm"
-     gene            3615..4910
-                     /gene="wzt"
-     CDS             3615..4910
-                     /gene="wzt"
-                     /EC_number="3.6.3.40"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237529.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="ABC transporter ATP-binding protein"
-                     /protein_id="CZQ25315.1"
-                     /db_xref="GI:1036211107"
-                     /translation="MSIKVQHVGKAYKYYPSKWNRVIEKLLPGDKPRHSKKWVLKDINF
-                     SIEPGEAVGIVGVNGAGKSTLLKLLTGTTQPTKGSIEIQGRVAALLELGMGFHPDFTGR
-                     QNVYMSGLMMGLSREEIERLMPEIEAFADIGDYIEEPVRIYSSGMQMRLAFAVATASRP
-                     DILIVDEALSVGDSRFQAKCYARIADFKKQGTTLLLVSHSAGDIVKHCDRAIFLKNGDI
-                     CMDGTARDVTNRYLDELFGKADKNSAPKSETATSSASGESQMSLDEIEDVYHTRPGYRP
-                     EEYRWGQGGAKIIDYHIQSAGVDFPPSLTGNQQTDFLMKVVFEYDFDCVVPGLLIKTLD
-                     GLFLYGTNSFLASEGRENISVSRGDVRVFKFSFPVDLNSGDYLLSFGISEGSPQTEMTP
-                     LDRRYDSIILHVTKSMDFWGVIDLKSTFNSYK"
-                     /locus_tag="O3β_04_wzt"
-     gene            4931..6988
-                     /gene="wbdD"
-     CDS             4931..6988
-                     /gene="wbdD"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237530.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="methyltransferase"
-                     /protein_id="CZQ25316.1"
-                     /db_xref="GI:1036211108"
-                     /translation="MTTNTHKLVSELPEIYQTIFGHPEWDGDAARDCNERLALISEQYD
-                     SLSRELGRPLRVLDLGCAQGFFSLSLASKGASVLGIDFLQQNIDVCQALAEENPHCDVK
-                     FQVGRIEDIVSTLEENQFDLAIGLSVFHHIVHLHGVAEVRSLLERLANLTQAMILELAV
-                     KEEPLYWGKSQPEDPRELIDQCAFYRLIGRFDTHLSNISRPMYIISNHRVILPEFNQPF
-                     TSWRDSPYTGAGFAHKQSRRYYFSSEFICKFYRFSTVSCLLTDKESERNRTELAHEEAF
-                     LKSPPSGLKVPALFTAGGNGEAGWLVMEKIPGELLNDVLASERHIDREKVISDLLDQLV
-                     ILEEHGLYHDDFRTWNVLIDDNDSARLIDFGSIGDVQQDCSWPVNIFQSFIIFVNEIFC
-                     ENKSWRGFWRSAPLSPFQLPEPYSNWLTAFWKHPVGEWSFALLQQLFSTKDALPAASSI
-                     MDASDLWVRAQEPVLLESQTQIRNTDARVVRLESQINELTSLINIMGESIQTFEKREYP
-                     PQDVTTNVQPRIEIEQSKAVDSEEIMRLHTQLNDAQQEIENLRHEIAKIHYSRSWKMTK
-                     WYRYAGLQYYLLRQYGFKQRFKHLLKRVLSNVIYFLRAHPRLKQKVINLLRTIGIYDFA
-                     YRMHRRMNPGSHNPYPNDPQYQSQTEKQILHPELLPPEVNSIFSELKNKR"
-                     /locus_tag="O3β_05_wbdD"
-     gene            6999..9521
-                     /gene="wbdA"
-     CDS             6999..9521
-                     /gene="wbdA"
-                     /EC_number="2.4.1.246"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237531.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="mannosyltransferase A"
-                     /protein_id="CZQ25317.1"
-                     /db_xref="GI:1036211109"
-                     /translation="MHILIDVQGYQSESKFRGVGRSTYEMSRAIIKNAGQHRVSILMNG
-                     MYSIDSINEIKKSWGDILPQEEMFIFSAAGPTALRDCENHPRSVAATLARELAIANINP
-                     DVVFIINFYEGFDDSYTVSIPQTTVPWKTVCVCHDLIPLLNKERYLGEPNFRQYYYDKL
-                     AQYERADAIFAISRSSMQEVIDYTSIPAEKIINISSGVSDSFKIKDYTHDEIKDLRNKY
-                     HLPQEFILSLAMIEPRKNIEALIHAYSLLPHALQQSYPLVLAYKISTDEKERLYRVAEN
-                     YGLSRNQLIFTGFLNDSDLIALYNLCKIFVFPSIHEGFGLPPLEAMRCGAATLGSNVTS
-                     LPEVIGMEEALFNPLDVPDICRVMQRALTDSEFYSALKAHAPAQAAKFTWDHTAQLALK
-                     GFERLVDKASASEPLDITSFTAYTINRIKNIAELSETERLQTAWAIARNSFATHQRKLL
-                     VDISVLVEHDAKTGIQRVSRSILSELLKSGVAGYTVSAVYYRPGECYRYANEYLNTHFN
-                     GAFGPDVPVLFTKDDILVATDLTAHLFPELTVQLDFIRLSGAKVCFVVHDILPLRRPEW
-                     SDEGMQRVFPIWLSCIAQHADRLICVSASVAEDVKAWIAENSHWVKPNPLLTVSNFHLG
-                     ADLDASVPSTGMPDNAQALLAAMAAAPSFIMVGTMEPRKGHAQTLAAFEELWLQGKNYN
-                     LFIIGKQGWHVDDLCERLRHHPQLNKKLFWLQNISDEFLTKLYSQSSALIFASLGEGFG
-                     LPLIEAAQKKLPVIIRDIPVFKEIAQEHAWYFSGEAPADIAKAVEDWLALYEQNAHPRS
-                     ENINWLTWKQSAEFLLKNLPIIAPAAKQ"
-                     /locus_tag="O3β_06_wbdA"
-     gene            9568..10713
-                     /gene="wbdB"
-     CDS             9568..10713
-                     /gene="wbdB"
-                     /EC_number="2.4.1.57"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237532.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="mannosyltransferase B"
-                     /protein_id="CZQ25318.1"
-                     /db_xref="GI:1036211110"
-                     /translation="MKIIFATEPIKYPLTGIGRYSLELVKRLAVAREIEELKLFHGASF
-                     IDQIPQVENKSDTKASNHGRLSAFLRRQPLLIEAYRLLHPRRQAWALRDYKDYIYHGPN
-                     FYLPHRLEHAVTTFHDISIFTCPEYHPKDRVRYMEKSLHESLDSAKLILTVSDFSRSEI
-                     IRLFNYPAERIVTTKLACSSDYIPRSPAECLPVLQKYQLAWQGYALYIGTMEPRKNIRG
-                     LLQAYQLLPMETRMRYPLILSGYRGWEDDVLWQLVERGTREGWIRYLGYVPDEDLPYLY
-                     AAARTFVYPSFYEGFGLPILEAMSCGVPVVCSNVTSLPEVVGDAGLVADPNDVDAISAH
-                     ILQSLQDDSWREIATARGLAQAKQFSWENCTTQTINAYKLL"
-                     /locus_tag="O3β_07_wbdB"
-     gene            10723..11838
-                     /gene="wbdC"
-     CDS             10723..11838
-                     /gene="wbdC"
-                     /EC_number="2.4.1.11"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237533.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyl transferase family protein"
-                     /protein_id="CZQ25319.1"
-                     /db_xref="GI:1036211111"
-                     /translation="MRVLHVYKTYYPDTYGGIEQVIYQLSQGCARRGIAADVFTFSPDK
-                     ETGPVAYEDHRVIYNKQLFEIASTPFSLKALKRFKQIKDDYDIINYHFPFPFMDMLHLS
-                     ARPDARTVVTYHSDIVKQKRLMKLYQPLQERFLASVDCIVASSPNYVASSQTLKKYQDK
-                     TVVIPFGLEQHDVQHDPQRVAHWRETVGDNFFLFVGAFRYYKGLHILLDAAERSRLPVV
-                     IVGGGPLEAEVRREAQQRGLSNVVFTGMLNDEDKYILFQLCRGVVFPSHLRSEAFGITL
-                     LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPNDSQALVEAMNELWHNDETASRYGE
-                     NSRRRFEEMFTADHMIDAYVNLYTTLLESKS"
-                     /locus_tag="O3β_08_wbdC"
-ORIGIN
-        1 atgttgcttc ctgtgatcat ggctggtggt accggcagtc gtctctggcc gatgtctcgc
-       61 gagctttacc cgaaacagtt cctccgcctg ttcgggcaga actccatgct gcaggaaacc
-      121 atcacccgac tctcgggcct tgaaatccat gaaccgatgg tcatctgtaa cgaagagcac
-      181 cgcttcctgg tggccgaaca gctgcgccag ctcaacaagc tgtcgaacaa cattattctt
-      241 gagccggtcg ggcgcaacac cgccccggcc atcgccctgg cggccctcca ggccacccgc
-      301 cacggcgacg acccgctgat gctggtcctc gccgccgacc atatcatcaa taaccagccg
-      361 gtcttccacg acgccatccg cgtcgccgag cagtatgccg atgaaggcca tctggtcacc
-      421 ttcggtatcg tgccgaacgc cccggaaacc ggctacggct acatccagcg cggcgtggcc
-      481 ctcaccgaca gcgcccacac cccgtaccag gtggcccgct tcgtggagaa gccggaccgc
-      541 gagcgcgccg aggcctacct cgcctccggg gagtactact ggaacagcgg catgtttatg
-      601 ttccgcgcca aaaaatacct ctccgagctg gccaaattcc gcccggatat cctcgaagcc
-      661 tgccaggccg cggtcaatgc cgccgataac ggcagcgact tcatcagcat cccgcatgac
-      721 attttctgtg agtgcccgga cgagtccgtg gactacgcgg tgatggagaa aaccgccgac
-      781 gcggtggtgg tcggtctcga tgccgactgg agcgacgtcg gctcctggtc cgccctgtgg
-      841 gaggtcagcc cgaaagatga gcagggtaac gtcctcagcg gcgacgcgtg ggtgcacaac
-      901 agcgaaaact gctacatcaa cagcgacgag aagctggtgg cggccatcgg cgtggagaac
-      961 ctggtgattg tcagcaccaa ggacgccgtg ctggtgatga accgtgagcg ttcccaggac
-     1021 gtgaagaagg cggtcgagtt cctcaagcag aaccagcgca gcgagtacaa gcgccaccgc
-     1081 gagatttacc gtccctgggg ccgctgcgac gtggtggtcc agaccccgcg cttcaacgtc
-     1141 aaccgtatta cggtgaaacc gggcggcgcc ttctcgatgc agatgcacca ccaccgtgcc
-     1201 gagcactggg tcattctcgc cggcaccggc caggtgacgg tcaacggcaa gcagttcctg
-     1261 ctgaccgaga accagtccac ctttattccg attggcgccg agcacagcct ggaaaacccg
-     1321 ggccgcattc cgctggaagt gctggagatc cagtcggggt cgtacctcgg cgaggacgac
-     1381 attattcgta ttaaagacca gtatggtcgt tgctaatttt ttcgggacaa aacgcagaat
-     1441 gacacagtta acatgcttta aggcttatga catccgtggt gaactgggcg aggagctgaa
-     1501 cgaggacatc gcctaccgta tcggccgcgc ctatggcgaa tttctgaaac ccgggaagat
-     1561 agtggtgggg ggcgatgtgc gcctcaccag cgagtcgctg aagctggcgc tggcccgcgg
-     1621 gctgatggac gccggcaccg acgtgctgga tattggcctg agcggcacgg aagagattta
-     1681 cttcgccact ttccacctcg gggtggacgg cggtatcgag gtgacggcga gccataaccc
-     1741 gatgaactac aacggcatga agctggtgcg cgagaacgcg aagcccatca gcggcgacac
-     1801 cggcctgcgg gatatccagc gcctggcgga ggagaatcag ttcgcgccgg tagacccggc
-     1861 gcgtcgcggg accctgcgcc agatatcggt gctgaaggag tacgtcgacc acctgatggg
-     1921 ctatgtggac ctggcgaact tcacccgtcc gctgaagctg gtggtgaact ccggcaacgg
-     1981 ggcggcgggg cacgtgattg atgaagtgga gaaacgcttc gcggcggccg gggcgccggt
-     2041 gacctttatc aaggtgcatc accagccgga cggccatttc ccgaacggta tcccgaaccc
-     2101 gctgctgccg gagtgccgcc aggacaccgc cgacgcggtg cgtgcgcatc aggcggacat
-     2161 ggggatcgcc tttgacggcg acttcgaccg ctgcttcctg ttcgatgacg aggcgtcgtt
-     2221 tatcgagggg tactacattg tcggcctgct ggcggaggcg ttcctgcaga aacagccggg
-     2281 ggcgaaaatc attcacgacc cgcgtctgac gtggaacacg gtggacatcg tgacccgcag
-     2341 cggcggccag ccggtgatgt cgaagacggg gcatgcgttc atcaaggagc ggatgcgcca
-     2401 ggaagacgcc atctacggcg gggaaatgag tgcgcaccat tacttccgcg acttcgccta
-     2461 ctgcgacagc gggatgatcc cgtggctgct ggtggcggag ctgctgtgcc tgaagaacag
-     2521 ttcgctgaaa tcgctggtgg cggaccgcca ggcggcgttc ccggcgtcgg gggagatcaa
-     2581 ccgcaagctg gggaatgcgg cggaggcgat agcgcgcatc cgggcgcagt atgagccggc
-     2641 ggccgcacac atcgacacaa cggacggtat cagtattgaa taccctgagt ggcgctttaa
-     2701 cctgcgcacg tccaacacgg agccggtggt gcgtctgaac gttgagtcca gagcggatac
-     2761 tgcgttaatg aatgagaaaa ccgccgagct gctcaacctg ttaaaagagg aatcgctttg
-     2821 agtcctatgt tttcagcgat ctatcgctac cgtggcttta ttattgacag cgtcaaacgg
-     2881 gactttcagt cccgttacca gactagcttc ttaggcgcgg catggctgat cttacagccg
-     2941 atcgccatga tttccgtata tacattaatc ttttctgagt taatgcgtgc ccgcctggcg
-     3001 ggcatggacg gcccttttgc ctacagtatc tacctctgtt ccggggtgtt aacctggggg
-     3061 ctgtttacgg aaacgctcgg caatctggtc aacgtttttc tgaccaacgc caacattctt
-     3121 aaaaagctta gctttccgcg gatctgttta ccgatcattg tcaccgcctc ggcgttcatt
-     3181 aacttcctga tcatttttgg tctgtttgta ctgtttctga tcgtcacggg caatttcccg
-     3241 ggcatgattt tctttgaaat cattccggtg ctgatcgttc agatgctgtt caccctcggc
-     3301 ctcgggatca tcctcggggt gctgaacgtt tttgtccgcg acgtcgggca gttcgtgaat
-     3361 atcctgctgc agttttggtt ctggtttacg cccattgtct acgtgtccaa aacgctgccg
-     3421 gagtgggtct ctggtctgct ggcgtataac ccgatggcga ccattatcgg ttcataccag
-     3481 aacgtgatgc tctatcacca gagccctaac tggctggcgc tgcttccggt cacggtgctg
-     3541 tccgtcattc tgtttttatt tgcctggcgt ttatttaaaa aacatgccgc tgatattgtg
-     3601 gacgagattt aatcatgagt atcaaagttc agcacgtcgg caaggcgtat aaatattatc
-     3661 cctccaaatg gaaccgggtc attgagaaac ttctgccggg cgataagccg cggcacagca
-     3721 agaaatgggt attgaaagat atcaatttca gtattgaacc cggtgaagcg gtcggcattg
-     3781 ttggggtgaa cggcgcaggt aaaagtacgt tactgaagct gctgactggc accactcagc
-     3841 cgaccaaagg cagcattgag atccaggggc gtgtcgctgc gctgctggag ctgggcatgg
-     3901 gcttccatcc tgactttacc ggtcggcaga acgtgtatat gtccgggctg atgatgggcc
-     3961 tgagccggga agagattgag cgcttaatgc cggagatcga agcctttgcg gatatcggtg
-     4021 actacattga agagcccgtg cgcatctact ccagcgggat gcaaatgcgc ctggcgttcg
-     4081 ccgtggccac ggcctcacgc ccggatattc tgatcgtcga tgaagcgctt tccgttggtg
-     4141 actcccgctt tcaggcgaag tgctatgccc gtattgcgga cttcaaaaag cagggcacca
-     4201 cgctgctgct ggtctcccac agcgccgggg atatcgtcaa acactgtgac cgcgccattt
-     4261 tcctcaaaaa tggtgatatc tgtatggacg gcaccgcccg tgacgtgacc aaccgttatc
-     4321 tggatgagct gtttggcaaa gccgacaaaa acagcgcgcc aaaaagcgaa acggcaacct
-     4381 cgtcagccag cggcgaaagt cagatgtctc tcgatgagat tgaagatgtg taccacacgc
-     4441 gcccaggcta ccgtccggaa gagtaccgtt gggggcaggg gggtgcaaaa atcattgatt
-     4501 atcacatcca aagcgccggg gttgattttc cgccttcact gacgggcaat cagcagaccg
-     4561 atttcctgat gaaagtcgta tttgaatatg actttgattg cgtggtaccg ggtttgttaa
-     4621 tcaaaactct ggatggctta tttctatatg gtaccaactc tttcctggcc tcggaaggcc
-     4681 gggaaaacat ttcggtatca cgtggggacg ttagagtatt taaattcagt tttccggttg
-     4741 atttaaatag cggtgactat cttctgtcgt ttggtatttc agagggaagc ccgcaaaccg
-     4801 aaatgacgcc gctcgatcgt cgctatgact ccatcatttt gcatgtaact aagagcatgg
-     4861 atttctgggg agtgattgac ctgaagtcga ctttcaatag ttacaaatga agatgagaaa
-     4921 aaatcattcc atgactacta atacacataa attggttagc gaattacctg aaatttatca
-     4981 gactattttt gggcatcctg agtgggatgg cgatgctgca cgagactgta atgaacggct
-     5041 cgcgctaatt agtgaacaat atgacagctt gtccagagag ttaggaaggc cactacgggt
-     5101 tctcgacctg ggctgtgctc aggggttctt cagtttaagt ttggcaagca agggtgccag
-     5161 cgtattaggt atcgactttt tgcagcagaa cattgatgtt tgtcaggcgc ttgctgaaga
-     5221 aaatccacat tgtgatgtta aatttcaagt cgggcggata gaagacattg tcagcactct
-     5281 ggaagaaaac caatttgatc tcgccattgg actaagtgtt tttcaccaca ttgttcatct
-     5341 gcatggggtt gctgaagtca gatcgctgtt agagcgtttg gcaaatctga cgcaggcgat
-     5401 gattctcgag ctcgctgtca aggaggaacc actctattgg gggaaatctc agcctgaaga
-     5461 tccgcgtgaa cttattgacc aatgtgcttt ctatcgattg attggaagat ttgacactca
-     5521 tctgtctaat atttcacgtc cgatgtatat tatcagtaac cacagggtta ttcttccgga
-     5581 atttaatcag ccttttactt catggcgcga cagtccttac accggagcag gctttgcgca
-     5641 taaacagagc cgtcgctatt atttctcttc ggagttcata tgtaagttct atcgttttag
-     5701 tacagtaagt tgcttactaa ctgataagga gagcgagcgt aatcgtactg aactcgccca
-     5761 tgaagaagct tttcttaaat ctccaccatc tggcttaaaa gtgccggcgt tgtttactgc
-     5821 aggggggaat ggagaagcgg gatggttggt aatggaaaaa attcccggag agctgttaaa
-     5881 cgacgttctg gccagtgaac ggcatattga tcgggaaaaa gttatttccg atctcctcga
-     5941 ccaattagtt attttggaag aacatggtct atatcatgat gatttcagaa catggaatgt
-     6001 tttaattgac gataatgaca gcgctcgttt aatagatttt ggttcgattg gcgatgtaca
-     6061 acaagactgc agctggccag ttaatatttt ccagtcgttc attatttttg taaatgaaat
-     6121 attttgtgaa aataaatcct ggaggggctt ctggcgttcc gcaccattaa gtcctttcca
-     6181 gttgcctgaa ccgtattcaa attggttgac agcattctgg aaacatcctg ttggtgagtg
-     6241 gagttttgct ttactccaac aactcttttc aaccaaagat gctctaccgg ctgcgagttc
-     6301 cattatggac gcttctgatc tatgggtccg ggctcaggag cccgtattgt tggaaagtca
-     6361 aacgcaaata cgcaatacgg atgcgcgggt agtccgtctc gagtcgcaaa tcaatgaact
-     6421 cacctccctg attaatatta tgggtgagag cattcagacg tttgagaagc gtgagtatcc
-     6481 gccacaagac gttactacta atgtacagcc gcgtatcgag attgagcaga gtaaagccgt
-     6541 tgattcagaa gagattatgc gacttcatac gcagctcaat gatgctcagc aagaaataga
-     6601 gaatctacgt catgagattg ctaaaattca ttatagtcgc tcatggaaaa tgaccaagtg
-     6661 gtatcggtac gctggcttac agtactatct gcttcgtcag tacggcttca aacagcgttt
-     6721 taagcattta ctcaaacgag tgcttagcaa cgtaatttat tttttgcgtg cacatccacg
-     6781 actaaagcag aaggtgatca atctactgcg tacaattgga atttatgact ttgcttatcg
-     6841 tatgcatcgt cgtatgaatc ctggttcaca taacccttat ccaaacgacc cacaatacca
-     6901 gtcgcagact gaaaagcaga tcttacatcc agagttattg cctccggaag ttaactcaat
-     6961 ttttagcgag cttaaaaaca aaagataagg tgagtcactt gcatattttg attgacgtac
-     7021 aaggatatca atcggaaagt aaattccgtg gagttggtcg cagcacctat gaaatgagtc
-     7081 gtgcgatcat aaaaaatgct ggccagcatc gagtaagcat tttaatgaat ggcatgtatt
-     7141 cgattgatag tataaatgaa attaaaaaaa gctggggtga tatattaccg caggaagaaa
-     7201 tgtttatttt ttcagctgct ggccctacag ctcttcgcga ctgtgaaaac catccccgga
-     7261 gtgttgccgc cacactagct cgtgaacttg ctattgctaa tatcaatccc gacgttgttt
-     7321 ttattattaa tttctacgaa ggttttgacg atagttatac cgtctcaatt cctcaaacta
-     7381 cagtaccatg gaaaacagtt tgtgtttgtc acgatctaat tccgttactg aataaagaac
-     7441 gctatctggg cgaaccaaac ttccgtcagt attattatga taaactagct caatacgaaa
-     7501 gggcggacgc tatttttgct atttccagat catccatgca ggaagttatc gattacacat
-     7561 cgattccggc agaaaaaatt attaatattt catctggagt aagcgattca tttaaaatta
-     7621 aagattatac tcacgatgaa atcaaagact tacgtaataa atatcatctt cctcaagagt
-     7681 ttattctttc tttggcaatg atagagccac gtaaaaatat tgaagcgctg attcatgcat
-     7741 atagtttatt accgcatgcc ctgcaacaga gttatccctt agttttagcc tataaaatta
-     7801 gcaccgatga aaaggaaagg ctgtaccgag ttgcagagaa ctatggttta tctcgtaatc
-     7861 agcttatttt tacaggcttc ttaaacgata gtgaccttat cgcactttac aatttgtgca
-     7921 aaattttcgt tttcccctct atacatgaag ggtttggcct gccgccacta gaagctatgc
-     7981 gttgtggtgc agctacgctg ggttcaaatg tgaccagctt acccgaggtc atcggtatgg
-     8041 aagaggcttt atttaatcct ctggatgtcc ccgacatttg ccgtgttatg caaagggcct
-     8101 tgactgacag tgagttctac tcagcattaa aagctcatgc tccggcgcag gcggcaaagt
-     8161 tcacatggga tcacaccgcg cagctcgcgt taaagggatt tgagaggctt gtagataagg
-     8221 cttccgcatc agaacctctg gatatcacaa gcttcaccgc atacaccatt aatagaatta
-     8281 aaaatattgc agaattaagt gaaaccgaac gcttacagac agcctgggcg attgctcgta
-     8341 atagctttgc tacacatcag cgcaagctgc tggttgatat ttctgttctt gttgagcatg
-     8401 atgcgaaaac gggaattcaa cgggtttctc gcagtatact tagtgaatta ctgaaatctg
-     8461 gcgttgctgg ttatactgtc agtgcggttt attatcgacc gggtgaatgc tatcgctatg
-     8521 ccaacgaata cctgaatacc cattttaacg gggcgttcgg gcctgatgta cctgtactgt
-     8581 ttaccaaaga tgatattctg gttgctaccg atctaactgc ccatctgttt cctgagctta
-     8641 ctgtccagct ggattttatt cgtctatccg gtgccaaggt ttgttttgtt gtgcatgaca
-     8701 ttttgcctct gagaagaccg gagtggagcg atgagggaat gcaacgcgtg ttccccattt
-     8761 ggttatcttg cattgcgcag cacgcagacc gcttgatttg tgtatcagca agcgttgcag
-     8821 aggatgtaaa agcctggatt gcggaaaaca gccattgggt gaaaccgaac ccgctgctga
-     8881 ccgtcagcaa cttccatctg ggagccgacc tcgatgccag cgtaccgtcc actggcatgc
-     8941 cggataatgc ccaggcgctg ttagcagcga tggccgcggc tccatcattt atcatggtgg
-     9001 gcacgatgga accacgcaaa ggacatgcgc agacgctagc ggcatttgaa gaattgtggt
-     9061 tacagggcaa gaactacaat ctgtttatca ttggtaaaca ggggtggcat gttgatgatt
-     9121 tatgtgaacg tttacgtcac catccacagc taaataaaaa actattttgg ctacaaaaca
-     9181 ttagcgatga gttccttacg aagttgtatt ctcagtctag tgcgttaatc ttcgcatctc
-     9241 tcggagaagg ctttggcctg ccgttgattg aagcggcgca gaaaaagctg ccggtgatta
-     9301 tccgtgacat tccggtgttt aaagagattg ctcaggaaca tgcgtggtat ttctccgggg
-     9361 aagcgccggc cgacatcgcg aaggccgtcg aagactggtt agccctgtat gagcaaaacg
-     9421 cgcatcctcg ttccgagaat atcaactggt taacctggaa gcagagcgcg gaatttctcc
-     9481 tgaaaaacct gccgattatc gcgccagccg cgaagcaata atcgctatca acagggccac
-     9541 cccggtggcc cttgtgatga gttcgttatg aaaattattt ttgctactga gccaattaaa
-     9601 tacccgttaa cgggcatcgg tcggtattcc ctggagctgg ttaagcggct ggcggtcgcc
-     9661 cgcgaaatcg aagagctgaa gctgtttcac ggcgcgtcgt ttatcgatca gatcccccag
-     9721 gtggagaata aaagcgatac caaagccagc aatcatggtc gtttgtcggc gtttctgcgc
-     9781 cgccagccgc tgctgattga ggcgtatcgc ctgctgcacc cgcggcgcca ggcgtgggca
-     9841 ttgcgcgact ataaagatta tatctaccat ggtcccaatt tttacctgcc gcatcgcctg
-     9901 gaacacgccg tgaccacgtt tcatgacatc tccattttta cctgcccgga atatcatcca
-     9961 aaagatcggg ttcgctatat ggagaagtcc ctgcatgaga gcctggattc ggcaaagctg
-    10021 atcctgaccg tctctgactt ctcgcgcagt gaaatcatcc gcctgttcaa ctatccggcg
-    10081 gagcggatcg tcaccaccaa gctggcctgc agcagcgact atattccacg cagcccggcg
-    10141 gagtgcctgc cggtcctgca gaaatatcag ctggcgtggc aggggtatgc gttatatatc
-    10201 ggcaccatgg agccgcgtaa aaatatccgt ggtctgctgc aggcctatca gctgctgccg
-    10261 atggagaccc gcatgcgcta cccgctgatc ctcagcggct atcgcggctg ggaagacgat
-    10321 gtgctgtggc agttagtcga gcgtggtacg cgtgaagggt ggatccgtta cctgggctat
-    10381 gtcccggatg aggacctgcc ttatctgtac gcggcggcca gaacctttgt ttatccctcc
-    10441 ttctatgagg gattcggttt acctattctt gaagcgatgt cttgcggtgt gccggtagta
-    10501 tgttccaatg tcacttcttt gcctgaggtg gttggcgatg ccggcctcgt tgccgatcct
-    10561 aatgatgtag acgcgattag cgcgcatatt ttgcagagcc tgcaggatga tagctggcgg
-    10621 gaaatcgcca ccgcgcgcgg tcttgcccag gcgaaacagt tttcgtggga gaactgtacg
-    10681 acccagacca ttaacgccta taaattactc taagggtgtc agttgagagt tctacacgtc
-    10741 tataagacct actatcccga tacctacggc ggtattgagc aggtcattta tcagctcagt
-    10801 cagggttgcg cccgccgggg gatcgcagcc gatgttttta cttttagccc ggacaaagag
-    10861 acaggtcctg tcgcctacga agaccatcgg gtcatttata ataagcagct ttttgaaatt
-    10921 gcctccacgc cgttttcgtt gaaagcgtta aagcgtttta agcagattaa agatgattac
-    10981 gacatcatca actaccattt tccgtttccc tttatggata tgctgcatct ctcggcgcgg
-    11041 cctgacgcca gaacggtggt gacctatcac tcggatattg tgaaacaaaa acggttgatg
-    11101 aagttgtacc agccgctgca ggagcgattc ctcgccagcg tagactgcat tgttgcctcg
-    11161 tcgcccaact acgtggcctc cagccagacc ctgaaaaaat atcaggataa aacggtggtg
-    11221 atcccgtttg gtctggagca gcatgacgtg cagcacgatc cgcagcgggt ggcgcactgg
-    11281 cgggaaaccg tcggcgataa cttcttcctc ttcgtcggcg ctttccgcta ctacaaaggg
-    11341 ctgcacattc tgctggatgc cgccgagcgt agccggctgc cagtggtgat cgtcgggggc
-    11401 gggccgctgg aggcggaggt gcggcgtgag gcgcagcagc gcggactgag caatgtggtg
-    11461 tttaccggca tgctcaacga cgaagataaa tacattctct tccagctctg ccggggcgtg
-    11521 gtcttcccct cgcatctgcg ctcagaggcg tttggcatta cgttactgga aggcgcgcgc
-    11581 tttgccaggc cgctgatctc ctgcgagatc ggcaccggta cctcgttcat taaccaggac
-    11641 aaagtaaatg gctgcgtgat cccgccgaat gacagtcagg cgctggtgga ggcgatgaat
-    11701 gagctctggc ataacgatga aaccgccagc cgctatggcg aaaactcgcg tcgtcgtttt
-    11761 gaagagatgt ttacagccga ccatatgatt gacgcttacg tcaatctcta cactacgctg
-    11821 ctggaaagca aatcctga
-//
-LOCUS       LT174605                9449 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O4.
-ACCESSION   LT174605
-VERSION     LT174605.1  GI:1036211112
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1
-  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
-            Holt,K.E. and Thomson,N.R.
-  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
-            antigens
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 9449)
-  AUTHORS   Informatics,P.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
-            1SA, UNITED KINGDOM
-FEATURES             Location/Qualifiers
-     source          1..9449
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="AJ214"
-                     /serovar="O4"
-                     /db_xref="taxon:573"
-                     /note="O locus: O4"
-                     /note="O type: O4"
-                     /note="sequence manually trimmed to removed insertion
-                     sequences"
-     gene            complement(1..1797)
-                     /gene="hydrolase"
-     CDS             complement(1..1797)
-                     /gene="hydrolase"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Predicted hydrolase (HAD superfamily)"
-                     /protein_id="CZQ25320.1"
-                     /db_xref="GI:1036211113"
-                     /translation="MLQWVENYISAEQYDTPAIAHELYSWEIEQEKKHIYLDPGIEDFL
-                     AQYPSDKTIFLSDFYTSSTDLTELLVSAGLDQSVISDGVSSIDERLNKRSGRLFDFIQQ
-                     KYQLAGVDWIHIGDNEWSDVQMPTSKGIKSIRYLPAQQHQLREQKEFLWNKNEDLTETI
-                     TNNILNKYAASKDLSVDFQLGLKTTPLIAGFCLKILEQAVISKSEKILFFTREGEFFIK
-                     AMNILISHLKTNIKEIKLPEIDIIEVSRLATFAPSLQEISTKEMMRVWNLYSTQSISSL
-                     FKTLNVAPETFQSFIDKYGIPADEQIQYPWQDSRIQQLFDDSGFKETLWQHVMQQRALL
-                     KNYFATKGLTDDINARICVVDVGWRGTIHDNIALLYPDIHFTGIYLGLQKFLNEQPSNT
-                     SKVAFGPDLNHQLEYPHFLDSVAPIEMITNSPSGSVTGYGLENGKIVAIRSVNDDENSA
-                     WHNFTKTFQEGILAGMESFSAAVLSYGITHDVVRGYALNIWDVLISGSNKSLTDAFNNL
-                     NHNETFGLGGYVKKNHVPTTFEILSSLWNKNNRAALIEFIKANQWSDGIRKRDNLPSLN
-                     KYILALTIDLAVFYKRKFYRKY"
-                     /locus_tag="O4_01_hydrolase"
-     gene            complement(2037..5365)
-                     /gene="hypothetical"
-     CDS             complement(2037..3227)
-                     /gene="hypothetical"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Uncharacterised protein"
-                     /protein_id="CZQ25321.1"
-                     /db_xref="GI:1036211114"
-                     /translation="MANIAWFIPQLIEGSGGHRTMLQHAAYLEKMGHTCTIYLEDKSGK
-                     TSGAEVIHKLFGLKFKDVIYDWNNAQPCDAAVATIWYSAPFVAALPFDCKRLYFVQDFE
-                     AYFNPVGDAYLMAENSYCYGLKPITIGRWLRYKLQNDFAVESYHFEFGANHNIYKRVPT
-                     IQKEKAVCFIYQPDKPRRCSRIGIEALGIVKHCMPDVKIYLYGTSINDNLWFEHENLGL
-                     LDLPKCNELYNKCSVGLCISSSNPSRIPFEMMNAGLPVVEVWRENNLYDFSEDAMLLCK
-                     QTPESIATGIMKILNDADLAASMSSAGQKFMNGRTLETETEGFYKAFNCVMNEQAYTAE
-                     VISRSYNKPPFEAPLARPDIANTLTFAHQSLLKRIALRLPLFVRTPLSALYFKLKN"
-                     /locus_tag="O4_02_hypothetical"
-     CDS             complement(3248..5365)
-                     /gene="hypothetical"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Uncharacterised protein"
-                     /protein_id="CZQ25322.1"
-                     /db_xref="GI:1036211115"
-                     /translation="MNDISITDYLGPGVYLLQNYPKETEGLIAEKGYKVHNCADLAQCK
-                     DILNRNKVNFLLTNDKDNNFNEYVKIVRTAARQLVNKIVINIFVEKGNGQSFQDFINIT
-                     DNLGYSIDTVFYLLNPGYDEQFRDDQSLKIVLSYRRQSVVSTDKNILETTIFEKKLVNT
-                     FPYIRPGDRVLVIIKNKNSITNIKNIIAEQTKASEVEIYSLDEIKSVQLNGNGYHFLIT
-                     DKYADDGLNNALKVIISYLVPAGRYVSFHTDKTVVETLSNYNLQPEVYLFYEHGHLKTQ
-                     IHQGEEITLSPELCVFMKSPLARSELPYQETIYGYSHPPKNLLAFARDYTNPWLIRGIV
-                     EFPFRNRSTYHLQQYSHQILEHSAPDSPDYAAALAVLGYQMLSGSDDTADIYAKMLDYC
-                     SNVSQMDNPTPHQYRWLISLSTLLGLICNKNNDKANALIHLSRAANSSIDKFSPSIGTK
-                     ILQSFYLQSVILISLNRISCAEIIVDRGIKRGIQLLYQHPDELVGKISQPFNFVLYIYH
-                     DILDWLIKMVNIKNAIPGRKFNIANFDNGNTWSALLHERMNAINNMSQMIDERDRTIHD
-                     QKCLIDERDRTIHDQKRLIDERDSTVLTQKNLIDERDLVSAQQNQLIEQNNKTIQQQIQ
-                     NVTDLNSQVSSKEQKVDELQNQNIKLISLIDEKDLHIAQLSADLERANTILRKINSTPV
-                     IRHLLRMLNIK"
-                     /locus_tag="O4_03_hypothetical"
-     gene            complement(5370..6779)
-                     /gene="wzt"
-     CDS             complement(5370..6779)
-                     /gene="wzt"
-                     /EC_number="3.6.3.40"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_001336133.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="O-antigen export-NBD component"
-                     /protein_id="CZQ25323.1"
-                     /db_xref="GI:1036211116"
-                     /translation="MSSDNIAISVSNISKCYNIYQNPRDRLKQFFLPKVQSMVGKPVQR
-                     YYNEFWALNNINFTINKGESAGIIGRNGSGKSTLLQLITGTLTPTTGTIQTKGRIAALL
-                     ELGSGFNPEFTGRENIYLNGAVLGLSRAEIDAKFDAIAGFADIGTHLDQPVKTYSSGMM
-                     VRLAFAVQVQLEPDILIVDEALAVGDALFQKRCFQQIEKLTSNGVTLLFVSHDQESVRT
-                     LTNRAILLDRGTQLSTGLSSEVLLEYRRLLHREESKYFSQLAEEVAAHADATRDINQTP
-                     TAPAKIEISANAETPAVEETSPSRTDKLSFGEGEAEVENVELFTASGERSNAFNPGDKI
-                     RVRVNCKVNKDINHINVGIRIRNKEGVKIYSWGTLNQDMYVRFHQLKDPQFWEREFKAG
-                     ERFYVDMEFECTLGTNLYEIQAAISYEGTPNYFSQRILHWRDEAAFFHVNVLRDEYFFG
-                     GILDLKMTAEW"
-                     /locus_tag="O4_04_wzt"
-     gene            complement(6769..7500)
-                     /gene="wzm"
-     CDS             complement(6769..7500)
-                     /gene="wzm"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_001336134.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="O-antigen export-TMD component"
-                     /protein_id="CZQ25324.1"
-                     /db_xref="GI:1036211117"
-                     /translation="MGRYKGSFLGLAWSLFNPILMLTVYTFVFSVIFKSRWGSSPDAGH
-                     ADFAIILFTGLIIFNLFAECINRSTSLITSNVNFVKKVVFPIEILPIVNLLAALFHASI
-                     SLIVLFIAILVFKHQLHFTVLLLPVITIPLMLSILGLSWILASLGVFVRDMPQTISIIV
-                     TILMFLSPVFYPLSALPVVFQKIVMLNPLAFMIEEARKVVYWGNEPNWTMLAINMLIGL
-                     VIFAAGFLFFQKTKKGFADVI"
-                     /locus_tag="O4_05_wzm"
-     gene            complement(7588..8733)
-                     /gene="glycosyltransferase"
-     CDS             complement(7588..8733)
-                     /gene="glycosyltransferase"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006499560.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyl transferase"
-                     /protein_id="CZQ25325.1"
-                     /db_xref="GI:1036211118"
-                     /translation="MRIVYFVNAAWYFELHWLDRSEAAISKGYEVHLVSNFADDAIKNN
-                     LEKKGIKCWDIELNRFSKNVFKNISIFTAFRKICKQIKPDLIHLITIKPILFGGLYARV
-                     AGIPFVVSFVGLGRLFGNKRGWLNKFIFNSVLSIYSLLLSAKSPAQVIFEHNADFAELS
-                     KYIKFDENNIHIIEGAGVDRFRFSYQPEPTQNNFSVLFASRLLWSKGLGEVVEAIGKVK
-                     QNENNTTLYVAGILDDKDPDRIELDQILQWEKEGKIIWLGRRDDIQNLIRNSHVVILPT
-                     KYSEGVPRIIIEACAMGRSCIVGNVPGCKAIIKDNFNGCVLKTHSASEIAEKIEYLRDN
-                     MEIRKKFGLRSAEIVKERFSKEIVIDKTLCVYNKILSTTKR"
-                     /locus_tag="O4_06_glycosyltransferase"
-ORIGIN
-        1 ttaatacttg cgatagaatt ttcttttata aaaaaccgca aggtcaatcg tcagtgctaa
-       61 aatgtattta tttagcgagg gcagattgtc tcttttacgt atgccatcgc tccattgatt
-      121 tgctttaata aattcaatca atgctgcacg gttgttttta ttccataaag agcttaatat
-      181 ctcgaaggtc gtgggtacat ggtttttctt aacgtatcca cctaagccga atgtttcgtt
-      241 atgatttaaa ttattaaaag cgtcagttag agatttatta ctaccactaa ttagcacatc
-      301 ccaaatattt agggcgtagc cacgtacaac gtcgtgagta atgccataac tcaacactgc
-      361 agcggagaag gattccatac cggccaggat cccttcttga aatgtttttg tgaaattatg
-      421 ccacgcgctg ttttcgtcgt cgttaacact gcgaatagcg actatcttac cattctccag
-      481 cccatagcct gttacgctac ctgaagggga gttggtaatc atttcaatag gagcaacgga
-      541 atcaagaaaa tgaggatact ccagttggtg attcaaatct gggccaaaag caacttttga
-      601 tgtgtttgat ggttgctcgt tgagaaattt ctgcaggccc agatatatgc cggtaaaatg
-      661 aatatcagga taaagaagag caatattatc gtgaatggtg ccacgccagc cgacatcgac
-      721 tacgcaaata cgcgcattga tatcatcagt tagacctttt gtcgcaaaat agttcttcaa
-      781 aagagctctt tgctgcatca catgctgcca gagcgtctct ttgaaaccag agtcgtcaaa
-      841 aagttgctga atacggctgt cctgccatgg atattggatc tgttcatctg caggaatccc
-      901 atatttgtcg atgaaactct ggaatgtttc aggggcaacg ttaagggtct tgaataaaga
-      961 gctaatggac tgtgtgctat ataaattcca aacacgcatc atctcttttg tgctaatttc
-     1021 ttgtagagac ggcgcgaagg tagccagacg gctgacttct ataatatcga tttctggtaa
-     1081 ctttatttct ttaatattag tcttgagatg actaatcaaa atattcattg ctttaatgaa
-     1141 aaactcgcct tcacgagtga aaaagaggat tttttcactt tttgatatga cggcttgttc
-     1201 caaaatttta aggcaaaaac cagcgattaa cggagttgtt ttcaagccaa gctgaaaatc
-     1261 aactgataaa tctttagatg ctgcatattt attaagaata ttattggtga tcgtttccgt
-     1321 gagatcttca tttttattcc agagaaactc tttttgctca cgcagctgat gctgttgggc
-     1381 tgggagatac cgaatacttt ttataccttt tgatgtcggc atttgcacat cggaccattc
-     1441 attatcgcca atatgtatcc agtcaacgcc ggctaactga tatttttgtt gaataaaatc
-     1501 gaagagacgt ccacttctct tgttcagtcg ctcgtcaatt gaagaaacgc catctgatat
-     1561 gacagactga tccaatccag cgctaacgag taactctgtt aaatcagtgg atgaagtata
-     1621 aaaatcggac agaaagattg tcttatcaga gggatattgc gcaagaaagt cctcaatacc
-     1681 tggatccaga tagatgtgct tcttctcttg ctcaatttcc caggaatata gctcatgtgc
-     1741 tatcgctggc gtatcatatt gctctgcaga gatatagttt tctacccatt gaagcattac
-     1801 atcctgaatg agatactcat catcataacc aagatctttg tttttcttac caattaagcg
-     1861 ctctgtttca actcgcttag taaatagctg gtcgacggaa tcaacattgt gtagcgaatg
-     1921 aaatttaagg aaaaaataat atgcagttga ccgctttatg aagtctggat ggcaatcacg
-     1981 acgcagaatt gtatcccata catcaacagt tttgagttta aatttattca tctggattaa
-     2041 ttcttcaact taaaataaag cgcgcttaaa ggtgtgcgca caaataacgg taaacgtaga
-     2101 gcaattctct ttaacagact ctgatgcgcg aatgttaacg tgttggcaat atcaggtctg
-     2161 gcaagagggg cttcaaacgg gggcttatta tacgatcgtg aaatcacttc tgctgtgtat
-     2221 gcctgctcgt tcatcacgca gttgaacgct ttgtaaaagc cttctgtttc cgtttccagg
-     2281 gtacgcccat tcataaactt ttgaccagcc gagctcatac tcgcggctaa atcagcatcg
-     2341 tttagaattt tcataatacc ggtggcaatg ctttcaggtg tctgtttaca caacagcata
-     2401 gcatcttcgc taaaatcata aagattgttt tctcgccaga cttcaacaac gggaaggcct
-     2461 gcattcatca tttcaaaggg gatgcgagag ggatttgaag aactaataca gagtcctacg
-     2521 gagcatttat tatatagctc attacatttc ggcaaatcta ataaacctag attttcatgt
-     2581 tcgaaccaga gattatcatt aattgatgta ccataaagat aaattttaac atctggcatg
-     2641 caatgtttaa ctatacctaa agcctcaata ccaatacgcg aacaacgtcg cggtttatct
-     2701 ggctgataga taaagcaaac cgctttttct ttttgaatgg tgggaactcg cttatagata
-     2761 ttatgattcg ccccaaattc gaagtgatag ctttcaacag caaaatcatt ttgcagttta
-     2821 tatcgtaacc agcgcccaat cgtaattggc tttaagccgt aacagtatga attttcagcc
-     2881 atcaggtaag catcgcccac cgggttgaag taagcttcaa aatcctgaac gaaatataaa
-     2941 cgtttacaat caaatggtag agcggccacg aatggtgcag aataccatat tgttgcaact
-     3001 gcagcatcac atggttgcgc attattccag tcataaatga cgtctttaaa ttttagacca
-     3061 aataatttat gaattacctc tgcaccgctt gttttgccgc ttttatcttc aagataaatt
-     3121 gtacatgtat gacccatttt ttccagataa gcggcatgtt gcagcattgt gcggtgacca
-     3181 ccagaccctt caatgagttg aggtataaac caagcaatat tagccattat aacctttcac
-     3241 aatagaatta ttttatattt agcatgcgta gtagatgcct tattacaggc gtgctattaa
-     3301 tcttacgcag tatggtattt gcacgttcta gatctgcaga gagctgggca atatggagat
-     3361 ctttttcatc gattaatgaa attaatttta tgttttgatt ctgtaattca tcaactttct
-     3421 gttccttaga ggaaacttga ctatttaagt cagttacatt ttggatttgc tgctgaatag
-     3481 ttttattatt ctgctcaatt aattgatttt gctgagcaga gaccaggtca cgctcatcaa
-     3541 ttaaattttt ttgcgtaaga acagtgctgt ctcgctcatc aataaggcgc ttctggtcgt
-     3601 gaatagttct atcgcgttca tcaattaagc atttttgatc atgaattgtt ctgtcacgct
-     3661 catctatcat ttgcgacata ttatttattg cattcatgcg ttcatgaagc aaagccgacc
-     3721 aggtgttacc gttgtcaaaa tttgcaatgt tgaattttct gcctggtatg gcgtttttaa
-     3781 tgttgaccat ctttataagc caatcaagaa tatcatggta aatataaagc acaaaattaa
-     3841 atggttgaga tattttaccc accagttcgt caggatgttg ataaagtagc tgtatacctc
-     3901 ttttaatccc tctatcgacg attatctcgg cacaggagat tctatttaaa gaaattaata
-     3961 taacggactg aagataaaag ctttgtaaaa tcttcgtgcc gatagagggg ctaaatttat
-     4021 caatgctgga gtttgctgca cgagataaat ggattaacgc attagcttta tcattatttt
-     4081 tgttacaaat aagacctaaa agtgtcgata aagatatgag ccaacgatat tgatgtggcg
-     4141 taggattatc catctgcgac acatttgagc agtaatctag catttttgcg taaatgtcag
-     4201 ctgtatcatc actgccgctt agcatttgat aacctaatac tgccaatgca gcggcataat
-     4261 cggggctgtc aggagcactg tgctccaaaa tctgatggct atactgctgt agatgataag
-     4321 ttgacctatt cctgaatggg aattctacga tcccgcgaat aagccacggg ttagtataat
-     4381 ctctggcaaa agctaatagg ttttttggtg gatgcgagta gccataaatc gtttcctgat
-     4441 acggaagctc tgacctagct aaagggcttt tcataaaaac acataattca ggagagagtg
-     4501 taatttcctc tccctgatgt atttgagtct ttaaatggcc atgttcataa aataaataaa
-     4561 cttcaggttg taaattgtaa ttacttaatg tctcaactac agttttatct gtatgaaaac
-     4621 taacgtacct gccagcgggc accaggtaag atataatgac tttgagtgca ttatttagtc
-     4681 catcatcggc atatttatca gtaatgagaa aatggtagcc attgccattt agctgaacac
-     4741 ttttaatttc atccaatgag taaatttcaa cttcagatgc cttggtttgt tctgcaataa
-     4801 tatttttaat gtttgttatc gaatttttat tcttaatgat tacaagtact cgatccccag
-     4861 gacgtatgta gggaaaagta tttacaagtt ttttttcaaa aatagtcgtt tctaagatat
-     4921 ttttgtctgt cgaaactact gactgacgtc tataactcaa aactatcttt aggctttgat
-     4981 catcccgaaa ttgttcatca tagccaggat tgagcaaata aaatacagtg tctatcgaat
-     5041 aaccaagatt gtcagttata ttaataaaat cctggaaact ctgaccgttt cccttttcta
-     5101 caaagatatt aataacgatt ttatttacaa gctgtcttgc agcggttctg acaatcttga
-     5161 catattcatt aaaattatta tctttatcat tggttaaaag gaaattaact ttattgcggt
-     5221 taagaatatc tttacactgc gccagatcag cgcagttgtg caccttataa cccttctctg
-     5281 caatcagacc ctctgtttct tttgggtaat tttgtaataa atacacccca ggcccgagat
-     5341 aatcagttat tgaaatatca ttcatcaact taccactctg cagtcatctt gagatccaga
-     5401 atgccaccaa agaaatattc atcacgcagg acattaacgt gaaaaaacgc ggcttcatca
-     5461 cgccagtgta aaatgcgctg cgagaaataa ttaggtgtcc cctcatagga tatcgccgcc
-     5521 tgtatttcat ataggtttgt tcctaaagta cattcaaatt ccatatcaac ataaaaacgc
-     5581 tcgcctgctt taaactcacg ttcccaaaat tggggatctt taagttgatg gaaacgaaca
-     5641 tacatgtcct ggtttaacgt tccccatgaa taaattttga cgccttcttt attgcgaata
-     5701 cgaatgccaa cgttaatgtg gtttatatct ttatttactt tgcaattaac acgaactctg
-     5761 attttatcac cagggttaaa ggcattgctg cgttcaccag aagccgtaaa caattcaaca
-     5821 ttttcaacct ctgcttcacc ttcaccgaac gatagtttat ctgtacgaga gggcgaggtt
-     5881 tcctctacag caggggtttc agcattagca ctaatttcta tcttagccgg cgcggtgggg
-     5941 gtttgattaa tatcgcgagt ggcgtccgcg tgggcagcaa cttcctctgc taactgagaa
-     6001 aaatacttac tttcttcccg gtgtagtaaa cgacgatatt caagtaaaac ttctgatgat
-     6061 aagccagtac ttaattgcgt cccacgatcg agaagaatag ctctgtttgt taaggtacgc
-     6121 acggactctt gatcgtgtga aacaaacagt aaagttacgc cattgctggt taatttctca
-     6181 atttgttgga aacagcgctt ttgaaaaagt gcgtcgccta cagcaagtgc ttcatctacg
-     6241 atgagaatat ctggctctaa ttgtacctga acggcaaatg caaggcgcac catcattccg
-     6301 ctggagtatg tttttaccgg ctggtcgaga tgggttccta tatcagcaaa accggcaata
-     6361 gcatcaaatt ttgcatctat ttctgcccgc gataatccca gaacggcgcc gttaagatag
-     6421 atgttttccc taccggtaaa ctctgggttg aaaccggagc ctaattccaa gagggcagct
-     6481 attcttccct tggtttgtat cgtgcccgtt gttggagtta gcgtgccggt gattagctgt
-     6541 agtaatgtac ttttgccaga accattgcgt ccaataattc ccgctgactc acctttattg
-     6601 atggtaaagt tgatgttatt taacgcccaa aattcgttat agtagcgttg tacaggtttc
-     6661 ccaaccatac tctggacttt aggtaagaaa aactgtttta acctatctct ggggttttgg
-     6721 taaatgttat agcatttgct aatgttactt acgctaattg caatgttatc agatgacatc
-     6781 ggcaaatcct ttttttgttt tttggaaaaa taaaaaacct gcagcaaaga taactaaacc
-     6841 aataagcata ttaattgcga gcatggtcca gttaggctca tttccccagt aaacaacttt
-     6901 tcttgcttct tcaatcataa atgccagagg attcaacatt acaatttttt ggaaaaccac
-     6961 cggtaatgct gataacggat aaaatacggg agataaaaac attaatattg ttacgatgat
-     7021 actaatagtt tgtggcatat cacgaacaaa aacgcccagt gaggccagga tccagcttaa
-     7081 tccaagtata gagagcataa gtggaatagt aatgactggc agtaacagga cagtaaaatg
-     7141 aagctgatgc ttaaacacca gtattgcgat aaataagact atgaggctaa tgctggcatg
-     7201 aaataaagca gccagcagat ttactatagg taatatctca atagggaaaa caactttttt
-     7261 gacgaagttt acatttgagg tgataaggct ggttgacctg ttaatacatt ctgcaaataa
-     7321 gttaaaaata atcagtccgg taaacaaaat gattgcaaaa tctgcatgcc cggcatctgg
-     7381 actgcttccc caacgagatt tgaatataac cgagaataca aatgtgtaga ctgttaacat
-     7441 caatatgggg ttgaaaagtg accatgccag accaagaaag gatcctttat agcgtcccat
-     7501 aacgtctctt ttagacattt gccagattaa ctcgcgcttc tggataatta tcttcgaaat
-     7561 ttttactaaa gttccaatca ttatttttta ccgctttgtt gtacttagta ttttattgta
-     7621 aacacataac gttttatcta taacaatttc tttgctgaat ctttctttta caatttcggc
-     7681 tgagcgtagg ccaaattttt ttcttatttc catgttatct ctaagatatt caattttctc
-     7741 cgcgatctca ctagcgctat gtgtttttag tacacatcca ttgaaattat ctttaattat
-     7801 ggctttacag ccgggtacat ttccgacaat gcaacttcgg cccatagcac acgcttcaat
-     7861 gattattctt ggcacgcctt ctgaatattt agttggcaaa atcacgacat ggctatttct
-     7921 gattaaattt tggatgtcat ctcttcgacc taaccaaatg atttttcctt ctttttccca
-     7981 ttgcaaaatt tgatctaatt caattctatc cggatctttg tcatcgagaa ttcccgcaac
-     8041 gtataaggtt gtgttatttt cattttgttt aaccttaccg atggcctcga ctacttcacc
-     8101 gagccccttt gaccatagca aacggctggc aaataatacc gagaaattat tctgagttgg
-     8161 ttctggctga taactaaagc gaaacctgtc taccccggct ccttcaatga tatggatgtt
-     8221 attttcatca aatttaatat atttactcag ctcagcaaag tcagcattat gctcaaatat
-     8281 tacttgcgct gggctttttg ctgatagcaa aagactataa attgacagta ctgagttgaa
-     8341 aatgaattta ttcaaccaac ctcgtttatt gccaaacaat ctccctaatc ccacaaagct
-     8401 tacgacaaaa gggatgcctg caacccgggc atacaatcca ccaaaaagga ttggttttat
-     8461 agtaattaga tgaataagat cgggtttaat ttgcttacag atctttctaa atgcagtgaa
-     8521 tattgaaatg tttttaaaca catttttaga aaatctgtta agctcaatat cccaacattt
-     8581 tatacctttt ttttccaggt tatttttgat ggcgtcatca gcaaaattac ttacaagatg
-     8641 aacttcatac cctttgctaa ttgccgcttc tgaccggtcc aaccaatgca gttcgaagta
-     8701 ccacgctgca ttgacaaaat acactatcct cataccattc ctcaacaacc cgcgagatgg
-     8761 tcaatcacgg cttactacat gtaatgtagg cacgctaccg cccttggctc tggctgccaa
-     8821 agggcgaaac tcttgttttg tcaggagtat tgacggccag gctactgacc gctgcaacta
-     8881 cccaatgtct ggtagttaaa taccagcata cacctcactg accacaggtt tccaaactcc
-     8941 cgtgattcgg ctaaaaacca ggctattatg aaatatattc ctgacagcat atgttttgca
-     9001 ttataagagc ataatttctt acgcatttta tgcctactgg atgattccta tagctaactg
-     9061 gttgtttcat aaaaaaatct ataaagtaaa atagttcatg gatttcaaac agatacatcc
-     9121 aactgttact tatttcataa catagcttta catttgagct cactttgaac atttagtgaa
-     9181 tgagaggccg tgtatggtga gtttttatgc atttaatttt tatttaacct tgtgtggaca
-     9241 tgtataaact tagggccggg atcttgaagc cctaaaaggt ttaggcgcaa attatgcgtc
-     9301 ttaccctaca ttgggttaaa tcttccgcgc ccgccaaaac tactattgat cgccattgtc
-     9361 ggatacggtg cctccgtttg atagatttca tggatttatt gagctgctta cgccgctgtg
-     9421 attatattct tttataagaa catttccag
-//
-LOCUS       LT174606               12084 bp    DNA     linear   BCT 13-JUN-2016
-DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis gene
-            cluster, type: O5.
-ACCESSION   LT174606
-VERSION     LT174606.1  GI:1036211123
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacteriales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1
-  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
-            Holt,K.E. and Thomson,N.R.
-  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae surface
-            antigens
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 12084)
-  AUTHORS   Informatics,P.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
-            1SA, UNITED KINGDOM
-FEATURES             Location/Qualifiers
-     source          1..12084
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="AKPRH1202322"
-                     /serovar="O5"
-                     /db_xref="taxon:573"
-                     /note="O locus: O5"
-                     /note="O type: O5"
-     gene            1..1416
-                     /gene="manC"
-     CDS             1..1416
-                     /gene="manC"
-                     /EC_number="2.7.7.13"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_006635421.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="mannose-1-phosphate guanylyltransferase"
-                     /protein_id="CZQ25330.1"
-                     /db_xref="GI:1036211124"
-                     /translation="MLLPVIMAGGTGSRLWPMSRELYPKQFLRLYGQNSMLQETITRLS
-                     GLEIHEPMVICNEEHRFLVAEQLRQLNKLSNNIILEPVGRNTAPAIALAALQATRHGDD
-                     PLMLVLAADHIINNQPVFHDAIRVAEQYADEGHLVTFGIVPNAPETGYGYIQRGVALTD
-                     SAHTPYQVARFVEKPDRERAEAYLASGEYYWNSGMFMFRAKKYLSELAKFRPDILEACQ
-                     AAVNAADNGSDFISIPHDIFCECPDESVDYAVMEKTADAVVVGLDADWSDVGSWSALWE
-                     VSPKDEQGNVLSGDAWVHDSENCYINSDEKLVAAIGVENLVIVSTKDAVLVMNRERSQD
-                     VKKAVEFLKQNQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
-                     AEHWVILAGTGQVTVNGKQFLLTENQSTFIPIGAEHSLENPGRIPLEVLEIQSGSYLGE
-                     DDIIRIKDQYGRC"
-                     /locus_tag="O5_01_manC"
-     gene            1439..2815
-                     /gene="manB"
-     CDS             1439..2815
-                     /gene="manB"
-                     /EC_number="5.4.2.2"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237527.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="phosphomannomutase"
-                     /protein_id="CZQ25331.1"
-                     /db_xref="GI:1036211125"
-                     /translation="MTQLTCFKAYDIRGELGEELNEDIAYRIGRAYGEFLKPGKIVVGG
-                     DVRLTSESLKLALARGLMDAGTDVLDIGLSGTEEIYFATFHLGVDGGIEVTASHNPMNY
-                     NGMKLVRENAKPISGDTGLRDIQRLAEENQFPPVDPARRGTLRQISVLKEYVDHLMGYV
-                     DLANFTRPLKLVVNSGNGAAGHVIDEVEKRFAAAGAPVTFIKVHHQPDGHFPNGIPNPL
-                     LPECRQDTADAVRAHQADMGIAFDGDFDRCFLFDGEASFIEGYYIVGLLAEAFLQKQPG
-                     AKIIHDPRLTWNTVDIVTRSGGQPVMSKTGHAFIKERMRQEDAIYGGEMSAHHYFRDFA
-                     YCDSGMIPWLLVAELLCLKNSSLKSLVADRQAAFPASGEINRKLGNAAEAIARIRAQYE
-                     PAAAHIDTTDGISIEYPEWRFNLRTSNTEPVVRLNVESRADTALMNEKTTELLHLLSGE
-                     "
-                     /locus_tag="O5_02_manB"
-     gene            2817..3611
-                     /gene="wzm"
-     CDS             2817..3611
-                     /gene="wzm"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237528.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="ABC transporter permease"
-                     /protein_id="CZQ25332.1"
-                     /db_xref="GI:1036211126"
-                     /translation="MRDLLTTIYRYRGFIWSSVKRDFQARYQTSMLGALWLVLQPLSMI
-                     LVYTLVFSEVMKARMPDNTGPFAYSIYLCSGVLTWGLFTEMLDKGQSVFINNANLIKKL
-                     SFPKICLPIIVTLSAVLNFAIIFSLFLIFIIVTGNFPGWLFFSVIPVLLLQILFAGGLG
-                     MILGVMNVFFRDVGQLVGVALQFWFWFTPIVYVLNSLPAWAKNLLLYNPMTRIMQSYQS
-                     IFAYHQAPNWYSLWPVLALAIIFCVIGFRMFRKHAADMVDEL"
-                     /locus_tag="O5_03_wzm"
-     gene            3611..4825
-                     /gene="wzt"
-     CDS             3611..4825
-                     /gene="wzt"
-                     /EC_number="3.6.3.40"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237529.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="ABC transporter ATP-binding protein"
-                     /protein_id="CZQ25333.1"
-                     /db_xref="GI:1036211127"
-                     /translation="MSYIRVKNVGKAYRQYHSKTGRLIEWLSPLNTKRHNLKWILSDIN
-                     FEVAPGEAVGIIGINGAGKSTLLKLITGTSRPTTGEIEISGRVAALLELGMGFHSDFTG
-                     RQNVYMSGQLLGLSSEKITELMPQIEEFAEIGDYIDQPVRVYSSGMQVRLAFSVATAIR
-                     PDVLIIDEALSVGDAYFQHKSFERIRKFRLEGTTLLLVSHDKQAIQSICDRAILLNKGH
-                     IEMEGEPEAVMDYYNALLADKQNQSIKQVEHNGKTQTVSGTGEVTISEVHLLDEQGNVT
-                     EFASVGHRISLQVNVEVKADIPELVVGYMIKDRLGQPIFGTNTHHLKQTLTSLKKGEKR
-                     SFLFSFDARLGVGSYSVAVALHTSSTHLGKNYEWRDLAVVFNVVNTEQQEFVGVSWLPP
-                     ELEIS"
-                     /locus_tag="O5_04_wzt"
-     gene            4825..6102
-                     /gene="wbdD"
-     CDS             4825..6102
-                     /gene="wbdD"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237530.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="methyltransferase"
-                     /protein_id="CZQ25334.1"
-                     /db_xref="GI:1036211128"
-                     /translation="MGSSFYRSFEERHRGSVEDIKNRLSFYLPFLSRLKDLYPEGVIAD
-                     IGCGRGEWLEILTENGIANIGVDLDDGMLARAKEAGLNVQKMDCLQFLQNQADQSLIAL
-                     TGFHIAEHLPFEVLQQLVMHTLRVLKPGGLLILETPNPENVSVGTCSFYMDPTHNHPLP
-                     PPLLEFLPIHYGFNRAITVRLQEKEALKSPDAAVNLVDVLKGVSPDYSIIAQKAAPADV
-                     LERFETLFTQQYGLTLDVLSNRYDAILRQQFSSFASQLETLNQTYTRQLSKMAENIQTL
-                     QGQVDELNHVIGQNNQLHQQVADLHNSRSWRITQPLRWLSLQRQLLRQEGAKVRARRAA
-                     KKILRKGMALSLVFFHRYPKSKVYLFKFLRKTGCYTLLQRLFQRVMLVQSDTMMMQSRR
-                     YDVGTEEMTSRALSIYNELKNKNTEK"
-                     /locus_tag="O5_05_wbdD"
-     gene            6105..9746
-                     /gene="wbdA"
-     CDS             6105..9746
-                     /gene="wbdA"
-                     /EC_number="2.4.1.246"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237531.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="mannosyltransferase A"
-                     /protein_id="CZQ25335.1"
-                     /db_xref="GI:1036211129"
-                     /translation="MRIVIDLQGAQTESRFRGIGRYSIAIARAIIRNNNRHEVFIALSA
-                     MLGESITDVKAQFADLLPADNIVVWHAAGPVRAMDKGNEWRRESAELIREAFLESLRPD
-                     VVFITSLFEGHVDDAATSVHKFSRQYKVAVLHHDLIPLVQAETYLLDDVFKSYYLQKVE
-                     WLKNADLLLTNSAYTAQEAIEHLHLQGDHVQNIAAAADPQFCMAEVTASEKESVLGHYG
-                     IQREFVLYAPGGFDSRKNFKRLIEAYAGLSDALRRSHQLVIVSKLSIGDRQYLESLASG
-                     NGLQQGELVLTGYVPENELIQLYRLCKLFIFASLHEGFGLPVLEAMSCGAPAIGSNVTS
-                     IPEVIGNPEALFDPYSVSSIREKIAQCLNDAPFLARLKEMAQQQARNFSWDNAAVTALE
-                     AFEKIATEDAGTVQVLPEALIQRILAISHCQPDERDLRLCATAIDYNLKTAELYQIDDK
-                     ALTWRVEGPFDSSYSLALVNREFARALSADGVEVLLHSTEGPGDFAPDASFMAQPENSD
-                     LLAFYNQCRTRKSNEKIDILSRNIYPPRVADMDAKVKLLHCYAWEETGFPQPWINEFNR
-                     ELDGVLCTSEHVRKVLIDNGLNVPAFVVGNGCDHWLTTAAETAKDVDEGTFRFLHVSSC
-                     FPRKGVQAMLQAWGRAFTRRDNVILIIKTFNNPHNEIDAWLAHAQAQFADYPKVEIIKE
-                     DMSASRLKGLYESCDVLVAPGCAEGFGLPIAEAMLSGLPAIVTNWSGQLDFVNSQNSWL
-                     VNYQFTRVKTHFGLFASTWASVDIDNLTDALKAAASTDKSVLRDMADAGRELILQQFTW
-                     KAVADRSRQAVKTLRAHIDIAQHRARIGWLTTWNTKCGIATYSQHLLESAPHGADVVFA
-                     PQVSAGDLVCADEEFVLRNWIVGKENNYLENLQPQIDALRLDVIVIQFNYGFFNHRELS
-                     AFIRRQHDAGRAVVMTMHSTVDPLEKEPTWNFRLAEMADALALCDRLLVHSIADMNRLK
-                     DLGLTDNVALFPHGVINYAAGSAARQQQALPLIASYGFCLPHKGLMELVESVHRLKQAG
-                     KPVRLRLVNAEYPVGESRDLVAELKAAAQRLGVNDLIEMHNDFLPDAESLRLLSEADLL
-                     IFAYQNTGESASGAVRYGMATQKPVAVTPLAIFDDLDDAVFKFDGCSVDDISQGIDRIL
-                     HSIREQDAWATRTQQRADAWREQHDYYAVSRRLVNMCQGLAKAKYFK"
-                     /locus_tag="O5_06_wbdA"
-     gene            9802..10959
-                     /gene="wbdB"
-     CDS             9802..10959
-                     /gene="wbdB"
-                     /EC_number="2.4.1.250"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237532.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="mannosyltransferase B"
-                     /protein_id="CZQ25336.1"
-                     /db_xref="GI:1036211130"
-                     /translation="MSFIMKIIFATEPIKYPLTGIGRYSLELVKRLAVAREIEELKLFH
-                     GASFIDQIPQVENKSDTKASNHGRLSAFLRRQPLLIEAYRLLHPRRQAWALRDYKDYIY
-                     HGPNFYLPHRLERAVTTFHDISIFTCPEYHPKDRVRYMEKSLHESLDSAKLILTVSDFS
-                     RSEIIRLFNYPADRIVTTKLACSSDYIPRSPAECLPVLQKYQLAWQGYALYIGTMEPRK
-                     NIRGLLQAYQLLPMETRMRYPLILSGYRGWEDDVLWQLVERGTREGWIRYLGYVPDEDL
-                     PYLYAAARTFVYPSFYEGFGLPILEAMSCGVPVVCSNVTSLPEVVGDAGLVADPNDVDA
-                     ISVHILQSLQDDSWREIATARGLAQAKQFSWENCTTQTINAYKLL"
-                     /locus_tag="O5_07_wbdB"
-     gene            10969..12084
-                     /gene="wbdC"
-     CDS             10969..12084
-                     /gene="wbdC"
-                     /EC_number="2.4.1.11"
-                     /inference="ab initio prediction:Prodigal:2.60"
-                     /inference="similar to AA sequence:RefSeq:YP_002237533.1"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="glycosyl transferase family protein"
-                     /protein_id="CZQ25337.1"
-                     /db_xref="GI:1036211131"
-                     /translation="MRVLHVYKTYYPDTYGGIEQVIYQLSQGCARRGIAADVFTFSPDK
-                     ETGPVAYEDHRVIYNKQLFEIASTPFSLKALKRFKQIKDDYDIINYHFPFPFMDMLHLS
-                     ARPDARTVVTYHSDIVKQKRLMKLYQPLQERFLASVDCIVASSPNYVASSQTLKKYQDK
-                     TVVIPFGLEQHDVQHDPQRVAHWRETVGDNFFLFVGAFRYYKGLHILLDAAERSRLPVV
-                     IVGGGPLEAEVRREAQQRGLSNVVFTGMLNDEDKYILFQLCRGVVFPSHLRSEAFGITL
-                     LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPNDSQALVEAMNELWHNDETASRYGE
-                     NSRRRFEEMFTADHMIDAYVNLYTTLLESKS"
-                     /locus_tag="O5_08_wbdC"
-ORIGIN
-        1 atgttacttc ctgtaattat ggctggtggt accggcagtc gtctctggcc gatgtctcgc
-       61 gagctttacc cgaaacagtt cctccggctg tacgggcaga actccatgct gcaggaaacc
-      121 atcacccgac tctcgggcct tgaaatccat gaaccgatgg tcatctgtaa cgaagagcac
-      181 cgcttcctgg tggccgaaca gctgcgtcag ctcaacaagc tgtcgaacaa cattattctt
-      241 gagccggtcg ggcgcaacac cgccccggcc atcgccctgg cggccctcca ggccacccgt
-      301 cacggcgacg acccgctgat gctggtcctc gccgccgacc atatcatcaa taaccagccg
-      361 gtcttccacg acgccatccg cgtcgccgag cagtacgccg atgaaggcca tctggtcacc
-      421 tttggtatcg tgccgaacgc cccggaaacc ggctacggtt acatccagcg cggcgtggcc
-      481 ctcaccgaca gcgcccacac cccgtaccag gtggcccgct tcgtggagaa gccggaccgc
-      541 gagcgcgccg aggcctacct cgcctccggg gagtactact ggaacagcgg catgtttatg
-      601 ttccgcgcca aaaaatacct ctccgagctg gccaaattcc gcccggatat cctcgaagcc
-      661 tgccaggccg cggtcaatgc cgccgacaac ggcagcgact tcatcagcat tccgcatgac
-      721 attttctgcg agtgcccgga cgagtccgtg gactacgcgg tgatggagaa aaccgccgac
-      781 gcggtggtgg tcggtctcga tgccgactgg agcgacgtcg gctcctggtc cgccctgtgg
-      841 gaggtcagcc cgaaagacga gcagggtaac gtcctcagcg gtgacgcgtg ggtgcatgac
-      901 agcgaaaact gctacatcaa cagcgacgag aagctggtgg cggccattgg cgtggagaac
-      961 ctggtgattg tcagcaccaa ggacgccgtg ctggtgatga accgcgagcg ttcccaggac
-     1021 gtgaagaagg cggtcgagtt cctcaagcag aaccagcgca gcgagtacaa gcgccaccgc
-     1081 gagatttacc gtccctgggg ccgctgcgac gtggtggtcc agaccccgcg cttcaacgtc
-     1141 aaccgtatca ccgtgaaacc gggcggcgcc ttctcgatgc agatgcacca ccaccgcgcc
-     1201 gagcactggg tcattctcgc cggcaccggt caggtgacgg tcaacggcaa gcagttcctg
-     1261 ctgaccgaga accagtccac ctttattccg attggcgccg agcacagcct ggaaaacccg
-     1321 ggccgcattc cgctggaagt gctggagatc cagtcggggt cgtacctcgg cgaggacgac
-     1381 attattcgta ttaaagacca gtatggtcgt tgctaatttt ttcgggacaa aacgcagaat
-     1441 gacacagtta acatgcttta aggcttatga catccgtggt gaactgggcg aggagctgaa
-     1501 cgaggacatc gcctaccgta tcggccgcgc ctacggcgaa tttctgaaac ccgggaagat
-     1561 agtggtgggg ggcgatgtgc gcctcaccag cgagtcgctg aagctggcgc tggcccgcgg
-     1621 gctgatggac gccggcaccg acgtgctgga tatcggcctg agcggcacgg aagagattta
-     1681 cttcgccacc ttccacctcg gggtggacgg cggcatcgag gtgacggcga gccataaccc
-     1741 gatgaactac aacggcatga agctggtgcg cgagaacgcg aagcccatca gcggcgacac
-     1801 cggcctgcgg gatatccagc gcctggcgga ggagaaccag ttcccgccgg tggacccggc
-     1861 gcgtcgcgga accctgcgtc agatttcggt gctgaaggag tacgtcgacc acctgatggg
-     1921 ctacgtggac ctggcgaact tcacccgtcc gctgaagctg gtggtgaact ccggcaacgg
-     1981 ggcggcgggg cacgtgattg atgaggtgga gaaacgcttc gcggcggccg gggcgccggt
-     2041 gacctttatc aaggtgcatc accagccgga cggccatttc ccgaacggta tcccgaaccc
-     2101 gctgctgccg gagtgccgtc aggacaccgc cgatgcggtg cgtgcgcatc aggcggacat
-     2161 gggtatcgcc tttgacggcg acttcgaccg ctgcttcctg ttcgatggcg aggcgtcgtt
-     2221 tatcgagggg tactacattg tcggcctgct ggcggaagcg ttcctgcaga agcagccggg
-     2281 ggcgaaaatc attcacgacc cgcgcctgac gtggaacacg gtggacatcg tgacccgcag
-     2341 cggcggccag ccggtgatgt cgaagacggg gcatgcgttc atcaaggagc ggatgcgcca
-     2401 ggaagacgcc atctacggcg gggagatgag cgcgcaccat tacttccgcg acttcgccta
-     2461 ctgcgacagc gggatgatcc cgtggctgct ggtggcggag ctgctgtgcc tgaagaacag
-     2521 ttcgctgaaa tcgctggtgg cggaccgcca ggcggcgttc ccggcgtcgg gggagatcaa
-     2581 ccgcaagctg ggaaatgcgg cggaggcgat agcgcgcatc cgggcgcagt atgagccggc
-     2641 ggccgcacac atcgacacaa cggacggtat cagtattgaa taccctgagt ggcgctttaa
-     2701 cctgcgcacg tccaataccg agccggtggt gcgtctgaac gtggagtcca gagcggatac
-     2761 tgcgttaatg aatgagaaaa cgaccgagct gttacacctg ttaagcgggg aataaggtga
-     2821 gagatttact aacgacgatt tatcgttatc ggggatttat ctggagcagt gttaagcgtg
-     2881 attttcaggc acgctatcaa accagtatgc tgggcgcgtt atggctcgtt ttacaaccgc
-     2941 tctctatgat cttggtctat accctggtct tttccgaggt gatgaaggcc agaatgcccg
-     3001 acaacaccgg gccgtttgcc tacagtattt atctctgttc tggggtactg acctggggat
-     3061 tgtttacaga gatgctggat aaaggtcaga gcgtattcat caataatgct aatctgatca
-     3121 agaaactaag ttttccgaaa atttgtctgc cgatcatcgt gacgttatca gcagtgctta
-     3181 atttcgcgat tatcttcagc ctgtttctga tttttatcat tgtcactggt aacttccctg
-     3241 gctggctgtt tttctcggtg ataccggttc tgcttttgca gatccttttt gccggtgggc
-     3301 tgggtatgat cctcggtgtg atgaacgtct ttttccggga tgtggggcaa ctggttgggg
-     3361 ttgcactgca attttggttt tggttcactc ccattgttta cgtactgaat tcattaccag
-     3421 catgggcgaa aaatctgctg ctttataatc cgatgactcg aatcatgcaa tcttatcagt
-     3481 ccatcttcgc ctaccatcag gcgcccaact ggtattcgct atggccagta ttggctctcg
-     3541 ccattatttt ctgcgtcatc ggtttcagga tgttccgcaa gcatgcggcg gatatggtgg
-     3601 atgaattata atgagttata tcagagtaaa aaatgtcggt aaggcatatc gccagtatca
-     3661 ctcaaaaact gggcgactga tcgaatggtt atcccctctg aatacaaaac gccataatct
-     3721 taaatggatc ctcagcgaca ttaatttcga agttgctccg ggagaggcgg ttggtattat
-     3781 cggtatcaac ggtgcgggca agagtaccct acttaaactt attaccggta cgtccaggcc
-     3841 aacgaccgga gagattgaaa tctcaggccg tgtcgctgcc ttactcgaac tgggtatggg
-     3901 gtttcattct gatttcactg gccgacagaa cgtttatatg tcagggcaac tgctggggtt
-     3961 atcctctgag aaaattactg agttgatgcc gcaaatcgaa gagtttgcgg agatcgggga
-     4021 ttatatcgac cagccggtgc gcgtctattc cagtggtatg caggttcgat tagcttttag
-     4081 cgtagcgacc gctatccgtc ctgatgtgct gattattgat gaagcgttat ccgttgggga
-     4141 tgcctatttc cagcataaaa gtttcgaacg tatccgtaaa ttccgtctgg aaggaaccac
-     4201 gttgctgctg gtatctcatg ataaacaggc gatccagagc atttgcgacc gggctatttt
-     4261 gttgaacaaa ggccacattg agatggaagg cgagcctgaa gcggtgatgg attattacaa
-     4321 tgcgcttctt gccgataagc aaaatcagtc cattaaacaa gttgagcaca acggtaaaac
-     4381 gcaaactgtt tcaggcactg gtgaagtgac aatctctgag gttcatcttc tcgatgaaca
-     4441 gggcaatgtg actgaatttg cctcggtagg gcatcggatc agcttgcagg ttaatgttga
-     4501 ggttaaggct gatatccctg agctcgtcgt cggttatatg atcaaggatc gacttgggca
-     4561 accgattttc gggaccaata cgcatcatct caaacaaaca ctcaccagcc tgaaaaaagg
-     4621 cgaaaagcgt tcgtttttat tctcttttga tgcgaggttg ggggttggct cctattctgt
-     4681 cgctgtcgcg ttgcatactt ccagtacgca tctcggcaaa aactatgaat ggcgcgatct
-     4741 ggccgtggta ttcaacgtcg ttaacacgga acaacaagag tttgtcggcg tgtcctggtt
-     4801 gccacctgaa ctggagattt cttaatgggt tcgtcgtttt atcgttcatt tgaagaacga
-     4861 cacagaggtt cggttgaaga tatcaagaac cgcctgagtt tttatttacc tttcttgtct
-     4921 cgtctgaagg atctttatcc cgaaggcgtg attgcggata ttggctgtgg acgtggtgaa
-     4981 tggctggaaa tcctgactga aaatggtatt gcgaacatcg gcgtcgatct cgatgatggc
-     5041 atgctggcac gtgccaagga agccgggctg aacgtgcaga aaatggattg tctgcagttt
-     5101 ctgcaaaatc aagcagacca gagtctgata gcgttgactg gtttccatat tgctgagcat
-     5161 ttgccctttg aggtattgca gcagctcgtc atgcatacct tacgggtgct gaaacctggc
-     5221 ggtttgctaa tcctcgaaac gccgaacccg gagaatgtaa gcgtcgggac ctgttcattt
-     5281 tatatggatc caacgcataa tcaccctttg ccgccgccat tgcttgagtt tttacctatt
-     5341 cattatggtt ttaaccgggc aattaccgtt cgtctacagg aaaaagaggc tctcaaatcc
-     5401 ccggacgcag cggttaatct ggtcgatgtg cttaaaggtg ttagccccga ttacagcatc
-     5461 attgctcaga aagcagcgcc tgcagatgtt cttgaacgct ttgaaaccct gtttacccaa
-     5521 caatatggcc tgacgctgga tgtcctgagc aaccgttacg atgcaatttt acgccaacag
-     5581 ttctcatcct ttgcctcaca gctggagacg ttaaaccaga catatacgcg ccagctaagc
-     5641 aaaatggcag agaatattca gacgttgcaa ggccaggttg acgaactaaa tcatgtcatt
-     5701 ggtcagaaca atcagcttca tcagcaagtg gcagatttgc ataacagccg ttcatggcgt
-     5761 atcactcaac ctctacgctg gctgtctttg caacgccaat tactgcgtca ggaaggggct
-     5821 aaagtacgag cccgtcgggc ggcgaaaaaa atattgcgca aagggatggc gctctcgctg
-     5881 gtctttttcc atcgttatcc taagtcaaag gtttatctgt ttaaatttct aagaaaaacc
-     5941 ggctgctaca cattgctaca gcgtttgttc cagcgcgtaa tgctggtgca atctgacacg
-     6001 atgatgatgc agtccagaag atatgatgtg ggtactgaag aaatgacaag tcgcgcgttg
-     6061 agtatttata acgaattaaa aaataaaaat acggagaaat aacgatgcgt attgtcattg
-     6121 atttacaagg cgcgcagacg gaaagccgct ttcgtggcat tggtcgttat agtattgcta
-     6181 tcgccagagc gattattaga aataacaatc gacatgaggt tttcatcgcg ctatccgcta
-     6241 tgctgggtga gtcgattact gatgttaagg cgcaatttgc tgatctcctg ccagcagaca
-     6301 acatagtcgt ctggcatgct gcaggaccag tacgtgcaat ggataaaggt aatgaatggc
-     6361 gtcgggagag cgcagaactg attcgggaag cgtttcttga atcattgcgt ccggatgtcg
-     6421 ttttcattac aagcttgttt gaaggtcatg tcgacgatgc ggccacttcg gtacacaaat
-     6481 ttagtcgtca gtacaaagta gccgtactgc atcacgatct tattcccctg gtgcaggctg
-     6541 agacctatct gctggatgat gtattcaaat cctattattt acagaaagtg gaatggttaa
-     6601 aaaacgctga ccttctgcta actaactccg cttatacggc acaggaagcg attgagcatc
-     6661 tgcatttgca gggcgaccat gtgcagaata ttgcagctgc agccgatcct cagttttgta
-     6721 tggcggaagt gacagcgagc gagaaagagt ccgtccttgg ccattacggt attcagcgcg
-     6781 agtttgtgct gtatgcacca ggtggatttg actccaggaa aaactttaag cgattgattg
-     6841 aggcgtatgc aggactcagt gatgctctac gtcgcagcca tcaattggtt atcgttagta
-     6901 agctgtccat tggggatcgt cagtatctgg aatccctggc gtcaggtaat gggttgcagc
-     6961 agggtgaact ggttctgact ggctacgtgc cggaaaatga gctgattcaa ctctatcgtc
-     7021 tgtgtaagct tttcatcttt gcttcgctgc atgaaggctt tgggctgcct gttctggaag
-     7081 caatgtcgtg cggcgcaccg gccattggct caaatgtcac cagtattcct gaagtcatcg
-     7141 gtaatcctga ggcattattc gacccgtatt ctgtctcttc cattcgggaa aagatcgcgc
-     7201 aatgtctgaa tgatgctcca ttcctggcgc gcctgaagga aatggctcag cagcaagcac
-     7261 gtaatttctc ctgggacaac gctgccgtga cggctctgga agctttcgag aagattgcga
-     7321 cagaagacgc cggcaccgtg caggtcttgc ctgaggcact gattcagcgg atccttgcta
-     7381 tctctcactg tcagccagat gagcgcgatc tgcgtttgtg cgcaacggcc atcgattaca
-     7441 atctgaagac ggctgagctg tatcaaattg atgataaagc gctgacctgg cgtgtggaag
-     7501 gtcccttcga tagctcatat agtctggcgc tggtgaatcg ggagtttgcc cgggcactct
-     7561 cagccgatgg tgtagaagta ctattgcact ccactgaagg gccgggcgat tttgcgccgg
-     7621 atgcctcgtt tatggcacag ccggaaaata gcgatcttct ggcattttat aatcaatgtc
-     7681 gtacccgcaa gagtaacgaa aagatagata ttcttagcag aaatatctat ccaccgcggg
-     7741 ttgccgatat ggatgccaaa gtaaaactcc ttcattgcta tgcctgggaa gaaacgggtt
-     7801 ttccacagcc gtggattaat gaatttaacc gggaacttga cggcgtgctg tgtacttcag
-     7861 aacatgtccg taaggtattg attgacaacg gcttgaatgt gcctgcattt gttgtaggca
-     7921 acggctgcga tcattggctc accacagcag ctgaaacggc aaaagatgtg gatgagggaa
-     7981 ccttccgttt cctgcatgtc tcttcctgct tcccacgaaa aggggtgcag gcaatgcttc
-     8041 aggcttgggg cagggcgttc actcgtcgtg acaatgttat cttgatcatt aagactttta
-     8101 acaatccaca caatgaaatt gacgcgtggc tggcacacgc ccaggctcaa ttcgcggact
-     8161 accccaaagt tgaaataatc aaagaggata tgtcagccag ccggcttaaa gggctttatg
-     8221 aaagctgcga tgttctggtt gctccaggtt gcgccgaagg ctttggttta cctatcgctg
-     8281 aagcaatgct gagtgggctt ccagccatcg tcactaactg gagcggtcaa ctagattttg
-     8341 ttaattcaca aaattcatgg ctggttaact atcagtttac ccgggtaaaa acacactttg
-     8401 gtctgtttgc ctcgacatgg gccagtgtgg acattgacaa cttaacggat gcgttaaaag
-     8461 ctgcagcctc gacggataaa tcagtgctgc gtgacatggc tgatgctggt cgcgagctta
-     8521 ttctgcagca gtttacctgg aaagcggtgg ctgatcgttc tcgtcaggca gttaagacgc
-     8581 tgcgtgcgca tattgatatt gctcagcatc gggcgcgaat tggctggttg acgacctgga
-     8641 acacgaaatg tgggatcgca acctattctc agcatttgct ggagagcgca ccgcatggcg
-     8701 cggatgttgt ttttgctccc caggtcagcg ctggagatct tgtgtgtgca gacgaagagt
-     8761 ttgtactgcg caactggatt gtgggtaaag aaaataacta tcttgaaaat ctccagccac
-     8821 aaattgatgc tctgcgactt gatgtcatcg tgatccagtt taactatgga ttctttaatc
-     8881 atcgcgaact gtcggcgttt attcgtcgcc agcatgacgc cggtcgagcg gttgtcatga
-     8941 cgatgcattc aactgtggat ccgctggaaa aagagccgac ctggaatttc cgccttgccg
-     9001 aaatggcgga tgcgctggcg ctttgtgacc gattgttggt gcattcaatt gccgatatga
-     9061 accgccttaa agatttaggc ttaaccgata atgttgcttt atttccgcat ggtgttatca
-     9121 actacgctgc tgggagcgcc gcgcgtcaac agcaggcttt accgttaatt gcgagctatg
-     9181 gcttctgctt accgcataag ggcctgatgg agctggtaga atccgtccat cgcctcaagc
-     9241 aggcggggaa accggttcgt ttgcgtctgg ttaacgcgga gtatccggtt ggagaatcac
-     9301 gcgatctggt ggcagaactt aaagcggcag ctcagcggct aggtgttaac gatctcattg
-     9361 agatgcataa tgatttcctg cctgatgcgg aaagtttgcg gctgctctca gaagctgatc
-     9421 tactgatttt tgcttaccag aatacgggtg agtcagctag cggagcggta cgttatggca
-     9481 tggcgaccca aaaacctgtt gcggtaacac ccctggcgat atttgatgat ctggacgatg
-     9541 cggtctttaa atttgatgga tgcagcgtcg acgatatcag tcaggggatt gaccggatcc
-     9601 ttcattccat ccgtgaacag gacgcctggg ctaccaggac tcaacaacgt gccgatgcat
-     9661 ggcgtgaaca acatgattat tatgctgttt cacgccgcct ggttaatatg tgtcaaggct
-     9721 tagctaaagc taaatatttt aaataaaaat attccccctt gtattttttg cctttgaata
-     9781 caaggggagc tagatgatga tgtgtcattt attatgaaaa ttatttttgc tactgagcca
-     9841 attaaatacc cattaacggg catcggtcgg tattccctgg agctggttaa gcggctggcg
-     9901 gttgcccgtg aaatcgaaga actgaagctg tttcacggcg cgtcgtttat cgatcagatc
-     9961 ccccaggtgg agaataaaag cgataccaaa gccagcaatc atggtcgtct gtcggcgttt
-    10021 ctgcgccgcc agccgctgct gattgaggcg tatcgcctgc tgcatccgcg gcgccaggcg
-    10081 tgggcattgc gcgattacaa agactacatt taccatggtc ccaatttcta tctgccgcat
-    10141 cgcctggaac gcgccgtgac cacgtttcat gacatctcca tttttacctg cccggaatat
-    10201 catccaaaag atcgggttcg ctatatggag aagtccctgc acgagagcct ggattcggcg
-    10261 aagctgatcc tgaccgtctc cgacttctcg cgcagtgaaa tcatccgcct gttcaactat
-    10321 ccggcggatc ggatcgtcac caccaagctg gcctgcagca gcgactatat tccgcgcagc
-    10381 ccggcggagt gcctgccggt cctgcagaaa tatcagctgg cgtggcaggg gtatgcgtta
-    10441 tatatcggca ccatggagcc gcgtaaaaat atccgcggtc tgctgcaggc ctatcagctg
-    10501 ctgccgatgg agacccgcat gcgctacccg ctgatcctca gcggttatcg cggatgggaa
-    10561 gacgatgtgc tgtggcagtt agtcgagcgc ggtacgcgtg aagggtggat ccgttacctg
-    10621 ggctatgtcc cggatgaaga cctgccttat ctgtacgcgg cggccagaac ctttgtttat
-    10681 ccctccttct atgagggatt cggtttacct attcttgaag cgatgtcttg cggtgtgccg
-    10741 gtagtatgtt ccaatgtcac ttctttgcct gaggtggttg gcgatgccgg cctcgttgcc
-    10801 gatcctaatg atgtagacgc gattagtgtg catattttgc agagcctgca ggatgatagc
-    10861 tggcgggaaa tcgccaccgc gcgcggtctt gcccaggcga aacagttttc gtgggagaac
-    10921 tgtacgaccc agaccattaa cgcctataaa ttactctaag ggtgtcagtt gagagttcta
-    10981 cacgtctata agacctacta tcccgatacc tacggcggta ttgagcaggt catttatcag
-    11041 ctaagtcagg gctgcgcccg ccggggaatc gcagccgatg tttttacttt tagcccggac
-    11101 aaagagacag gtcctgtcgc ctacgaagac catcgggtca tttataataa gcagcttttt
-    11161 gaaattgcct ccacgccgtt ttcgttgaaa gcgttaaagc gttttaagca gattaaagat
-    11221 gattacgaca tcatcaacta ccattttccg tttccattca tggatatgtt gcatctctcg
-    11281 gcgcggcctg acgccagaac ggtggtgacc tatcactcgg atattgtgaa acaaaaacgg
-    11341 ttaatgaagt tgtaccagcc gctgcaggag cgattcctcg ccagcgtaga ctgcatcgtc
-    11401 gcctcgtcgc ccaactacgt ggcctccagc cagaccctga aaaaatatca ggataaaacc
-    11461 gtggtgatcc cgtttggtct ggagcagcat gacgtgcagc acgatccgca gcgggtggcg
-    11521 cactggcggg aaaccgtcgg cgataacttc ttcctcttcg ttggcgcttt ccgctactac
-    11581 aaagggctgc acattctgct ggatgccgcc gagcgtagcc ggctgccggt ggtgatcgtc
-    11641 gggggcgggc cgctggaggc ggaagtgcgt cgtgaagcgc agcagcgcgg gctgagcaat
-    11701 gtggtgttta ccggcatgct caacgacgaa gataaataca ttctcttcca gctctgccgg
-    11761 ggcgtggtct tcccctcgca tctgcgctcc gaggcgtttg gcattacgtt actggaaggc
-    11821 gcgcgcttcg ccaggccgct gatctcctgc gagatcggca ccgggacctc gttcattaac
-    11881 caggacaaag tgaatggctg tgtgatcccg ccgaatgaca gtcaggcgct ggtggaggcg
-    11941 atgaatgagc tctggcataa cgatgaaacc gccagccgct atggcgaaaa ctcgcgtcgt
-    12001 cgttttgaag agatgtttac tgccgaccat atgattgacg cttacgtcaa tctctacact
-    12061 acgctgctgg aaagcaaatc ctga
-//
-LOCUS       AB819963                9395 bp    DNA     linear   BCT 02-APR-2016
-DEFINITION  Klebsiella pneumoniae DNA, lipopolysaccharide biosynthesis gene
-            cluster, serotype: O8, complete sequence, strain: 889.
-ACCESSION   AB819963
-VERSION     AB819963.1
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1
-  AUTHORS   Fang,C.T., Shih,Y.J., Cheong,C.M. and Yi,W.C.
-  TITLE     Rapid and Accurate Determination of Lipopolysaccharide O-Antigen
-            Types in Klebsiella pneumoniae with a Novel PCR-Based O-Genotyping
-            Method
-  JOURNAL   J. Clin. Microbiol. 54 (3), 666-675 (2016)
-   PUBMED   26719438
-  REMARK    DOI:10.1128/JCM.02494-15
-REFERENCE   2
-  AUTHORS   Cheong,C.M., Lai,S.Y., Yi,W.C. and Fang,C.T.
-  TITLE     Complete nucleotide sequence of Klebsiella pneumoniae serotype O8
-            lipopolysaccharide biosynthesis gene cluster, Statens Serum Institut
-            (Denmark) serotype O8 reference strain
-  JOURNAL   Unpublished
-REFERENCE   3  (bases 1 to 9395)
-  AUTHORS   Cheong,C.M., Lai,S.Y., Yi,W.C. and Fang,C.T.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (07-MAY-2013) Contact:Chi-Tai Fang National Taiwan
-            University, Institute of Epidemiology and Preventive Medicine; R535,
-            17 Xu-Zhou Road, Taipei 100, Taiwan
-FEATURES             Location/Qualifiers
-     source          1..9395
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="889"
-                     /serotype="O8"
-                     /db_xref="taxon:573"
-                     /note="Statens Serum Institut Klebsiella pnuemoniae
-                     serotype O8 reference strains"
-                     /note="O locus: O1α,O2δ"
-                     /note="O type: O2δ"
-                     /note="original sequence manually trimmed"
-                     /note="Updated from O8 by Tom Stanton in Feb 2025"
-     gene            1..780
-                     /gene="wzm"
-     CDS             1..780
-                     /gene="wzm"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="lipopolysaccharide O-antigen ABC transport system
-                     transmembrane component"
-                     /protein_id="BAN20060.1"
-                     /translation="MSLKMKYNLGYLFDLLVVITNKDLKVRYKSSVFGYLWSIANPLLF
-                     AMIYYFIFKLVMRVQIPNYTLFLITGLFPWQWFASSATNSLFSFIANAQIIKKTVFPRS
-                     VIPLSNVMMEGLHFLCTIPVIIAFLFVYGMRPSLSWLWGIPIIAIGQVIFTFGISIIFS
-                     TLNLFFRDLERFVSLGIMLMFYCTPILYASDMIPEKFSWIITYNPLASMILSWRELFMN
-                     GVLNYEYISILYITGFILTIVGLAIFNKLKYRFAEIL"
-                     /locus_tag="O1α,O2δ_01_wzm"
-     gene            780..1520
-                     /gene="wzt"
-     CDS             780..1520
-                     /gene="wzt"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="lipopolysaccharide O-antigen ABC transport system
-                     ATP-binding component"
-                     /protein_id="BAN20061.1"
-                     /translation="MEPVINFSNVTKEYPLYHHIGSGIKDLVFHPKRAFQLLKGRKYLA
-                     IEDISFTVAKGEAVALIGRNGAGKSTSLGLVAGVIKPTKGSVTTHGRVASMLELGGGFH
-                     PELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGEFIDEPIRVYSSGMLAKLGFSV
-                     ISQVEPDILIIDEVLAVGDISFQAKCIKTIREFKKKGVTILFVSHNMSDVERICDRVVW
-                     IENHRLREIGSAERIIELYKQAMA"
-                     /locus_tag="O1α,O2δ_02_wzt"
-     gene            1534..3426
-                     /gene="wbbM"
-     CDS             1534..3426
-                     /gene="wbbM"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="putative glycosyltransferase"
-                     /protein_id="BAN20062.1"
-                     /translation="MNSIKIYTCHHKPSAFLDASIIQPLHVGKANSYNDIGCAGDDTGD
-                     NISFKNPFYCELTAHYWVWKNESLSDYVGFMHYRRHLNFSTQQDHAEDNWGVVNYPLIN
-                     PDYEAQFGLTDDAIRTCVEGSDLLLPKKWSVTSAGSKNNLDHYSKGEFLHIKDYKAALE
-                     VVEELYPEYKTAIQQFNNATDGYYTNMFVMRKDMFIDYSEWLFSILDRLEERISMDNYN
-                     AQEKRVIGHIAERLFNIYIIRCQQVSELNIKELQRTFVTSETYNGKLEPVFTTGTPIVI
-                     SFDNNYAVSGGALINSIVRHADKNKNYDIVVLENKVSNLNKKRLRHLVAGQSNISLRFF
-                     DVNVFTEISAVHTRAHFSASTYARLFIPQLFRSYDKVVFIDSDTVVKADLATLMDVDIG
-                     TNLVAAVKDIVMEGFVKFGAMSESDDGVMPAKEYLQKTLGMTNPDEYFQAGIIVFNVGQ
-                     MVKEDTFSLLMATLKAKKYWFLDQDIMNKVFFGRVKFLPLEWNVYHGNGNTDDFFPNLK
-                     FSTFMRFLQARSNPKMIHYAGENKPWNTDKVDFYDDFFENIAHTPWEQEVYYRQLPVTS
-                     VMHSHGAETQPAVLMQTKIKSALMPYVNKYAPVGSPRRNTLTKYYYKVRRSILG"
-                     /locus_tag="O1α,O2δ_03_wbbM"
-     gene            3445..4599
-                     /gene="glf"
-     CDS             3445..4599
-                     /gene="glf"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="UDP-galactopyranose mutase"
-                     /protein_id="BAN20063.1"
-                     /translation="MNNKNIMIVGAGFSGVVIARQLAEQGYTVKIIDRRDHIGGNSYDT
-                     RDPQTDVMVHVYGPHIFHTDNETVWNYVNQYAEMMPYVNRVKATVNGQVFSLPINLHTI
-                     NQFFAKTCSPDEARALISEKGDSSIVEPQTFEEQALRFIGKELYEAFFKGYTIKQWGME
-                     PSELPASILKRLPVRFNYDDNYFNHKFQGMPKLGYTRMIEAIADHENISIELQREFLPE
-                     EREDYAHVFYSGPLDAFYSYQYGRLGYRTLDFEKFTYQGDYQGCAVMNYCSIDVPYTRI
-                     TEHKYFSPWESHEGSVCYKEYSRACGENDIPYYPIRQMGEMALLEKYLSLAESEKNITF
-                     VGRLGTYRYLDMDVTIAEALKTADEFLSSVANQEEMPVFTVPVR"
-                     /locus_tag="O1α,O2δ_04_glf"
-     gene            4596..5489
-                     /gene="wbbN"
-     CDS             4596..5489
-                     /gene="wbbN"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="putative glycosyltransferase"
-                     /protein_id="BAN20064.1"
-                     /translation="MKCTALIVTFNRLDKLKKTVAETLKLDFSTVMIVNNGSTDGTPAW
-                     LDSITDSRVVVLNLPVNSGGAGGFKAGSQHICDAIDTDWVFFYDDDAFPASDILEKFFA
-                     LEKKECQVFTGLVKDLHGHPCAMNLPFRKVPSSFADTLRYIRTPQRFVPTIDESVMVET
-                     VSFVGMIISSKVLQEHIDHIHDELFIYFDDLYFGYALTLDGQKILYSPELIFHHDVSIQ
-                     GKIISPEWKVYYLCRNLILARKLFQEVKVFSNFSILIRLCKYLSILPWQRRKSSYLCFM
-                     YRGIVHGIRGISGKQH"
-                     /locus_tag="O1α,O2δ_05_wbbN"
-     gene            5502..6635
-                     /gene="wbbO"
-     CDS             5502..6635
-                     /gene="wbbO"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="putative galactosyltransferase"
-                     /protein_id="BAN20065.1"
-                     /translation="MKRLCYFINSDWYFDLHWTDRAIAARDAGYEIHIISHFVDSKITN
-                     KFKSLGFICHNVPLAAQSFNVFTFIRAFFDSRKIIKEIDPDLLHCITIKPCLIGGFFAK
-                     KTQRPVILSFVGLGRVFSENSGLIKLLRHFTIKAYKHIASNKRSMYMFEHDKDRRKIVD
-                     FLGIDIQKTIVIDGAGINPEIYKYSLEQKRDIPVVLFASRMLWSKGLGDLIEAKKILSK
-                     RNISFTLNVAGILVEHDKDAIPLDVIQRWHEEGAINWLGHSSNVFDLIEESNIVALPSV
-                     YSEGVPRILLEASSVGRACIAYDVGGCDSLIVDNDNGLIVKSNSVHELADKLGFLLDNP
-                     EARVEMGIKGRKRVQDKFSSVMIINKTLKTYHDVVEG"
-                     /locus_tag="O1α,O2δ_06_wbbO"
-     CDS             6759..8078
-                     /note="orf11"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="putative glycosyltransferase"
-                     /protein_id="BAN20066.1"
-                     /translation="MSDEANEIVVSVVIPVHNAAEYISDTLNSVLSQTLKKIEIVVIDD
-                     CSTDNTLEIIKDISRQDSRVQIISNVANLGGGGSRNVGLDIAVGKYIIFLDDDDYIESD
-                     MLEKMSAYAVETQVDVVVCRCQSFDLNSGVYAPMVESIRVDLLPPKTIFQPQDITTDFF
-                     RAFVWWPWDKLFRREAIISHGLRFQEIRTTNDLFFVCAFMLIARHISVLDEVLISHTIN
-                     RSGSLSATRADSHRCALIALIALQEFMQQKDLLDGRIKDYKNYAVVFLEWHLNTISGPA
-                     FSPLFDDVKAFIIELDASDDDFYDDFIAAAHQRIATLSADEYLFSLKDRVLKELEFSQA
-                     NNARLEQTIDILEQKNNQLGQELAAQQVAQHEEKQNFHDQLTKRDEHHRALQNRYDIQE
-                     REMFDQRAKLESLQQHNVNIIGSLSWRLTKPLRLIRRFFK"
-                     /locus_tag="O1α,O2δ_07"
-     CDS             8397..9395
-                     /note="orf12"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="putative acyltransferases"
-                     /protein_id="BAN20067.1"
-                     /translation="MVMLSHMFGSFMGWPAVRPFSGAYLCVVYFFIMSGFVLSYAHSSG
-                     SFIKYILTRLARLWPLHFFSTVLMVLIYYYNAHHGGYVSSPDVFSVSVILKNIAFLHGI
-                     YWHEFQLINEPSWSISIEFWASLLIPLIFVRLNTTLRGVIIIAAFAFLCNRHPSGIPPS
-                     MHTAMLSMLVGSFFYSISRTEYFSRIIKERFSAFFVTCAVIISMVGVYAMNHSRLDYFL
-                     FIAFVPMLFIDHLADDKIIKKIFTSDLFLFLGYISFPLYLLHELVIVSGFIFDPDNAWT
-                     SISIAALTSILISYVYARFIDYPLYKALKRLISKMSWPGAKKDYRGNLLNQ"
-                     /locus_tag="O1α,O2δ_08"
-ORIGIN
-        1 atgagtctaa aaatgaagta taatttaggg tatttgtttg atctgcttgt tgttataaca
-       61 aacaaagatt tgaaggtaag atataaaagc agcgtatttg gctatttgtg gtcaattgcc
-      121 aacccgcttc tttttgctat gatttattat ttcatcttta aacttgtgat gcgagttcag
-      181 atacccaatt atacactttt tctaattacc ggacttttcc cgtggcaatg gtttgctagt
-      241 tcggcaacta actcactttt ctcttttata gctaatgctc agattataaa aaagacggta
-      301 tttcctcgct cggttattcc tctaagtaat gtgatgatgg agggattaca ttttttatgt
-      361 accattcctg tgattattgc atttctgttc gtttacggca tgcgcccatc gctgtcgtgg
-      421 ctatggggta ttccaattat agctattggt caggttattt tcacgtttgg tatctcgata
-      481 attttctcaa cactcaatct gttttttcgc gatttagagc ggtttgttag tcttggtatc
-      541 atgttgatgt tttactgcac gccgattcta tatgcatcag acatgatccc ggagaaattt
-      601 agctggatta ttacttataa ccctctggcg agtatgatac ttagctggcg tgagctattc
-      661 atgaatgggg ttttaaacta tgaatatatc tccatactct atattacagg ctttatcctg
-      721 accatcgtcg gcttggccat ctttaataaa ttaaaatatc gatttgcaga gattttgtaa
-      781 tggaaccagt gatcaatttc agtaacgtta cgaaagaata tcctctttac catcatattg
-      841 gttcaggtat taaagactta gtctttcatc ccaagcgagc ttttcagctg cttaaaggga
-      901 ggaagtatct cgcgatcgag gatatctcat ttaccgtcgc caaaggtgag gcagttgcgc
-      961 tgattgggcg aaacggcgca ggtaaaagca cttcgttagg actagtcgct ggcgtaataa
-     1021 agccaacaaa aggctcggtg actactcatg gccgagttgc ttcgatgctg gaactcggcg
-     1081 gtggttttca tccagagtta acgggtcgtg aaaatattta tcttaatgcc acccttctcg
-     1141 ggctgcggcg gaaggaagtt cagcagcgga tggagcgtat tatcgagttc tccgagctgg
-     1201 gagagtttat tgatgaacca atccgtgtat attccagcgg gatgcttgct aagctcggat
-     1261 tctccgtcat tagtcaggtc gagcctgaca ttcttatcat cgatgaagta ctggccgttg
-     1321 gtgacatatc atttcaggcc aaatgtatta aaacgataag agaatttaag aagaaagggg
-     1381 tgacgatatt atttgtcagc cacaatatga gtgatgtaga aagaatttgt gaccgagttg
-     1441 tgtggattga aaaccatcgg cttcgggaaa tcggctctgc cgaaagaatc attgaacttt
-     1501 acaagcaagc gatggcttaa acctggtaat aatatgaata gcattaaaat ttatacctgt
-     1561 catcataaac cgagtgcatt tcttgatgcc tctattatcc aacctctgca tgtcggtaaa
-     1621 gcaaactctt ataatgatat tggctgtgca ggtgatgata ctggagataa tatctcgttt
-     1681 aaaaatccat tctactgtga gctgacggcc cattactggg tatggaaaaa tgaatctctt
-     1741 tccgattatg tcggcttcat gcattatcgt cgacatttaa atttctccac gcagcaggat
-     1801 catgcggaag ataactgggg ggtggtgaat tatccgctaa taaacccgga ctacgaggca
-     1861 cagtttggat taaccgatga cgctattcgt acatgcgttg aggggagtga tcttttacta
-     1921 cctaaaaaat ggtcggtaac atcggctggc agtaaaaata atctcgacca ctacagcaag
-     1981 ggtgagtttt tacatattaa agactacaag gctgcgctag aggttgttga agaactttat
-     2041 ccagaatata agacagcaat acagcagttt aataatgcca ctgatggtta ttatacaaac
-     2101 atgtttgtta tgcgcaaaga tatgttcatt gattactcag agtggttgtt tagcattctg
-     2161 gatcgtcttg aagaacgtat ctcaatggat aattacaatg cgcaagaaaa acgtgtgatt
-     2221 ggtcatatcg ctgagcgctt gtttaacatt tatattatca ggtgtcagca ggttagcgaa
-     2281 ttaaacataa aagagctgca gcgtaccttt gtgacaagtg aaacgtataa cgggaagctc
-     2341 gaacccgttt tcacaactgg cacaccaatt gtcattagtt ttgataataa ctatgcggta
-     2401 agtggcggcg ctttaattaa ttcaattgtc cggcatgcgg ataaaaataa aaactatgat
-     2461 atagttgttc tcgagaacaa agtcagtaat ttaaataaaa aacggctgcg ccatctcgtt
-     2521 gccggacaga gtaatatttc actacgtttt tttgatgtta atgttttcac cgaaattagc
-     2581 gctgttcata cccgcgcgca ttttagtgca tcgacatatg cgcgtttgtt tatacctcag
-     2641 ctgttccgca gctatgataa agttgtcttt attgattctg atacagtagt taaagccgat
-     2701 ctggcgacgc tgatggatgt cgatatcgga actaatctgg ttgctgctgt taaagatatc
-     2761 gtcatggaag ggtttgttaa gtttggcgcg atgtcagaat cggatgatgg tgtcatgcca
-     2821 gctaaagaat acctgcaaaa aaccctgggg atgactaatc cggatgagta cttccaggct
-     2881 gggattattg tttttaatgt aggccagatg gtaaaagaag acactttctc gttactcatg
-     2941 gcgacgctaa aagctaaaaa atactggttt ttagatcaag acattatgaa caaagtattc
-     3001 tttggtaggg ttaaattctt accgttagaa tggaacgtat atcacggcaa tggcaatacc
-     3061 gatgattttt tcccaaatct taaattttcg acattcatgc gatttttgca ggcaagatcc
-     3121 aaccctaaaa tgattcacta tgctggcgaa aataaaccat ggaataccga taaagtcgat
-     3181 ttctatgatg atttcttcga aaatattgcg cataccccct gggaacaaga agtctattac
-     3241 cgtcagctac ccgtgacgtc ggttatgcat agccatggtg ctgaaacaca gccggctgtt
-     3301 cttatgcaga ctaaaattaa aagcgctctg atgccttatg ttaacaaata tgctcctgtt
-     3361 ggttcgccaa gaagaaatac actgacaaaa tactactata aagtaagacg ctctattctt
-     3421 ggctaactta accggagaaa aaatatgaat aacaaaaata tcatgattgt aggcgccggt
-     3481 ttttcgggcg tagttattgc gaggcaactt gctgaacagg gttataccgt aaaaatcatc
-     3541 gatcgacgcg atcatatcgg cggcaactct tacgatacgc gagacccgca aactgacgtt
-     3601 atggtacatg tttacggccc ccatattttc catactgata atgaaaccgt atggaactat
-     3661 gtcaatcagt atgcggaaat gatgccctat gttaacagag tcaaggctac agttaacgga
-     3721 caggtttttt ccctgcctat taatctacac actattaatc agttctttgc taaaacgtgt
-     3781 tcacctgatg aagccagagc gttaatttcc gaaaagggcg atagctcgat tgtggaacca
-     3841 caaacctttg aagagcaagc cttgcgcttt atcggtaaag aattgtatga agcattcttt
-     3901 aaaggctaca ccataaaaca atgggggatg gagccttcgg agttaccggc ttcgatactt
-     3961 aagcgcctac cggttcgctt taattacgat gataactact tcaatcataa attccaggga
-     4021 atgccaaaac ttggctatac ccggatgatt gaggccatcg ccgatcatga gaacatcagt
-     4081 attgaactgc agcgtgagtt ccttcctgag gaacgtgaag attacgctca tgtcttctat
-     4141 agcggccctc ttgacgcctt ctattcgtac cagtacggtc ggttaggcta ccgcactctg
-     4201 gatttcgaaa aatttaccta tcaaggtgac tatcagggtt gcgctgtgat gaattattgc
-     4261 tccatcgatg tgccatatac acgcatcact gagcataagt atttttctcc atgggaaagc
-     4321 catgaaggtt cggtctgcta taaagaatac agtcgcgctt gcggcgagaa tgatattcct
-     4381 tattacccca ttcggcagat gggggagatg gctttactgg aaaaatatct ttctcttgcc
-     4441 gaaagtgaaa aaaatattac cttcgtcggt cggttaggta cctatcggta tcttgatatg
-     4501 gatgtaacca ttgcggaagc gctgaaaaca gccgatgagt ttttatcttc ggtggctaac
-     4561 caggaagaga tgccggtatt tacggttcct gtacgatgaa atgtaccgcg ttaattgtaa
-     4621 catttaaccg tcttgataaa ttaaagaaga cggtggcgga aacgctcaag ctcgattttt
-     4681 cgacagttat gattgttaat aatgggtcca cggatgggac ccccgcctgg cttgattcta
-     4741 ttaccgatag ccgtgtcgtt gtcttgaatc ttcctgttaa tagcggcgga gcgggggggt
-     4801 ttaaggcagg tagtcagcat atttgtgatg cgattgatac ggactgggtt ttcttttacg
-     4861 atgatgatgc ttttcctgcc agcgatatac tggaaaagtt ttttgctctt gaaaaaaagg
-     4921 aatgtcaggt ctttactggt ttagtcaaag atcttcacgg ccacccttgt gcaatgaatc
-     4981 ttcctttcag gaaagtacct tcatcttttg ctgatacttt acgttatatt cgcacccccc
-     5041 aacgctttgt tcctaccatt gacgagagtg tcatggttga gacagtttcg tttgttggca
-     5101 tgattattag cagcaaagta ttgcaagagc atattgatca catccatgat gaactgttta
-     5161 tctattttga tgatctttat tttggctatg cgttgacatt ggacggtcaa aaaatcctct
-     5221 attcaccaga actgattttt catcatgatg tcagtatcca ggggaaaatc atctctccgg
-     5281 aatggaaggt atattatctg tgccgaaatt taattttggc caggaaacta ttccaggaag
-     5341 taaaagtatt tagcaatttc tctatcctta tacgcctatg taaatattta tccatattgc
-     5401 catggcagcg cagaaaatca tcatatctgt gtttcatgta tcgtggaata gttcatggca
-     5461 tacggggaat tagcggtaag caacattaag tggatatagt aatgaagaga ctgtgttatt
-     5521 tcataaactc ggattggtat tttgatttgc attggaccga ccgagcaata gccgctcgtg
-     5581 atgctggtta tgagattcac atcattagtc attttgttga tagtaaaata accaataaat
-     5641 tcaaatcgtt agggtttatc tgtcataacg ttccgcttgc tgcccagtca ttcaacgtat
-     5701 ttacttttat tcgagcattc tttgattctc ggaaaataat taaagaaata gacccggatc
-     5761 tgctgcactg catcactata aaaccttgtc taattggcgg gttctttgcg aaaaaaacgc
-     5821 agcgtccagt tattttgagc tttgttggcc ttggtcgggt gttttcggaa aattccgggc
-     5881 ttattaaact actacggcat tttacaatta aagcatacaa acatattgcg agtaataaac
-     5941 gcagtatgta tatgtttgag catgataaag atagaaggaa aattgttgat tttctcggta
-     6001 ttgatatcca gaaaaccatt gtcattgatg gtgccggtat caacccggaa atatataaat
-     6061 attcgttgga acaaaagcga gatatccctg tagtgctgtt tgccagccgg atgctctgga
-     6121 gcaaagggtt gggcgaccta atcgaagcaa aaaaaatact gagcaaaagg aacattagct
-     6181 ttactttaaa cgttgccggt atactggttg agcatgataa ggatgccatt cctctcgatg
-     6241 taatacaacg ttggcatgaa gagggcgcaa tcaactggct ggggcatagc tcaaatgtat
-     6301 ttgatttgat cgaggaatcg aatattgtcg ctttgccgtc cgtatattcg gaaggcgttc
-     6361 ctcgcatctt gctggaggcg tcatcggtag ggcgggcctg tatagcttat gatgtgggtg
-     6421 gatgcgatag cctgatcgtt gataatgaca atggcttaat cgtgaaaagt aattcagttc
-     6481 acgaattagc ggataaactc gggtttttgt tggataatcc cgaggctcgt gtcgagatgg
-     6541 gtattaaagg aagaaagcgc gttcaggata aattttcaag cgtgatgatt atcaataaaa
-     6601 cattaaaaac atatcatgac gtggtagaag gatagtagtt aaacgcgtat cactgttagt
-     6661 tcatcttatt tctgataatt ataattattc aatttaattg tttgacggct ggtatcagct
-     6721 atcataattc tgagtatacg tgctgtaaag gtggttatat gtctgatgaa gcaaatgaaa
-     6781 ttgtcgtttc tgttgttatt cccgttcata atgcggcgga atatatctct gatacactaa
-     6841 attctgtatt atctcagaca ttaaaaaaaa ttgaaattgt tgtaattgat gactgttcta
-     6901 ctgataatac gctagaaatt atcaaagata tctctcgcca agattcgcgc gtacagatta
-     6961 ttagcaatgt agcgaatctc ggtggtggtg gttccagaaa cgttgggtta gatattgcgg
-     7021 ttggtaaata tatcatattt ctcgatgatg acgattatat cgagagtgat atgctggaga
-     7081 aaatgtcagc ctatgcagtt gaaacacagg tggatgtggt tgtttgccgc tgtcagtcat
-     7141 tcgacttaaa ttcaggcgta tatgctccaa tggtcgaatc aatacgtgta gatttgctac
-     7201 ctcccaagac cattttccag ccgcaagata tcacgactga tttcttccgg gcttttgtgt
-     7261 ggtggccatg ggataagcta ttccgccgtg aggcaattat ttcccatgga ctgcgttttc
-     7321 aggaaattcg cacaactaat gatttgtttt ttgtctgtgc ttttatgttg attgcgcgcc
-     7381 atatttcggt tttagatgaa gtcctaatct cgcatacgat caaccgcagt ggctcattat
-     7441 cggctaccag agccgactct caccgctgcg cgctgattgc gcttatcgct ttgcaagagt
-     7501 ttatgcagca aaaagacctg ctcgacggac gaattaaaga ctataaaaat tatgcagtgg
-     7561 tttttcttga atggcatttg aataccatat ccgggccagc tttttcgccg ctttttgacg
-     7621 atgtgaaagc ttttattatt gagcttgatg ccagtgacga tgatttttat gatgatttca
-     7681 ttgctgccgc gcatcagcgg atcgctacgt tgtcagcaga tgagtatctg ttttccctta
-     7741 aagatcgtgt gctgaaagaa ctcgaattct cgcaagcaaa caatgcccgc ctggagcaga
-     7801 caatcgacat tctggagcaa aaaaacaacc agcttgggca agaattggcc gctcaacagg
-     7861 ttgctcaaca tgaagaaaaa caaaattttc atgatcagtt aacaaaacgg gatgaacatc
-     7921 atcgcgctct acagaatcgt tatgatatac aagaacgtga aatgttcgac caaagagcaa
-     7981 aactggaatc gttgcagcaa cataatgtta atataattgg ctctttatca tggcgcctga
-     8041 ccaaaccgtt gagactaatt agacgttttt ttaaataaat ctttacttga ccttaaaaag
-     8101 gttgcggtta ttaaaattat tctatgcaat ttgttgttat cttttttctg tttagtgttt
-     8161 taatagattg aacgaataaa atagttaagc attccgcttt tgtgattatt gctgggggca
-     8221 gcatggtcac gatcgagttt aactaagtag ttgttcattt ttataattat atttttaaac
-     8281 aatggaaaaa ttattccatt tataaataaa aagattttgc tcattgaaac gtggggtgta
-     8341 atttgtctgt taatagattt gatgccattg atggcactcg tggcatcctc gcctgtatgg
-     8401 ttatgctgag ccatatgttc ggcagcttta tgggatggcc agcggtcagg ccctttagcg
-     8461 gggcctatct gtgcgtcgtg tactttttta ttatgagcgg gtttgtttta tcctacgcgc
-     8521 actcatcagg aagttttatt aaatatatcc ttacccggct tgcgcgatta tggccactgc
-     8581 actttttttc gacagtactg atggtcttga tttattatta caatgcccat cacggcggct
-     8641 atgtttcgag tccggatgtt ttttctgttt ctgttattct aaaaaatatt gcgtttctcc
-     8701 acggtattta ttggcatgaa tttcagctaa tcaacgaacc ctcgtggagt attagtatcg
-     8761 agttctgggc atcgctgctc attccactta tatttgtcag actaaatacg acgttacgcg
-     8821 gtgttataat cattgcagct tttgccttcc tgtgcaatag acatccatca ggaataccac
-     8881 catcaatgca tacagcaatg ttgtccatgc tggttggttc tttcttttac tctatttctc
-     8941 gaacagaata ttttagccgc attataaagg agcggttttc ggcgttcttt gttacctgtg
-     9001 ctgtaatcat cagtatggtg ggggtttatg ccatgaacca tagccgactt gattattttc
-     9061 tgtttattgc ctttgtccct atgctgttta tagatcatct ggcggatgat aaaattataa
-     9121 agaaaatatt cacctcagat ctttttcttt ttttagggta tatcagtttc cctctctatt
-     9181 tacttcatga gctggtaatt gtctctggat ttatttttga cccggataat gcctggacgt
-     9241 ctatctcgat tgcggcgctg acatcaattt taatttctta cgtatatgcg cgctttattg
-     9301 actacccgct gtacaaagcg ttaaaaaggc taatatcaaa aatgtcctgg ccaggtgcta
-     9361 aaaaagatta ccgtggtaat cttttaaatc aataa
-//
-LOCUS       O1α,O2γ                 9400 bp    DNA     linear   BCT 14-FEB-2018
-DEFINITION  Klebsiella pneumoniae strain CWK53 O2aeh O locus, complete sequence.
-ACCESSION   MG280710
-VERSION     MG280710.1
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1  (bases 1 to 10105)
-  AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
-            Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
-            Whitfield,C.
-  TITLE     Molecular basis for structural diversity in serogroup O2-antigen
-            polysaccharides in Klebsiella pneumoniae
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 10105)
-  AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
-            Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
-            Whitfield,C.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (27-OCT-2017) Dept of Molecular and Cellular Biology,
-            University of Guelph, 50 Stone Road, Guelph, Ontario N1G 2W1, Canada
-COMMENT     ##Assembly-Data-START##
-            Assembly Method       :: Velvet v. 1.2.10
-            Assembly Name :: Klebsiella pneumoniae CWK53 O-antigen biosynthesis
-            (rfb) gene cluster
-            Coverage              :: 100x
-            Sequencing Technology :: Illumina
-            ##Assembly-Data-END##
-FEATURES             Location/Qualifiers
-     source          1..9400
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="CWK53"
-                     /serotype="O2aeh"
-                     /db_xref="taxon:573"
-                     /note="Sequence edited to remove hisI gene, Kelly Wyres
-                     April 2021"
-                     /note="O locus: O1α,O2γ"
-                     /note="O type: O2γ"
-                     /note="Updated from O1/O2v3 by Tom Stanton in Feb 2025"
-     gene            1..768
-                     /gene="wzm"
-     CDS             1..768
-                     /gene="wzm"
-                     /note="lipopolysaccharide O-antigen export protein integral
-                     membrane component"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Wzm"
-                     /protein_id="AVA30565.1"
-                     /translation="MKYNIGYLFDLLVVITNKDLKVRYKSSVFGYLWSIANPLLFAMIY
-                     YFIFKLVMRVQIPNYTLFLITGLFPWQWFASSATNSLFSFIANAQIIKKTVFPRSVIPL
-                     SNVMMEGLHFLCTIPVIIAFLFVYGMSPSISWLWGIPIIAIGQVIFTFGISIIFSTLNL
-                     FFRDLERFVSLGIMLMFYCTPILYAADMIPEKFSWIITYNPLASMILSWRQLFMDGVLN
-                     YEYISILYVTGIILTIVGLSIFNKLKYRFAEIL"
-                     /locus_tag="O1α,O2γ_01_wzm"
-     misc_feature    1..>9400
-                     /note="rfb gene cluster"
-     gene            768..1508
-                     /gene="wzt"
-     CDS             768..1508
-                     /gene="wzt"
-                     /note="lipopolysaccharide O-antigen export protein
-                     nucleotide binding component"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Wzt"
-                     /protein_id="AVA30566.1"
-                     /translation="MEPVINFSHVTKEYPLYHHIGSGIKDLVFHPKRAFQLLKGRKYLA
-                     IEDISFTVGKGEAVALIGRNGAGKSTSLGLVAGVIKPTKGTVTTQGRVASMLELGGGFH
-                     PELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGDFIDEPIRVYSSGMLAKLGFSV
-                     ISQVEPDILIIDEVLAVGDISFQAKCIQTIKDFKSKGVTILFVSHNMSDVEKICDRVVW
-                     IEDHKLREIGSAERIIELYKQAMA"
-                     /locus_tag="O1α,O2γ_02_wzt"
-     gene            1523..3415
-                     /gene="wbbM"
-     CDS             1523..3415
-                     /gene="wbbM"
-                     /note="glycosyltransferase involved in lipopolysaccharide
-                     O-antigen biosynthesis"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="WbbM"
-                     /protein_id="AVA30567.1"
-                     /translation="MNSIKIYTCHHKPSAFLNASIIKPLHVGKANTYNDIGCEGEDSGD
-                     NISFKNPFYCELTAHYWVWKNEPLADYVGFMHYRRHLNFAEQQNHPEDNWGVVNYPLIN
-                     AEYESQFGLSDESISTCVDGYDLLLPKKWSVTSAGSKNNLDHYAKGEFLHIKDYQSALD
-                     VVEELYPEYKDAIQQFNNATDGYYTNMFVMRKDMFTDYSEWLFAILSNLEDRISMNNYN
-                     AQEKRVIGHIAERLFNIYIIKSQQDKQLKIKELQRTFVTAETFNGKLNPIFDESVPVVI
-                     SFDNNYALSGGALINSIVRHSDANRNYDIVVLENKVSHLNKQRLIKLVAGHNNISLRFF
-                     DVNSFTEMSDVHTRAHFSASTYARLFIPQLFREYKKVVFIDSDTVVKSDLATLLDVEIG
-                     TNLVAAVKDIVMEGFVKFGTMSESDDGIMPAGEYLKKTLGMTNPDEYFQAGIIVFNVEQ
-                     MVKENTFAQLMSALKAKKYWFLDQDIMNKVFFGRVKFLPLEWNVYHGNGNTDDFFPNLK
-                     FSTYMRFLEARRNPKMIHYAGENKPWNTEKVDFYDDFLENVLNTPWEKEIYYRQLPVAT
-                     VVPNQHTELQQTVLLQTKIKRALMPYVNKYAPVGSPRRNKLTKYYYKVRRSILG"
-                     /locus_tag="O1α,O2γ_03_wbbM"
-     gene            3434..4588
-                     /gene="glf"
-     CDS             3434..4588
-                     /gene="glf"
-                     /EC_number="5.4.99.9"
-                     /note="UDP-galactopyranose mutase"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="Glf"
-                     /protein_id="AVA30568.1"
-                     /translation="MKRNNILIVGAGFSGVVIARQLAEQGHKVKIIDQRDHIGGNSYDT
-                     RDPQTDVMVHVYGPHIFHTDNETVWNYVNRYAEMMPYVNRVKATVNGQVFSLPINLHTI
-                     NQFFAKTCSPDEARALISEKGDSSILEPKTFEEQALRFIGKELYEAFFKGYTIKQWGMQ
-                     PSELPASILKRLPVRFNYDDNYFNHKFQGMPKLGYTHMIEAIADHENITLQLQREFAAE
-                     NRESYDHVFYSGPLDAFYSYQHGRLGYRTLDFERFTWQGDYQGCAVMNYCSVDVPYTRI
-                     TEHKYFSPWESHEGSVCYKEYSRACGEDDIPYYPIRQMGEMALLDKYLSLAENEKNITF
-                     VGRLGTYRYLDMDVTIAEALKTADKYLSSLSNDEAMPVFVADVR"
-                     /locus_tag="O1α,O2γ_04_glf"
-     gene            4585..5475
-                     /gene="wbbN"
-     CDS             4585..5475
-                     /gene="wbbN"
-                     /note="putative glycosyltransferase involved in
-                     lipopolysaccharide O-antigen biosynthesis"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="WbbN"
-                     /protein_id="AVA30569.1"
-                     /translation="MKHTALIVTFNRLEKLKKTVAETVKLHFTSIVIVNNGSTDGTSDW
-                     LQTITDPRVIVLNLACNNGGAGGFKAGSQYICSSVDSDWVFFYDDDAYPQSDILDKFST
-                     INKEGCRVFTALVKDLQGRTCAMNVPFAKVPTSFSDTLQYIKHPQRYVPDNKEMLVQTV
-                     SFVGMIIKREVLNEHLHHIYDELFLYFDDLYFGYQLTLSGEKIIYNPELVFTHDVSIQG
-                     KVISPEWKVYYLCRNLILAKRIFTEVAVFSSSSILLRLCKYISIFPVQRRKWVYLKFLC
-                     RGIVHGVKGISGKFH"
-                     /locus_tag="O1α,O2γ_05_wbbN"
-     gene            5488..6621
-                     /gene="wbbO"
-     CDS             5488..6621
-                     /gene="wbbO"
-                     /note="glycosyltransferase involved in lipopolysaccharide
-                     O-antigen biosynthesis"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="WbbO"
-                     /protein_id="AVA30570.1"
-                     /translation="MKKLCYFINSDWYFDLHWTDRAIAARDAGYEIHIISHFVDDKIAI
-                     KFKTLGFICHNIPLVAQSFNVLIFFRAFFKARKIIQSINPDLLHCITIKPCLIGGFLAK
-                     STHRPVILSFVGLGRVFSAESGCLKLLRSFTVMAYKYIASNKCSLFMFEHDKDRAKLAD
-                     LVGIDYKQTIVIDGAGINPEIYKYSLEQQRDVPVVLFASRMLWSKGLGDLIEAKKILSN
-                     KNIHFTLNVAGILVENDKDAIPLATIQKWQSEGVINWLGHCSNVFDLIEESNIVALPSV
-                     YAEGVPRILLEASSVGRACIAYDVGGCDSLIINNDNGLIVKSKSVEELAEKLGFLLDNP
-                     ETRVAMGINGRKRIQDKFSSVMIINKTLKTYRDVVEE"
-                     /locus_tag="O1α,O2γ_06_wbbO"
-     CDS             6743..8047
-                     /note="Orf7"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="hypothetical protein"
-                     /protein_id="AVA30571.1"
-                     /translation="MSEKKSIAVSVIIPVHNAAGYISDTLSTVLSQTLNDIEIIIINDC
-                     SNDNTLEIVSALAETDSRIRVINNTTNLGGGGSRNVGLDAAIGEYVIFLDDDDYADNMM
-                     LERMYAQASDTQADVVICRSQSFDPSLQVYAPMPWSVRQELLPDLMVFSSQDIPSDFFR
-                     AFVWWPWDKLLRRQFIATHQLRFQEIRTTNDLFFVCAFMLMANRISVLNETLISHTINR
-                     SESLSATRAESHRCAVEALVALKAFICQQGMMDQRLRDYKNYVVVFLEWHLNTISGPAF
-                     HPFYQQVKEFIVALDAKDDDFYDEFIAAAHHRITTLSAEEYLFSLKDRVLKELEFFQAK
-                     SSALQQEVETLTDSFAEQKDENAILHNQLHEIEERVTEQEKNIRQLTDKNNNMHHEITI
-                     KQQEFNEIYQHHKNLISSLSWKLTKPLRVVRRFFK"
-                     /locus_tag="O1α,O2γ_07"
-     CDS             8381..9400
-                     /note="Orf8; involved in lipopolysaccharide O-antigen
-                     biosynthesis"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="putative acyltransferase"
-                     /protein_id="AVA30572.1"
-                     /translation="MGCRLSVNRFDAIDGTRGILAGMVMLSHMFGSFMGWPQVRPFSGA
-                     YLCVVYFFIMSGFVLTYAHASGNFFKYVLTRFARLWPLHFLSTILMVAIYYYNAHHGGY
-                     VSSPDVFSISVILKNILFLHGLYWHDFKLVNEPSWSISIEFWVSLLIPLIFTRLGNMTR
-                     AVVAGLLFIFLWHKHPSGIPPSMLTAMLSMLIGSLFFSLSQTEYFKCLMKEKFMAFFIT
-                     AAAIVSIVGVYAMNHSRLDYFLFVAFIPMLFIDHLPDNQLIKRVFTSNLFLFLGYISFP
-                     LYLLHELVIVSGFIFDPENAWVSISIAAFASIFIAYIYARFIDYPLYRALKRQIAKIS"
-                     /locus_tag="O1α,O2γ_08"
-ORIGIN
-        1 atgaagtata atataggata tttgtttgat cttcttgttg taataacaaa caaagatttg
-       61 aaagtacgtt ataaaagcag cgtatttggt tacttatggt caatcgcaaa tccactgctt
-      121 ttcgcaatga tatattattt cattttcaaa cttgttatgc gggtacagat accaaattat
-      181 acactctttt taattacggg tcttttccca tggcaatggt ttgcgagttc tgcgaccaac
-      241 tctctattct cgtttattgc taacgcacaa attattaaga agacagtatt ccctcgttca
-      301 gtaatcccat taagcaatgt gatgatggaa gggttacatt ttctctgtac tattcctgtc
-      361 attatcgcat ttttgtttgt ttatggtatg agtccatcaa tatcctggct gtgggggata
-      421 ccaataattg cgattgggca agttattttt acatttggta tttctataat cttttcaaca
-      481 ctcaatctct ttttccggga tctggagcgg tttgtgagtc ttggcatcat gctgatgttt
-      541 tattgcacgc caattttata tgcagcagat atgatcccgg agaagtttag ctggattatc
-      601 acctataatc ctcttgcaag tatgatcctc agctggcgcc agttattcat ggatggtgta
-      661 ttgaactatg agtatatctc aatactttat gttacaggta ttatcctgac catagtgggt
-      721 ctaagcatct ttaataaatt aaaatatcga tttgcagaga ttttgtaatg gaaccagtaa
-      781 taaattttag tcacgttacg aaagaatatc cactttatca tcatattggc tcaggaataa
-      841 aagacttagt atttcatcct aagcgtgctt tccagttact gaaagggcgg aaataccttg
-      901 ctatcgagga tatctctttt actgttggca agggggaagc ggttgcattg atcggacgta
-      961 atggcgcggg gaaaagtact tcattaggtt tggtggctgg tgttatcaag ccaacgaaag
-     1021 gtaccgttac gactcagggc cgggttgcat caatgctgga gctaggcggt gggttccatc
-     1081 cagaattgac tggtcgggaa aatatttatc tcaatgccac ccttcttgga ttacgacgta
-     1141 aagaagttca gcagcgtatg gaacgtatca ttgagttctc ggaattaggt gactttattg
-     1201 atgaacctat ccgtgtttac tcaagcggca tgcttgcaaa actggggttc tctgtcatca
-     1261 gccaggttga gcctgatatt cttatcattg atgaagtgct tgctgtgggc gatatctcat
-     1321 tccaggccaa gtgcattcag accatcaaag actttaaaag caaaggagtg acgatattat
-     1381 tcgtcagtca caatatgagt gatgttgaaa aaatctgtga cagagttgtt tggatcgaag
-     1441 accacaaact ccgcgaaatt ggctcagcag agagaatcat tgaactttac aagcaagcaa
-     1501 tggcttaata attggtaata agatgaatag tatcaaaatt tacacatgtc accacaaacc
-     1561 cagtgctttt ctaaacgcct ctattattaa accactgcat gtcgggaagg ctaatactta
-     1621 taatgatatt ggctgtgaag gggaggatag cggagacaac atttccttta aaaacccctt
-     1681 ttattgtgag ctgacggccc actactgggt gtggaagaat gaaccccttg ctgactatgt
-     1741 gggattcatg cattaccgca gacacttgaa ctttgcagaa caacaaaatc atcctgagga
-     1801 taactggggg gtggtcaact acccgctcat caatgccgaa tacgaaagcc agtttggatt
-     1861 aagtgatgaa tccataagca cctgcgtcga tggatatgat ctgctgttac ccaaaaaatg
-     1921 gtcggtaact tcggcaggaa gtaagaataa ccttgatcat tatgcaaagg gtgagttttt
-     1981 acacattaaa gactatcagt ctgctctgga tgtcgttgaa gagctgtatc cagaatataa
-     2041 agatgcgatt caacaattca ataatgcaac tgatggttat tatacgaaca tgtttgttat
-     2101 gcgcaaagac atgttcacgg attattctga atggcttttt gctattttgt ctaatcttga
-     2161 agatcggatt tcgatgaata actacaatgc tcaagaaaaa cgagttatag gacacattgc
-     2221 tgagcgttta ttcaatattt atatcatcaa aagccaacaa gataaacagc tgaaaataaa
-     2281 agaactacag cgtacgtttg tcactgctga aacatttaat ggcaaattaa atccgatttt
-     2341 tgacgaaagt gttccggttg ttatcagttt tgataataac tatgcattaa gtggcggggc
-     2401 attaataaat tcaattgttc gccattctga tgctaaccga aactatgata tcgttgttct
-     2461 ggaaaataag gtcagtcatt taaataaaca acgccttatc aagctagttg ctggtcataa
-     2521 caacatatca ctgcgctttt ttgatgtgaa ttcattcact gagatgagtg atgttcatac
-     2581 ccgtgcgcat tttagtgcgt cgacatatgc gcgcttgttc atcccgcaac ttttccgcga
-     2641 gtataaaaaa gttgtgttta tcgattctga taccgtggtg aagtctgatt tggcgacact
-     2701 tctggatgtt gagatcggca ctaacctggt tgccgctgtt aaagacatcg tcatggaagg
-     2761 atttgtgaag tttggtacga tgtcagaatc tgatgatggc attatgccag caggggaata
-     2821 cctgaaaaag acattaggaa tgactaaccc tgacgaatat tttcaggccg ggattattgt
-     2881 ttttaacgtc gaacaaatgg ttaaagagaa cacctttgcg caattgatgt cagcattgaa
-     2941 agccaaaaag tattggttct tagatcagga tatcatgaac aaagtcttct ttggccgagt
-     3001 caagttttta ccattagaat ggaatgtgta ccatggtaat ggtaataccg atgatttctt
-     3061 cccgaatctc aagttttcaa cctatatgcg gtttttggaa gccagaagaa atccaaaaat
-     3121 gattcactat gcgggtgaaa acaaaccatg gaatactgag aaagtcgatt tctatgatga
-     3181 ttttcttgaa aatgttttaa atacgccatg ggaaaaagaa atttactatc gccagttacc
-     3241 tgtggccacg gtagtaccta accaacatac tgaactgcag caaaccgtgt tactgcagac
-     3301 aaagattaaa cgagctttaa tgccatatgt taacaaatat gctcctgtcg gttcgccaag
-     3361 aagaaataag ctcactaaat attattataa agttcgtcgc tcgattcttg gctaatataa
-     3421 ctggagatac attatgaagc gtaacaatat tctcatcgtc ggcgctggtt tttcaggtgt
-     3481 ggtcattgcc cgccagcttg ctgaacaagg tcacaaggtt aaaatcatcg atcagcggga
-     3541 ccacattgga ggaaactctt atgacactcg cgatcctcag actgatgtca tggttcatgt
-     3601 ctacggtccg catattttcc atacggataa tgaaaccgtc tggaactatg tcaatcggta
-     3661 tgcggaaatg atgccctatg tgaatagagt aaaagctact gttaatggtc aggttttttc
-     3721 actgccgatt aatctgcata ctattaatca gttctttgct aaaacctgtt ctcctgatga
-     3781 agctcgcgcg ctcattagcg aaaaaggtga tagctcgatt ctggaaccga agacatttga
-     3841 agagcaggct ttgcgcttta ttggtaaaga attatatgaa gcgttcttca aaggctacac
-     3901 cataaaacag tgggggatgc agccttccga gcttccggca tctatactca aacggttgcc
-     3961 tgtgcgtttc aattatgacg ataactactt caatcataaa ttccagggca tgccgaagtt
-     4021 gggctatacc catatgattg aagcgatcgc cgatcatgaa aatatcactc tgcaattaca
-     4081 gcgtgagttt gcggctgaaa atcgtgaaag ttatgatcat gtgttttata gcgggccgtt
-     4141 agacgcgttc tattcatacc agcatgggcg tcttggctac cgtactctgg actttgagcg
-     4201 atttacctgg caaggtgatt atcagggctg cgcggtcatg aattattgct cagttgatgt
-     4261 cccgtatacg cgaattacgg aacataaata tttttccccg tgggaaagcc atgaaggttc
-     4321 cgtatgttat aaggaatata gtcgcgcttg cggtgaagat gatattcctt actatccaat
-     4381 ccgccagatg ggtgagatgg ctctgctgga taaatattta tcactggcgg agaatgagaa
-     4441 aaatattact ttcgttggac gcctggggac ttatcgctac cttgatatgg atgtaacgat
-     4501 tgcagaagca ttgaaaacgg ccgataaata tctgtcctca ttgtccaacg acgaagcgat
-     4561 gcctgtattt gtggccgacg tacgatgaaa catactgcat taatagtcac ttttaaccgt
-     4621 cttgaaaagc taaaaaagac ggttgctgaa actgttaagc tgcactttac ctctatcgtt
-     4681 attgtcaaca acgggtccac ggatgggacc tctgattggc ttcagacaat cactgatccc
-     4741 cgtgtaattg tcttgaatct ggcctgtaat aacggtggcg ccggagggtt taaggccggt
-     4801 agtcaataca tatgcagttc tgttgatagc gattgggtct tcttttatga cgatgatgct
-     4861 tatccgcaaa gtgatattct tgataagttc tcaacgataa ataaagaagg ttgtcgtgtt
-     4921 tttacggctt tagttaaaga tttgcagggc cggacatgcg cgatgaatgt tccatttgca
-     4981 aaagtcccga cctcgtttag tgatactttg caatatatca aacatcccca acgatatgta
-     5041 ccagataata aggaaatgct ggtgcaaaca gtttcatttg ttggcatgat cattaagcgt
-     5101 gaagtcttga atgagcacct tcatcatatt tatgatgaac ttttccttta ttttgatgac
-     5161 ctctattttg gttatcaatt aactctaagt ggtgagaaaa ttatctataa tccggaactt
-     5221 gtttttactc atgatgtgag tatccaggga aaggtcatat cgccagagtg gaaggtttac
-     5281 tatctttgtc gaaacttaat tttggctaag agaatattta cggaagtggc agtttttagt
-     5341 agttcatcaa tccttttgcg cctatgcaag tatatctcca tattccctgt acagcgccgg
-     5401 aaatgggtgt atctaaagtt tttatgccgt gggattgtac atggtgtaaa aggaattagc
-     5461 ggtaagtttc actaagtgga catagcaatg aaaaaactgt gttatttcat aaattcggat
-     5521 tggtattttg atttgcattg gaccgatcgt gcaattgccg cccgagatgc cggttatgag
-     5581 attcacatta ttagccattt tgtcgatgat aaaatagcga taaaattcaa aacactaggt
-     5641 tttatttgtc ataatattcc tcttgtcgct caatcgttca acgttttgat tttctttcgg
-     5701 gcctttttta aggctcggaa aattattcaa agcattaatc ctgatttatt acactgcatt
-     5761 accatcaaac cgtgtttgat cggcggattt ctggctaaaa gtacccatcg tcctgttatt
-     5821 ctgagttttg tcggtttagg ccgagtattt tcggcagagt ctggctgtct taagctgctg
-     5881 cgtagtttta ctgttatggc atataagtat atcgccagta acaaatgcag cttgtttatg
-     5941 ttcgaacatg ataaagacag agccaaactc gccgatctgg ttggtatcga ttacaaacag
-     6001 actattgtta ttgatggtgc gggtattaat ccagagattt acaaatattc tctggagcaa
-     6061 caacgtgatg tcccggtcgt cctttttgcc agccgtatgc tgtggagtaa aggacttggt
-     6121 gatctgattg aagccaaaaa aatactgagt aataaaaata ttcactttac gctgaatgtt
-     6181 gccggtatct tagttgagaa tgataaagac gcgattccgc tagcgacgat acagaagtgg
-     6241 caaagcgaag gcgtgattaa ctggctcggt cattgctcta atgtatttga tttaattgaa
-     6301 gaatcaaata tcgttgcttt gccgtcggtc tacgccgaag gcgtaccacg tatcttgctg
-     6361 gaagcttcct cggtcgggcg tgcttgtatc gcttatgatg ttggtggctg tgatagctta
-     6421 attatcaaca acgataatgg gttaattgta aaaagtaaat ctgttgagga attagcggag
-     6481 aaactcggtt tcctgttaga taatcctgaa acgcgagtcg caatgggtat caatggcaga
-     6541 aagcgtattc aagataaatt ctcgagtgtg atgatcatta ataaaacatt aaaaacatat
-     6601 cgcgatgttg ttgaagagta atttttgatg aagctgagtt gctttcatct tacctatcct
-     6661 taatgaactg gaaacctaca aattaaatgc taccaataaa taaatataat tgcgtttaga
-     6721 agctaagcgt caaggtgatt acatgtctga aaaaaagagt attgctgttt ctgttattat
-     6781 ccctgtgcac aatgctgctg gatatatttc cgatacatta agcaccgttt tgtcgcaaac
-     6841 attaaatgat atcgaaatca ttattatcaa tgattgttct aacgataata ccttagagat
-     6901 tgtctctgcg ctggctgaaa ctgattcacg gattagagtg attaacaaca cgacaaatct
-     6961 tggtggtgga ggttcgagaa acgttgggtt ggatgctgct atcggtgagt acgttatttt
-     7021 tctcgatgac gacgattacg ctgataacat gatgttggag cgcatgtacg cgcaggccag
-     7081 cgatacacaa gcggatgtcg ttatttgtcg cagccagtct tttgatccct ccttacaagt
-     7141 ttatgctccg atgccgtggt cagttcgcca ggagctgcta cctgatctta tggttttttc
-     7201 ctcccaggat attccctctg actttttccg cgcctttgtc tggtggccat gggacaagct
-     7261 tctcaggcgt caatttattg ctactcatca gcttcgtttt caggaaatca ggacaacaaa
-     7321 cgatcttttc ttcgtctgtg ccttcatgct gatggcgaac agaatctcgg tcttaaatga
-     7381 aacgttaatt tctcatacca tcaatcgtag tgaatcctta tccgccacga gagcagaatc
-     7441 gcaccgctgt gctgttgaag cattagtggc tcttaaagca tttatctgtc agcaggggat
-     7501 gatggatcaa cgtctcagag attacaaaaa ctatgttgtc gttttccttg agtggcattt
-     7561 aaacacgata tctggtccgg catttcatcc gttttatcag caagtgaaag agtttattgt
-     7621 tgcgttagat gcaaaggatg atgattttta tgatgaattt atcgccgccg cgcatcatag
-     7681 aatcaccacg ctgtcagctg aagagtacct attctccctt aaagatcgtg ttctgaagga
-     7741 gcttgagttt ttccaggcaa agagctccgc attacagcaa gaagttgaga cgctgactga
-     7801 ctcattcgct gagcaaaagg atgaaaatgc gatattacat aatcaattgc atgagattga
-     7861 agagcgggtt actgaacagg aaaagaatat tcgtcagtta actgacaaaa ataataatat
-     7921 gcatcatgaa ataactatca aacagcaaga attcaatgaa atttatcagc atcacaaaaa
-     7981 tttaatctct tctttatcct ggaagttgac taagccacta cgagtggtaa gacgtttttt
-     8041 taaataattt caaaaagaag ttaagcaagt ttcacttctt tgttagtgtt cttgttattt
-     8101 tcaataaaaa tttttcgtta aataaaagag ctcctggtca tatgatttgc gagtctctat
-     8161 tcctgttaga ttaataattt attagttaga gagtaatagg tttttgtcga gttttactgg
-     8221 gggcagtaat atctcgatgt gtgtacttgt gtttttttgt gacttcctgc cttttgaatt
-     8281 ttttctatcg ggcagtgatc acctttgaat attgatagct attcttttta ttactaataa
-     8341 attctttctt ctaaaagaat gtagttttac tcattggaat atggggtgta gattgtctgt
-     8401 taacagattt gatgccattg atggcactcg tgggatattg gcgggtatgg tcatgctcag
-     8461 ccatatgttt ggcagcttta tgggttggcc gcaagtcaga ccatttagcg gtgcctatct
-     8521 gtgcgtggta tattttttca tcatgagtgg ctttgttcta acctatgccc acgcctcagg
-     8581 aaactttttc aaatacgttc ttacacgttt tgccagatta tggccgcttc attttctgtc
-     8641 aacgatactg atggtagcca tttattacta caatgcacac catggcggct atgtttccag
-     8701 tccggatgtt ttttctatta gcgtgatatt aaaaaatata ttatttcttc atggtcttta
-     8761 ctggcatgac ttcaagttag tcaatgagcc atcatggagt atcagtattg agttttgggt
-     8821 gtcactttta attcctctaa tctttacgcg attaggaaat atgactcgtg cggtagttgc
-     8881 aggtttatta tttatttttc tgtggcataa acatccatca gggataccgc catcaatgct
-     8941 aacagcaatg ctgtcaatgc tgattggttc attgtttttt tctttatcac agacagagta
-     9001 ctttaagtgt ctgatgaaag aaaagttcat ggctttcttt attaccgcag cggctatcgt
-     9061 atcgatcgtt ggcgtatatg caatgaacca tagtcgactg gactattttt tattcgttgc
-     9121 gtttatcccg atgctattca tcgatcatct tccggataat caattgataa agagagtttt
-     9181 cacctctaat ttattcttgt ttctcggtta tattagcttc cctttgtatt tattgcatga
-     9241 actggttatc gtatccggat tcatttttga ccctgagaat gcctgggtat caatatcaat
-     9301 agcggcattt gcatcaatat tcattgccta tatttatgca cgatttatcg attatcctct
-     9361 ctatcgggcg ttaaagcgtc agattgccaa aataagttaa
-//
-LOCUS       gmlABD                  3354 bp    DNA     linear   BCT 14-FEB-2018
-DEFINITION  Klebsiella pneumoniae strain CWK53 gmlABD gene cluster complete
+LOCUS       MG602074                3913 bp    DNA     linear   BCT 14-FEB-2018
+DEFINITION  Klebsiella pneumoniae strain 5053 wbmVWX gene cluster, complete
             sequence.
-ACCESSION   MG458670
-VERSION     MG458670.1
-KEYWORDS    .
-SOURCE      Klebsiella pneumoniae
-  ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1  (bases 1 to 5075)
-  AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
-            Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
-            Whitfield,C.
-  TITLE     Molecular basis for structural diversity in serogroup O2-antigen
-            polysaccharides in Klebsiella pneumoniae
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 5075)
-  AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
-            Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
-            Whitfield,C.
-  TITLE     Direct Submission
-  JOURNAL   Submitted (30-OCT-2017) Dept of Molecular and Cellular Biology,
-            University of Guelph, 50 Stone Road, Guelph, Ontario N1G 2W1, Canada
-COMMENT     ##Assembly-Data-START##
-            Assembly Method       :: Velvet v. 1.2.10
-            Assembly Name         :: Klebsiella pneumoniae CWK53 gmlABD cluster
-            Coverage              :: 100x
-            Sequencing Technology :: Illumina
-            ##Assembly-Data-END##
-FEATURES             Location/Qualifiers
-     source          1..3354
-                     /organism="Klebsiella pneumoniae"
-                     /mol_type="genomic DNA"
-                     /strain="CWK53"
-                     /serotype="O2aeh"
-                     /db_xref="taxon:573"
-                     /note="sequence edited to trim to gmlABD only by Kelly
-                     Wyres, April 2021"
-                     /note="Extra genes: gmlABD"
-     gene            1..375
-                     /gene="gmlA"
-     CDS             1..375
-                     /gene="gmlA"
-                     /note="putative export component of the periplasmic
-                     O-antigen modification pathway"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="GmlA"
-                     /protein_id="AVA30553.1"
-                     /translation="MKKILSNPALKYVMVGLLNTAITAVVIFLLMSAGVGVYLSNAMGY
-                     VVGILFSFVVNSLFTFSIALTGKRFIKFLASCAMCWVANIITVKMFLLIFPDLIYISQL
-                     CGMIVYTIAGFLINKLWVMK"
-                     /locus_tag="Extra_genes_gmlABD_01_gmlA"
-     misc_feature    <1..>3354
-                     /note="gmlABD gene cluster"
-     gene            375..1334
-                     /gene="gmlB"
-     CDS             375..1334
-                     /gene="gmlB"
-                     /note="putative glycosyltransferase synthesizing
-                     undecaprenol-P-galactose for periplasmic side-group
-                     modification of the O-antigen"
-                     /codon_start=1
-                     /transl_table=11
-                     /product="GmlB"
-                     /protein_id="AVA30554.1"
-                     /translation="MKQPKLAIVVPCYNEEEVFSHCLSELQAVLAELVTATLISADSYI
-                     LFVDDGSCDSTWQLIAQASMDYSTVKGVKLSRNRGHQVALVAGLEAAESDITVSIDADL
-                     QDDTSVIALMVKEYLNGNEIVYGVRNDRASDSPFKRKTAGLFYSCMKWMGVQQIPQHAD
-                     FRLLSDRAKKALLSFKEQNLYLRGLVPLIGYRSTQVAYSRTVRLAGESKYPLKKMLALA
-                     IEGITSLTITPLRIIAISGFAISILSVFAAIYALFEKFSGNTVEGWASVMIAIFFLGGV
-                     QMLSLGIIGEYVGKIYMESKGRPKYFIEKTTQQKVDDE"
-                     /locus_tag="Extra_genes_gmlABD_02_gmlB"
-     gene            1327..3354
-                     /gene="gmlD"
-     CDS             1327..3354
-                     /gene="gmlD"
-                     /note="putative GT-C type glycosyltransferase that adds an
-                     alpha(1-2)-linked galactose side group to the O-antigen
-                     from Und-P-galactose in the periplasm."
-                     /codon_start=1
-                     /transl_table=11
-                     /product="GmlD"
-                     /protein_id="AVA30555.1"
-                     /translation="MNNEKIISRIQYVVFIAILSVLCYSFVASENQAYTWDSRFYWVVW
-                     NEYTGLLHDSFSQWLASIKYSVYSADYNPLPVIALIPFNYLPIGNREAYILGVYILYFL
-                     PFAYIAMRLFATAAGVDNKYQPYIFVFLASFIPFVTPTLRGYPDIIGMIPLSLCCLILF
-                     KVNILKYQGARFVLLAIAMGVLLWLPFAFRRWYAYSVVSLFVTLPFLNTFLFGEAARFS
-                     KERIFKYFIFFTLAGLVVIFLVCVFQFELAERILTTNYSDIYSAYKATEQATFFITLNY
-                     AGLYLLPLIVLGGLYIVFGTSFRLKVLCAFALANFIITYIIFTRTQTPGMQHGMPFCFW
-                     LAILVLSALKLFFDRLNKGLAITLTIAFSLLTVAVFISTYSKPFGKPELVSRYLPGKEY
-                     PLRLENFDHYHELIAFMSARVEPDDKVAVFASSGSLNNDLFSAISPASFVSHIANVSQV
-                     DLRDKLATEAFSSRYAIVTDPAQTHLGIHGQQVIYLPNNLILEGKGIGAAYKRVSQPFI
-                     LSGGVQAYVYEKIRPYTIDEYRSMIDEFSRSYPSWKAEYENNLTESYLSAAVEKGDTWG
-                     QFSMYREGRIYAHPGATTPTIVRMFVGEYDTLRITSVNKNCGKTDGVKVIIKDATHRVE
-                     KHIATAESVVFDMRDFHNKDITLIIDNNGSSACDSLDINQ"
-                     /locus_tag="Extra_genes_gmlABD_03_gmlD"
-ORIGIN
-        1 gtgaaaaaaa tactttctaa tcccgcattg aaatatgtaa tggtggggtt attgaataca
-       61 gcaataactg cggtggtgat atttttatta atgtctgccg gggttggagt atatctatca
-      121 aatgccatgg gatatgtggt aggtattctc tttagttttg tggttaattc gttgtttacc
-      181 ttttcaatag cgctgaccgg caaacggttt ataaagtttc tggcatcttg tgcaatgtgc
-      241 tgggtagcta atattataac agttaaaatg tttttattaa tattccctga tttgatttat
-      301 atatctcagt tatgtggcat gattgtttac acaattgctg gttttttaat taataaactc
-      361 tgggtgatga aataatgaaa caaccaaagt tggctattgt tgtgccatgt tataacgagg
-      421 aagaagtatt cagtcactgc ttatctgaat tacaagcggt tctggcggaa ttagtcacgg
-      481 caacactgat ttcagctgat agctatattt tattcgttga tgatggcagc tgtgattcaa
-      541 cgtggcagtt gattgctcaa gcatcgatgg attactcaac ggttaaaggg gttaagcttt
-      601 caagaaatcg tggtcatcag gtagccctgg ttgcgggtct tgaggccgcc gaatcggata
-      661 ttactgtgag cattgatgca gatcttcagg atgatacttc tgttattgca ttaatggtta
-      721 aagagtacct caatggtaat gagatcgtat atggtgtacg taatgatcgg gcatctgact
-      781 ctccatttaa aagaaaaacc gcgggtctct tttatagttg tatgaagtgg atgggcgttc
-      841 agcagattcc ccagcatgcc gatttcagat tgttaagcga tcgcgctaaa aaggcgttgc
-      901 tgagctttaa agagcaaaat ttatatttac gtggattagt gccactgatt ggttatcgtt
-      961 ccactcaggt tgcatattcg agaacagttc gtctggctgg tgagtcgaag tatccattaa
-     1021 aaaaaatgct tgccctggca attgaaggca tcacttctct gaccattacc ccattaagga
-     1081 ttatcgctat ctcagggttt gcgatcagta ttctttcggt gtttgcagca atttatgcgc
-     1141 tgtttgagaa attctcagga aataccgttg aagggtgggc ctcagttatg atcgctattt
-     1201 tcttcctcgg cggtgtacag atgctatcgt taggcatcat tggtgagtat gtcggtaaga
-     1261 tatatatgga gtctaaaggt cgtcctaaat attttatcga aaaaacaacg cagcagaagg
-     1321 ttgatgatga ataacgaaaa aataatcagt agaatacagt atgtggtttt catcgccata
-     1381 ttatcagtac tttgttattc ctttgtggca agtgaaaatc aggcttatac atgggattcc
-     1441 agattttact gggtagtatg gaatgagtat actggcttac tgcatgactc atttagtcaa
-     1501 tggcttgcta gtataaaata ttcagtctat tcagctgatt ataacccttt gccagtcatt
-     1561 gcactgatcc cgtttaacta tctgccgata ggaaatcggg aagcttacat attgggtgtg
-     1621 tatattcttt attttttacc atttgcttat attgcaatgc gtttgtttgc gactgctgca
-     1681 ggtgtggaca acaaatacca gccgtatatc tttgtttttc tagcaagttt tattcctttt
-     1741 gtcacaccaa ccttgcgcgg ctatcctgat atcataggaa tgattccact atcgctgtgc
-     1801 tgcttgattt tgtttaaagt taatatatta aaataccagg gagcccgttt tgtattactt
-     1861 gcaatcgcaa tgggagtatt actatggttg ccctttgcat tccggcgatg gtatgcctat
-     1921 agcgtagttt ccttgtttgt tacgttgcct tttttgaata catttttgtt tggtgaagcg
-     1981 gccaggttta gtaaggaaag aatatttaaa tactttattt tctttactct tgctgggctg
-     2041 gtagtgattt ttttagtctg tgtttttcag ttcgaactgg ctgagagaat actgacgaca
-     2101 aactattctg atatttattc tgcatacaag gcgacagagc aagcaacctt ctttataacc
-     2161 ctgaactatg ctggtttata tttgctgcca ttaattgttt tgggaggctt gtatattgtt
-     2221 ttcggaacca gttttcgtct taaagttctt tgtgcttttg cattagctaa ttttattatc
-     2281 acctatatta tatttacccg aacacagaca ccagggatgc agcatggaat gccattctgt
-     2341 ttttggttgg caatactcgt gctttcggct ttaaaactat tctttgacag gttaaacaaa
-     2401 ggactggcga taacacttac gatcgcattc tcattactta cggttgcagt ctttattagc
-     2461 acatattcaa aaccatttgg taaaccggaa ttagtcagcc gctatcttcc tggcaaagag
-     2521 tatcctctca gattagaaaa ctttgaccat taccatgagc tgattgcctt tatgagtgcg
-     2581 cgtgttgagc cagatgataa ggtggctgtt tttgcatcca gcggttcact taataatgat
-     2641 ctgttttcag ccatatcacc ggcatcgttt gtcagccata tcgccaacgt ctcgcaggta
-     2701 gatttgcgtg ataagctggc tactgaagcc tttagttctc gttatgcgat tgtgaccgat
-     2761 ccagctcaaa cgcatcttgg aattcatgga caacaggtta tatatctgcc aaataatctt
-     2821 atcctggaag gtaagggaat tggtgccgct tataaaagag tcagtcagcc atttatactt
-     2881 agcggcggtg ttcaggcata cgtctatgaa aaaatcagac cgtatacaat cgatgaatac
-     2941 agaagcatga ttgatgaatt ttcccgttcc tacccctcat ggaaagcgga gtatgaaaat
-     3001 aatcttacag agagttatct aagcgcggca gtggagaaag gcgacacctg ggggcagttt
-     3061 agtatgtatc gtgaaggtcg aatctacgcc cacccaggcg caacaacacc gactattgtc
-     3121 aggatgttcg tcggggaata tgacacctta cgtattacgt cagtcaataa aaactgtggg
-     3181 aaaactgacg gagtgaaagt gattatcaaa gatgcgacgc atcgtgtaga aaagcatatt
-     3241 gccacagcag agagcgtggt ttttgatatg cgcgactttc acaacaaaga tattaccttg
-     3301 attattgata ataatggttc ctctgcttgt gatagcctgg atattaacca gtaa
-//
-LOCUS       wbmVW                   2733 bp    DNA     linear   BCT 14-FEB-2018
-DEFINITION  Klebsiella pneumoniae strain 5053 wbmVW genes, complete sequence.
-ACCESSION   MG602074
+ACCESSION   MG602074 REGION: 1032..4944
 VERSION     MG602074.1
 KEYWORDS    .
 SOURCE      Klebsiella pneumoniae
   ORGANISM  Klebsiella pneumoniae
-            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales;
-            Enterobacteriaceae; Klebsiella.
-REFERENCE   1  (bases 1 to 4944)
+            Bacteria; Pseudomonadati; Pseudomonadota; Gammaproteobacteria;
+            Enterobacterales; Enterobacteriaceae; Klebsiella/Raoultella group;
+            Klebsiella; Klebsiella pneumoniae complex.
+REFERENCE   1  (bases 1 to 3913)
   AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
             Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
             Whitfield,C.
   TITLE     Molecular basis for structural diversity in serogroup O2-antigen
             polysaccharides in Klebsiella pneumoniae
   JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 4944)
+REFERENCE   2  (bases 1 to 3913)
   AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
             Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
             Whitfield,C.
   TITLE     Direct Submission
   JOURNAL   Submitted (04-DEC-2017) Dept of Molecular and Cellular Biology,
-            University of Guelph, 50 Stone Road, Guelph, Ontario N1G 2W1, Canada
+            University of Guelph, 50 Stone Road, Guelph, Ontario N1G 2W1,
+            Canada
 COMMENT     ##Assembly-Data-START##
             Assembly Method       :: SPades v. 3.10.0
             Assembly Name         :: Klebsiella pneumoniae 5053 wbmVWX cluster
@@ -4863,19 +4243,19 @@ COMMENT     ##Assembly-Data-START##
             Sequencing Technology :: Illumina
             ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
-     source          1..2733
+     source          1..3913
                      /organism="Klebsiella pneumoniae"
                      /mol_type="genomic DNA"
                      /strain="5053"
                      /serotype="O2ac"
                      /db_xref="taxon:573"
-                     /note="Sequence edited to trim to wbmVW only, Kelly Wyres
-                     April 2021"
-                     /note="Extra genes: wbmVW"
+                     /note="sequence edited to trim to wbmVWX only, Tom Stanton, March 2025"
+                     /note="Extra genes: wbmVWX"
      gene            1..1266
                      /gene="wbmV"
      CDS             1..1266
                      /gene="wbmV"
+                     /locus_tag="Extra_genes_wbmVWX_01_wbmV"
                      /note="putative glycosyltransferase involved in
                      biosynthesis of the K. pneumoniae O2c antigen
                      polysaccharide"
@@ -4883,21 +4263,19 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /product="WbmV"
                      /protein_id="AVA30547.1"
-                     /translation="MEWFSDIKNSKIDLSIIIPMYNVEDYIIETLNSMRGVRGFKVELI
-                     LVDDGSTDNTLNLAKEWANSSDFDTFILSKENGGPSIARNLGLSKARGELVTFFDSDDI
-                     ALSYLYTDIINIMLSHGVDFCIFRGSSFDHVTQKVYEFPDYYVWEKIMGGAEFKVLTPQ
-                     QEPRLARLEPSAVVRVYRKDFITSNEIQFPENLFFEDVLFHAKCVLNAKKIALLNKTLL
-                     LYRVNREGQTTGSFGKKRRDVLKVIDLIISDYSKMKVTNDIWANLVGLLIRMNVWCSEN
-                     CAYQDKADFVKESISLFSKLPKNVLEIYMNEYSYNDWEIKLCKAFIERNEKVLNVSAEG
-                     GYPIFDNVHESLHPEENQVSLVSIDGKLEHLFSQQKEGWAHDRFNVLNGKLESLIAQNK
-                     ELYEKLEHKRSISSLINKIFKG"
-                     /locus_tag="Extra_genes_wbmVW_01_wbmV"
-     misc_feature    <1..>2733
-                     /note="wbmVWX gene cluster"
+                     /translation="MEWFSDIKNSKIDLSIIIPMYNVEDYIIETLNSMRGVRGFKVEL
+                     ILVDDGSTDNTLNLAKEWANSSDFDTFILSKENGGPSIARNLGLSKARGELVTFFDSD
+                     DIALSYLYTDIINIMLSHGVDFCIFRGSSFDHVTQKVYEFPDYYVWEKIMGGAEFKVL
+                     TPQQEPRLARLEPSAVVRVYRKDFITSNEIQFPENLFFEDVLFHAKCVLNAKKIALLN
+                     KTLLLYRVNREGQTTGSFGKKRRDVLKVIDLIISDYSKMKVTNDIWANLVGLLIRMNV
+                     WCSENCAYQDKADFVKESISLFSKLPKNVLEIYMNEYSYNDWEIKLCKAFIERNEKVL
+                     NVSAEGGYPIFDNVHESLHPEENQVSLVSIDGKLEHLFSQQKEGWAHDRFNVLNGKLE
+                     SLIAQNKELYEKLEHKRSISSLINKIFKG"
      gene            1270..2733
                      /gene="wbmW"
      CDS             1270..2733
                      /gene="wbmW"
+                     /locus_tag="Extra_genes_wbmVWX_02_wbmW"
                      /note="putative glycosyltransferase involved in
                      biosynthesis of the K. pneumoniae O2c antigen
                      polysaccharide"
@@ -4905,16 +4283,34 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /product="WbmW"
                      /protein_id="AVA30548.1"
-                     /translation="MLRMESFEALMEEMKFSLVDESLARKDYDRLTNSYYGKSCNPLIF
-                     CENLLIIGVRSGLEFLIAKSVNSNAVVHIVESNKSFLEKINKLNIANVTAFSSFKEYIS
-                     SVKSQKYDYVRINRVNFNLDLVAQLYSKHNILSICGELKEADCKPLTLYRLSRNSCDSF
-                     FFNIKDKNYNVAGARKCIEQPEVSVVVAAYGVENYLDECVSSIVHQTLKNIEILIVDDG
-                     SIDGTGKKADEWQKRFPDIVRVIHKENGGCASARLEGMREAKGEYVAFIDGDDWVEQPM
-                     YEDLFESAALHNSEIAQCGFYEFFADQTKNYYSTAWGADGQNGTTGLVKEPTEYLTLMP
-                     SIWRRIYKTSFLRKHGIEFPVQIRRHDDLPFAFMTIARAKRISVIPDCYYAYRLNRPGQ
-                     DVGATDERLFIHFEIFEWLYEQVRPWASMAIMSNMRLVEIGTHSWVLSRLDSHLKNDYL
-                     NKSISGISERYKRYELDDGWLDRLKLASR"
-                     /locus_tag="Extra_genes_wbmVW_02_wbmW"
+                     /translation="MLRMESFEALMEEMKFSLVDESLARKDYDRLTNSYYGKSCNPLI
+                     FCENLLIIGVRSGLEFLIAKSVNSNAVVHIVESNKSFLEKINKLNIANVTAFSSFKEY
+                     ISSVKSQKYDYVRINRVNFNLDLVAQLYSKHNILSICGELKEADCKPLTLYRLSRNSC
+                     DSFFFNIKDKNYNVAGARKCIEQPEVSVVVAAYGVENYLDECVSSIVHQTLKNIEILI
+                     VDDGSIDGTGKKADEWQKRFPDIVRVIHKENGGCASARLEGMREAKGEYVAFIDGDDW
+                     VEQPMYEDLFESAALHNSEIAQCGFYEFFADQTKNYYSTAWGADGQNGTTGLVKEPTE
+                     YLTLMPSIWRRIYKTSFLRKHGIEFPVQIRRHDDLPFAFMTIARAKRISVIPDCYYAY
+                     RLNRPGQDVGATDERLFIHFEIFEWLYEQVRPWASMAIMSNMRLVEIGTHSWVLSRLD
+                     SHLKNDYLNKSISGISERYKRYELDDGWLDRLKLASR"
+     gene            complement(2747..3913)
+                     /gene="wbmX"
+     CDS             complement(2747..3913)
+                     /gene="wbmX"
+                     /locus_tag="Extra_genes_wbmVWX_03_wbmX"
+                     /note="putative glycosyltransferase involved in
+                     biosynthesis of the K. pneumoniae O2c antigen
+                     polysaccharide"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="WbmX"
+                     /protein_id="AVA30549.1"
+                     /translation="MKINLVGAVGGGNFGDEFILNCCIAEHIKNKDAKVSVSGFSPDI
+                     ILKSGFSVENHSLNFFNILDKLRQKAENGLKISMNDLISQFEGAEEFDAIHFIGGGYI
+                     NSLWPSNYALLGIAYIYSKIHKKPIYATGLGLSPYEENESLTSLFNSLDIIDVRDEKS
+                     KSLIPSASFTGDDALLALNEPSMLVKNDDSPALILSLQSHLFEGQSLIEKIFTDGTFK
+                     ELKNKKIKKIIIIEAAPEDNIPFSRETFNNTLANGIEIEFVTGNEILRRGIPFNSRSF
+                     VISSRYHINLIYSMLNVSGIAVYQNEYYRNKHKSVTEMGGAWSILNHDKLSEALDHWL
+                     PLDSENYTSPNNMINKAKEKKELFNKIIANAQNKDKKSISLESALAVINKFITK"
 ORIGIN
         1 atggaatggt tttctgatat aaaaaattcg aagattgatc tatcaattat tataccgatg
        61 tataatgttg aggattatat tattgaaact ttgaattcca tgagaggtgt caggggtttc
@@ -4961,7 +4357,27 @@ ORIGIN
      2521 ctttatgagc aagttagacc atgggcctca atggcaatca tgagtaatat gagacttgtc
      2581 gaaatcggaa cgcatagctg ggtcctgagc agattagata gtcatttaaa aaatgattat
      2641 ttaaataaat ctatttctgg aattagtgaa agatataaga ggtatgagtt agatgatggc
-     2701 tggctagata gacttaagct ggccagccgc taa
+     2701 tggctagata gacttaagct ggccagccgc taaggtttca tagtggttat ttggtaataa
+     2761 atttattgat tactgctaat gcactttcta aagagatgct ttttttatct ttattttgtg
+     2821 cattagcaat tattttattg aataactctt tcttctcctt cgccttattt atcatgttgt
+     2881 tgggcgatgt gtaattttct gaatctaggg ggagccagtg atcaagggct tcactgagtt
+     2941 tatcatggtt taatattgac cacgcccctc ccatttctgt tactgattta tgcttgtttc
+     3001 tataatattc attttggtat acagctattc cactaacgtt gagcattgaa taaattaagt
+     3061 tgatatgata tctagaagat atgacaaagc tccttgagtt aaatggtatg ccgcgtctta
+     3121 aaatttcatt tcctgtcacg aattctattt ctattccatt tgctaaggtg ttgttaaatg
+     3181 tttcccttga aaaggggatg ttatcttctg gtgctgcttc gattataatt atttttttta
+     3241 tttttttgtt ttttagttct ttgaatgttc catcggtgaa gattttttct atcaaagact
+     3301 gtccttcaaa tagatgactt tgtaatgata atattaatgc aggagagtcg tcatttttaa
+     3361 ccagcatgct gggttcgttt aaggccaaga gggcgtcatc tcctgtaaaa gaagctgatg
+     3421 gaattaaact ttttgatttt tcgtctctta catctattat gtccaggcta ttaaaaaggc
+     3481 tagttaaact ttcattttct tcgtatgggg atagtccaag gcctgtggca taaataggtt
+     3541 ttttatggat ttttgaataa atgtaagcta tgcctagtaa ggcatagttg ctaggccaaa
+     3601 gtgaattaat atagccaccg cctataaaat gaatggcatc aaattcctcg gcgccttcaa
+     3661 actgtgagat aaggtcattc atggatattt ttaatccatt ttctgccttt tgtcttaatt
+     3721 tatctagtat gttgaaaaaa tttaaagaat gattttcaac tgaaaagcca ctctttaaaa
+     3781 taatgtcagg gctaaatcca ctgactgaaa cctttgcgtc tttgttcttg atatgctcag
+     3841 ctatacagca attcaatatg aattcgtctc caaaattgcc gccaccaacc gcaccaacca
+     3901 aatttatctt cat
 //
 LOCUS       UGMM01000004            3130 bp    DNA     linear   BCT 04-OCT-2023
 DEFINITION  Klebsiella pneumoniae strain NCTC11682 genome assembly, contig:
@@ -5088,4 +4504,213 @@ ORIGIN
      3001 TCAGCAAAGA GATGGCTGGG CCCATGACCG TTTTAATGCT CTGTATGAAG CAATTCATGT
      3061 CCAAGGCGCA AAACGAGGCA CCAGCCTGGT TCGCCGGGTT GCCCGGAAAG TGAAATCAAT
      3121 GTTAAAATAA
+//
+LOCUS       LT174602                2817 bp    DNA     linear   BCT 13-JUN-2016
+DEFINITION  Klebsiella pneumoniae lipopolysaccharide O-antigen biosynthesis
+            gene cluster, type: O1/O2, Variant 2.
+ACCESSION   LT174602 REGION: complement(7996..10812)
+VERSION     LT174602.1
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Pseudomonadati; Pseudomonadota; Gammaproteobacteria;
+            Enterobacterales; Enterobacteriaceae; Klebsiella/Raoultella group;
+            Klebsiella; Klebsiella pneumoniae complex.
+REFERENCE   1
+  AUTHORS   Follador,R., Heinz,E., Wyres,K.L., Ellington,M.J., Kowarik,M.,
+            Holt,K.E. and Thomson,N.R.
+  TITLE     Towards a vaccine: An investigation of Klebsiella pneumoniae
+            surface antigens
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 2817)
+  AUTHORS   Informatics,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (04-FEB-2016) SC, Wellcome Trust Sanger Institute, CB10
+            1SA, UNITED KINGDOM
+FEATURES             Location/Qualifiers
+     source          1..2817
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="441"
+                     /serovar="O1/O2 Variant 2"
+                     /db_xref="taxon:573"
+                     /note="sequence edited to trim to gmlABC only and reverse
+                     complement, Tom Stanton, March 2025"
+                     /note="Extra genes: gmlABC"
+     gene            1..378
+                     /gene="gmlA"
+     CDS             1..378
+                     /gene="gmlA"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_005020797.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="GtrA-like protein"
+                     /protein_id="CZQ25303.1"
+                     /locus_tag="Extra_genes_gmlABC_01_gmlA"
+                     /translation="MPSSGPLWQLMKYGLVGIVNTLITAVVIFLLMHLGLGIYLSNAM
+                     GYVVGIVFSFIANTIFTFTQPISINRLIKFLCVCFICYVANIIVIKIFFVFMPEKIYS
+                     AQILGMFTYTITGFILNKFWAMK"
+     gene            375..1355
+                     /gene="gmlB"
+     CDS             375..1355
+                     /gene="gmlB"
+                     /EC_number="2.4.-.-"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /inference="similar to AA sequence:RefSeq:YP_006635432.1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="glycosyltransferase"
+                     /protein_id="CZQ25302.1"
+                     /locus_tag="Extra_genes_gmlABC_02_gmlB"
+                     /translation="MTTSTDIKSTPSLAIVVPCYNEQEAFPFCLEKLSNVLNSLIARN
+                     KINNNSYLLFVDDGSRDNTWAQIKDASTAYHYVRGIKLSRNKGHQIALMAGLRSVDTD
+                     VTISIDADLQDDVNCIEKMIDAYSQGYDIVYGVRGNRDSDTFFKRTTANAFYAIMSHL
+                     GVNQTPNHADYRLLSNRALEALKQYKEQNIYLRGLVPLVGYPSIEVQYSREERIAGES
+                     KYPIKKMLALALEGITSLSVTPLRIIAMTGFITCIISTIAAIYALIQKTTGTTVEGWT
+                     SVMIAIFFLGGVQMLSLGIIGEYVGKIYIETKNRPKYFIDESVGNDSNGK"
+     gene            1357..2817
+                     /gene="gmlC"
+     CDS             1357..2817
+                     /gene="gmlC"
+                     /inference="ab initio prediction:Prodigal:2.60"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="Uncharacterised protein"
+                     /protein_id="CZQ25301.1"
+                     /locus_tag="Extra_genes_gmlABC_03_gmlC"
+                     /translation="MQNLINPLAEGNKKNVYIFYFFLLMLTFSPVIFFSYAFSDDWST
+                     LFDAITRNGSSFQWDVQSGRPVYAVFRYYGKMLINDISSFSYLRLFNILSLVVLSCFI
+                     YNFIDSRKIFDNPVFKIIFPLLICLLPAFQVYASWATCFPFTISVLLAGISYNKCFPH
+                     SKQRSSLPEKLASIVVLWVAFAIYQPTAITFLFFFMLDSCIKKESSLTVKKVATCFII
+                     LVIGVAGSFIMSKVLPVWLYGESLSRAELTADIGGKMKWFINESLINAVNNYNIQPVK
+                     IYSWFSSFAILIGLYTIFVGKTGRWKTFIVITIGIGSYAPNLATKENWAAFRSLVALE
+                     LIISTLFLIGINSLVSRISKQAFVWPLIALTIMIIAQYNIINGFIIPQRSEIQALAAE
+                     ITNKIPKNYTGKLMFDLTDPAYNAFTKTQRYDEFGNISLAAPWALKGMAEEIRIMKGF
+                     NFKLSNNVIISETNRCIDDCMVIKTSDAMRRSTINY"
+ORIGIN
+        1 atgccaagtt caggcccatt atggcaacta atgaaatatg ggttagttgg gatagtcaat
+       61 acactaatta cagcagttgt aattttcctg ctaatgcatt tgggtcttgg catttatctg
+      121 tccaatgcga tgggttatgt tgtaggtatt gttttcagct ttatagcaaa cacaatattt
+      181 acatttacgc aaccaatcag tatcaataga ctaataaaat ttttatgtgt ttgcttcatt
+      241 tgttatgtgg caaatatcat tgtcataaaa atatttttcg tttttatgcc agaaaaaata
+      301 tattcagcac aaatccttgg gatgttcaca tacactatca caggttttat tttaaacaag
+      361 ttctgggcga tgaaatgaca acctcaactg atataaaaag cactccttct ttagctattg
+      421 tggtaccttg ctataatgaa caagaggctt ttcctttctg tctcgaaaag ctttcgaatg
+      481 tactaaattc attgatagcc agaaataaaa ttaataacaa tagttatctt ttgtttgtcg
+      541 atgatggtag tcgtgacaat acttgggcac aaattaaaga tgcctcgacc gcttatcact
+      601 atgtgcgagg aataaaatta tcaagaaata aaggacatca aattgcgttg atggcagggt
+      661 tacgctcggt cgatacagac gtaaccatta gcatcgatgc ggatctacaa gacgatgtaa
+      721 attgcatcga aaaaatgatt gacgcttaca gccagggata tgacatagta tacggcgtaa
+      781 gaggtaatcg agacagtgac acgtttttta aacgtacaac agctaatgca ttttacgcaa
+      841 taatgtccca cttgggagta aatcaaactc caaatcatgc agattatcga ttattaagta
+      901 atcgagcatt ggaggctctt aaacaatata aagagcaaaa tatatattta cgtggattag
+      961 tgcctcttgt gggatacccc tcgatcgagg tgcaatatag ccgtgaagaa agaattgccg
+     1021 gtgaatcaaa atatccaatt aaaaaaatgc ttgcgctggc tctcgaggga attacctcat
+     1081 tatcagttac accgttacga attatagcta tgacaggttt tataacttgc atcatatcta
+     1141 ccatcgctgc gatttatgct ttaattcaaa aaacaacagg tactacagtt gagggatgga
+     1201 catcagtcat gatcgctata ttctttcttg gcggcgtgca aatgctttct ttaggtatta
+     1261 taggagaata tgtcggaaaa atttatatag agacgaaaaa tagacctaaa tatttcattg
+     1321 acgaaagcgt aggtaatgat agcaatggaa aataacatgc aaaatctgat caatccttta
+     1381 gcagagggaa ataaaaaaaa cgtttacatt ttttatttct ttttgcttat gttaacattt
+     1441 tcaccggtaa ttttcttttc atatgcattt tcagacgact ggtcaacact ctttgatgct
+     1501 ataacaagaa acggctcttc gtttcagtgg gatgtccaat ctggtcgtcc cgtttatgct
+     1561 gtgttccgtt actatggaaa aatgttaatt aatgatattt cttcattttc gtatttgcgg
+     1621 ctttttaata tattaagtct tgttgtctta agttgtttta tttacaactt catagacagc
+     1681 agaaaaatat ttgataaccc cgtattcaaa ataatatttc cgctgttaat ttgcttactc
+     1741 cctgcgtttc aagtttatgc ttcatgggca acatgtttcc cgttcactat ttcagtattg
+     1801 ctggcaggta ttagttataa taaatgtttc ccacattcga agcagcggtc gtcattgcca
+     1861 gaaaaattag catccattgt tgtcttatgg gtggcatttg caatatatca accgacagca
+     1921 attacattct tattcttttt tatgcttgat agttgcataa aaaaagaaag tagtttaact
+     1981 gtgaaaaaag ttgcgacatg ttttatcatt ttagttatcg gtgttgcagg cagttttatc
+     2041 atgtcaaaag tacttcctgt ctggctatat ggggaatcat tatcgagagc cgagttaacc
+     2101 gcagatatcg gtggaaagat gaaatggttc ataaatgaat cactaataaa cgctgtaaat
+     2161 aactataaca tacaaccagt aaaaatatat tcttggttct cctcatttgc aattttaatc
+     2221 ggcttataca ctatttttgt gggaaaaaca ggcagatgga aaacgttcat agtcataacg
+     2281 atcgggatag gttcctacgc tccaaattta gcgacaaaag aaaattgggc agcattccgc
+     2341 tcgttagtgg ccttagaact tattatatca actctatttc ttattggcat aaatagcctt
+     2401 gtcagtagaa tttctaagca agcatttgtc tggcctctta tcgctttaac aattatgata
+     2461 atagctcagt ataatattat aaatggattt attattcctc aacgctctga aattcaggca
+     2521 cttgctgcgg aaataactaa taaaatacct aagaattaca caggaaaatt aatgttcgat
+     2581 ctcacagatc ctgcttacaa tgcctttaca aaaacacaga gatatgatga gtttgggaat
+     2641 atttcattag cagcgccctg ggcgctcaaa ggtatggctg aagagatcag aattatgaaa
+     2701 ggatttaatt tcaaactatc taacaacgtt ataatttctg agaccaatcg atgtattgat
+     2761 gattgtatgg ttattaaaac gtcagatgca atgcgaaggt caacgataaa ttattag
+//
+LOCUS       MG280710                1020 bp    DNA     linear   BCT 14-FEB-2018
+DEFINITION  Klebsiella pneumoniae strain CWK53 rfb gene cluster, complete
+            sequence.
+ACCESSION   MG280710 REGION: 8381..9400
+VERSION     MG280710.1
+KEYWORDS    .
+SOURCE      Klebsiella pneumoniae
+  ORGANISM  Klebsiella pneumoniae
+            Bacteria; Pseudomonadati; Pseudomonadota; Gammaproteobacteria;
+            Enterobacterales; Enterobacteriaceae; Klebsiella/Raoultella group;
+            Klebsiella; Klebsiella pneumoniae complex.
+REFERENCE   1  (bases 1 to 1020)
+  AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
+            Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
+            Whitfield,C.
+  TITLE     Molecular basis for structural diversity in serogroup O2-antigen
+            polysaccharides in Klebsiella pneumoniae
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 1020)
+  AUTHORS   Clarke,B.R., Ovchinnikova,O.G., Kelly,S.D., Williamson,M.L.,
+            Butler,J.E., Liu,B., Wang,L., Gou,X., Follador,R., Lowary,T.L. and
+            Whitfield,C.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (27-OCT-2017) Dept of Molecular and Cellular Biology,
+            University of Guelph, 50 Stone Road, Guelph, Ontario N1G 2W1,
+            Canada
+COMMENT     ##Assembly-Data-START##
+            Assembly Method       :: Velvet v. 1.2.10
+            Assembly Name         :: Klebsiella pneumoniae CWK53 O-antigen
+                                     biosynthesis (rfb) gene cluster
+            Coverage              :: 100x
+            Sequencing Technology :: Illumina
+            ##Assembly-Data-END##
+FEATURES             Location/Qualifiers
+     source          1..1020
+                     /organism="Klebsiella pneumoniae"
+                     /mol_type="genomic DNA"
+                     /strain="CWK53"
+                     /serotype="O2aeh"
+                     /db_xref="taxon:573"
+                     /note="sequence edited to trim to Orf8 on;y, Tom Stanton, March 2025"
+                     /note="Extra genes: orf8"
+     CDS             1..1020
+                     /note="Orf8; involved in lipopolysaccharide O-antigen
+                     biosynthesis"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="putative acyltransferase"
+                     /protein_id="AVA30572.1"
+                     /locus_tag="Extra_genes_orf8_01_orf8"
+                     /gene="orf8"
+                     /translation="MGCRLSVNRFDAIDGTRGILAGMVMLSHMFGSFMGWPQVRPFSG
+                     AYLCVVYFFIMSGFVLTYAHASGNFFKYVLTRFARLWPLHFLSTILMVAIYYYNAHHG
+                     GYVSSPDVFSISVILKNILFLHGLYWHDFKLVNEPSWSISIEFWVSLLIPLIFTRLGN
+                     MTRAVVAGLLFIFLWHKHPSGIPPSMLTAMLSMLIGSLFFSLSQTEYFKCLMKEKFMA
+                     FFITAAAIVSIVGVYAMNHSRLDYFLFVAFIPMLFIDHLPDNQLIKRVFTSNLFLFLG
+                     YISFPLYLLHELVIVSGFIFDPENAWVSISIAAFASIFIAYIYARFIDYPLYRALKRQ
+                     IAKIS"
+ORIGIN
+        1 atggggtgta gattgtctgt taacagattt gatgccattg atggcactcg tgggatattg
+       61 gcgggtatgg tcatgctcag ccatatgttt ggcagcttta tgggttggcc gcaagtcaga
+      121 ccatttagcg gtgcctatct gtgcgtggta tattttttca tcatgagtgg ctttgttcta
+      181 acctatgccc acgcctcagg aaactttttc aaatacgttc ttacacgttt tgccagatta
+      241 tggccgcttc attttctgtc aacgatactg atggtagcca tttattacta caatgcacac
+      301 catggcggct atgtttccag tccggatgtt ttttctatta gcgtgatatt aaaaaatata
+      361 ttatttcttc atggtcttta ctggcatgac ttcaagttag tcaatgagcc atcatggagt
+      421 atcagtattg agttttgggt gtcactttta attcctctaa tctttacgcg attaggaaat
+      481 atgactcgtg cggtagttgc aggtttatta tttatttttc tgtggcataa acatccatca
+      541 gggataccgc catcaatgct aacagcaatg ctgtcaatgc tgattggttc attgtttttt
+      601 tctttatcac agacagagta ctttaagtgt ctgatgaaag aaaagttcat ggctttcttt
+      661 attaccgcag cggctatcgt atcgatcgtt ggcgtatatg caatgaacca tagtcgactg
+      721 gactattttt tattcgttgc gtttatcccg atgctattca tcgatcatct tccggataat
+      781 caattgataa agagagtttt cacctctaat ttattcttgt ttctcggtta tattagcttc
+      841 cctttgtatt tattgcatga actggttatc gtatccggat tcatttttga ccctgagaat
+      901 gcctgggtat caatatcaat agcggcattt gcatcaatat tcattgccta tatttatgca
+      961 cgatttatcg attatcctct ctatcgggcg ttaaagcgtc agattgccaa aataagttaa
 //

--- a/reference_database/Klebsiella_o_locus_primary_reference.gbk
+++ b/reference_database/Klebsiella_o_locus_primary_reference.gbk
@@ -1790,8 +1790,9 @@ FEATURES             Location/Qualifiers
                      /strain="94"
                      /serovar="O1/O2 Variant 1"
                      /db_xref="taxon:573"
-                     /note="O locus: O1/O2v1"
-                     /note="O type: O2a"
+                     /note="O locus: O1α,O2α"
+                     /note="O type: O2α"
+                     /note="Updated from O1/O2v1 by Tom Stanton in Feb 2025"
      gene            1..768
                      /gene="wzm"
      CDS             1..768
@@ -1809,7 +1810,7 @@ FEATURES             Location/Qualifiers
                      SNVMMEGLHFLCTIPVIVVFLFVYGMTPSLSWVWGIPLIAIGQVIFTFGVSIIFSTLNL
                      FFRDLERFVSLGIMLMFYCTPILYASDMIPEKFSWIITYNPLASMILSWRDLFMNGTLN
                      YEYISILYFTGIILTVVGLSIFNKLKYRFAEIL"
-                     /locus_tag="O1/O2v1_01_wzm"
+                     /locus_tag="O1α,O2α_01_wzm"
      gene            768..1508
                      /gene="wzt"
      CDS             768..1508
@@ -1827,7 +1828,7 @@ FEATURES             Location/Qualifiers
                      PELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGEFIDEPIRVYSSGMLAKLGFSV
                      ISQVEPDILIIDEVLAVGDIAFQAKCIQTIRDFKKRGVTILFVSHNMSDVEKICDRVIW
                      IENHRLREVGSADRIIELYKQAMA"
-                     /locus_tag="O1/O2v1_02_wzt"
+                     /locus_tag="O1α,O2α_02_wzt"
      gene            1524..3419
                      /gene="wbbM"
      CDS             1524..3419
@@ -1850,7 +1851,7 @@ FEATURES             Location/Qualifiers
                      QMVEENTFAELMRVLKAKKYWFLDQDIMNKVFYSRVTFLPLEWNVYHGNGNTDDFFPNL
                      KFATYMKFLAARKKPKMIHYAGENKPWNTEKVDFYDDFIENIANTPWEMEIYKRQMSLA
                      ASIGLTHSEPQQQILFQTKIKNVLMPYVNKYAPIGTPRRNMMTKYYYKVRRAILG"
-                     /locus_tag="O1/O2v1_03_wbbM"
+                     /locus_tag="O1α,O2α_03_wbbM"
      gene            3435..4589
                      /gene="glf"
      CDS             3435..4589
@@ -1870,7 +1871,7 @@ FEATURES             Location/Qualifiers
                      ERTHYDHVFYSGPLDAFYGYQYGRLGYRTLDFKKFTYQGDYQGCAVMNYCSVDVPYTRI
                      TEHKYFSPWEQHDGSVCYKEYSRACEENDIPYYPIRQMGEMALLEKYLSLAENEINITF
                      VGRLGTYRYLDMDVTIAEALKTAEVYLNSLTENQPMPVFTVSVR"
-                     /locus_tag="O1/O2v1_04_glf"
+                     /locus_tag="O1α,O2α_04_glf"
      gene            4586..5479
                      /gene="wbbN"
      CDS             4586..5479
@@ -1888,7 +1889,7 @@ FEATURES             Location/Qualifiers
                      VSFVGMVIHRDLLATSLDYIREQLFIYFDDLYFGYQLSLAGEQIMYSPELLFYHDVSIQ
                      GKLIAPEWKVYYLCRNLILSKKIFQKNGVYSNSAIAIRILKYILILPWQRQKYSYMKFI
                      LRGISHGIKGISGKYH"
-                     /locus_tag="O1/O2v1_05_wbbN"
+                     /locus_tag="O1α,O2α_05_wbbN"
      gene            5492..6625
                      /gene="wbbO"
      CDS             5492..6625
@@ -1908,7 +1909,7 @@ FEATURES             Location/Qualifiers
                      KNIHFTLNVAGILVENDKDAISLQVIENWHQQGLINWLGRSNNVCDLIEQSNIVALPSV
                      YSEGVPRILLEASSVGRACIAYDVGGCDSLIIDNDNGIIVKSNSPEELADKLAFLLSNP
                      KARVEMGIKGRKRIQDKFSSGMIISKTLKTYHDVVEG"
-                     /locus_tag="O1/O2v1_06_wbbO"
+                     /locus_tag="O1α,O2α_06_wbbO"
      gene            6748..8064
                      /gene="kfoC"
      CDS             6748..8064
@@ -1928,7 +1929,7 @@ FEATURES             Location/Qualifiers
                      FDSLFTASREFIASLDIDESDFYDDFIKAAHYRLIRLTPEEYLFSLKDRVLHELESSNL
                      STEKLQASIASQDQVLKAREEEIDELRASVAQKKERIDRLVQRNAYLETEYQKQQEQLT
                      KLQNELNNAAQRYSALISSLSWKVTRPLRLIKALITRKM"
-                     /locus_tag="O1/O2v1_07_kfoC"
+                     /locus_tag="O1α,O2α_07_kfoC"
 ORIGIN
         1 atgaagtaca atttagggta tttatttgat ttacttgttg tgataacaaa taaagatcta
        61 aaagtgcgct ataagagcag catgctaggc tatttatggt cagtagcaaa tccattgctt
@@ -2094,8 +2095,9 @@ FEATURES             Location/Qualifiers
                      /strain="441"
                      /serovar="O1/O2 Variant 2"
                      /db_xref="taxon:573"
-                     /note="O locus: O1/O2v2"
-                     /note="O type: O2afg"
+                     /note="O locus: O1α,O2β"
+                     /note="O type: O2β"
+                     /note="Updated from O1/O2v2 by Tom Stanton in Feb 2025"
      gene            1..768
                      /gene="wzm"
      CDS             1..768
@@ -2113,7 +2115,7 @@ FEATURES             Location/Qualifiers
                      SNVMMEGLHFLCTIPVIVVFLFVYGMTPSLSWVWGIPLIAIGQVIFTFGVSIIFSTLNL
                      FFRDLERFVSLGIMLMFYCTPILYASDMIPEKFSWIITYNPLASMILSWRDLFMNGTLN
                      YEYISILYFTGIILTVVGLSIFNKLKYRFAEIL"
-                     /locus_tag="O1/O2v2_01_wzm"
+                     /locus_tag="O1α,O2β_01_wzm"
      gene            768..1508
                      /gene="wzt"
      CDS             768..1508
@@ -2131,7 +2133,7 @@ FEATURES             Location/Qualifiers
                      PELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGEFIDEPIRVYSSGMLAKLGFSV
                      ISQVEPDILIIDEVLAVGDIAFQAKCIQTIKDFKKRGVTILFVSHNMSDVEKICDRVIW
                      IENHRLREVGSAERIIELYKQAMA"
-                     /locus_tag="O1/O2v2_02_wzt"
+                     /locus_tag="O1α,O2β_02_wzt"
      gene            1524..3419
                      /gene="wbbM"
      CDS             1524..3419
@@ -2154,7 +2156,7 @@ FEATURES             Location/Qualifiers
                      QMVEENTFAELMRVLKAKKYWFLDQDIMNKVFYSRVTFLPLEWNVYHGNGNTDDFFPNL
                      KFATYMKFLAARKKPKMIHYAGENKPWNTEKVDFYDDFIENIANTPWEMEIYKRQMSLA
                      ASIGLTHSEPQQQILFQTKIKNVLMPYVNKYAPIGTPRRNMMTKYYYKVRRAILG"
-                     /locus_tag="O1/O2v2_03_wbbM"
+                     /locus_tag="O1α,O2β_03_wbbM"
      gene            3435..4589
                      /gene="glf"
      CDS             3435..4589
@@ -2174,7 +2176,7 @@ FEATURES             Location/Qualifiers
                      ERTHYDHVFYSGPLDAFYGYQYGRLGYRTLDFKKFTYQGDYQGCAVMNYCSVDVPYTRI
                      TEHKYFSPWEQHDGSVCYKEYSRACEENDIPYYPIRQMGEMALLEKYLSLAENETNITF
                      VGRLGTYRYLDMDVTIAEALKTAEVYLNSLTDNQPMPVFTVSVR"
-                     /locus_tag="O1/O2v2_04_glf"
+                     /locus_tag="O1α,O2β_04_glf"
      gene            4586..5479
                      /gene="wbbN"
      CDS             4586..5479
@@ -2192,7 +2194,7 @@ FEATURES             Location/Qualifiers
                      VSFVGMVIHRDLLATSLDHIHEQLFIYFDDLYFGYQLSLAGEKIMYSTELLFYHDVSIQ
                      GKLIAPEWKVYYLCRNLILSKKIFQKNAVYSNSAIAIRILKYILILPWQRQKYSYMKFI
                      LRGISHGIKGISGKYH"
-                     /locus_tag="O1/O2v2_05_wbbN"
+                     /locus_tag="O1α,O2β_05_wbbN"
      gene            5492..6622
                      /gene="wbbO"
      CDS             5492..6622
@@ -2212,7 +2214,7 @@ FEATURES             Location/Qualifiers
                      KNIHFTLNVAGILVENDKDAISLQVIENWHQQGLINWLGRSNNVCDLIEQSNIVALPSV
                      YSEGVPRILLEASSVGRACIAYDVGGCDSLIIDNDNGIIVKSNSPEELADKLAFLLSNP
                      KARVEMGIKGRKRIQDKFSSVMIIDKTLQIYHDVVR"
-                     /locus_tag="O1/O2v2_06_wbbO"
+                     /locus_tag="O1α,O2β_06_wbbO"
      gene            6718..7926
                      /gene="kfoC"
      CDS             6718..7926
@@ -2233,7 +2235,7 @@ FEATURES             Location/Qualifiers
                      FNKLFQDVKLFISSFDINNEDFYDEFILSAYRRIADMSAEEYLFSLKDRVLNELENAQR
                      NILTLQNEVEEIKQQLQQKDEMIASMNRENLAIKADNKILENYNEELKTVQTKFLKLLS
                      SKD"
-                     /locus_tag="O1/O2v2_07_kfoC"
+                     /locus_tag="O1α,O2β_07_kfoC"
      gene            complement(7996..9456)
                      /gene="gmlC"
      CDS             complement(7996..9456)
@@ -2253,7 +2255,7 @@ FEATURES             Location/Qualifiers
                      FLIGINSLVSRISKQAFVWPLIALTIMIIAQYNIINGFIIPQRSEIQALAAEITNKIPK
                      NYTGKLMFDLTDPAYNAFTKTQRYDEFGNISLAAPWALKGMAEEIRIMKGFNFKLSNNV
                      IISETNRCIDDCMVIKTSDAMRRSTINY"
-                     /locus_tag="O1/O2v2_08_gmlC"
+                     /locus_tag="O1α,O2β_08_gmlC"
      gene            complement(9458..10438)
                      /gene="gmlB"
      CDS             complement(9458..10438)
@@ -2272,7 +2274,7 @@ FEATURES             Location/Qualifiers
                      QTPNHADYRLLSNRALEALKQYKEQNIYLRGLVPLVGYPSIEVQYSREERIAGESKYPI
                      KKMLALALEGITSLSVTPLRIIAMTGFITCIISTIAAIYALIQKTTGTTVEGWTSVMIA
                      IFFLGGVQMLSLGIIGEYVGKIYIETKNRPKYFIDESVGNDSNGK"
-                     /locus_tag="O1/O2v2_09_gmlB"
+                     /locus_tag="O1α,O2β_09_gmlB"
      gene            complement(10435..10812)
                      /gene="gmlA"
      CDS             complement(10435..10812)
@@ -2287,7 +2289,7 @@ FEATURES             Location/Qualifiers
                      /translation="MPSSGPLWQLMKYGLVGIVNTLITAVVIFLLMHLGLGIYLSNAMG
                      YVVGIVFSFIANTIFTFTQPISINRLIKFLCVCFICYVANIIVIKIFFVFMPEKIYSAQ
                      ILGMFTYTITGFILNKFWAMK"
-                     /locus_tag="O1/O2v2_10_gmlA"
+                     /locus_tag="O1α,O2β_10_gmlA"
 ORIGIN
         1 atgaagtaca atttagggta tttatttgat ttacttgttg tcataacaaa taaagatcta
        61 aaagtgcgct ataagagcag catgctaggc tatttatggt cagtagcaaa tccattgctt
@@ -2499,10 +2501,11 @@ FEATURES             Location/Qualifiers
                      /strain="AKPRH077088"
                      /serovar="O3/O3a"
                      /db_xref="taxon:573"
-                     /note="O locus: O3/O3a"
-                     /note="O type: O3/O3a"
+                     /note="O locus: O3α"
+                     /note="O type: O3α"
                      /note="annotation edited from original by K. Wyres Jan
                      2018"
+                     /note="Updated from O3/O3a by Tom Stanton in Feb 2025"
      gene            1..1416
                      /gene="manC"
      CDS             1..1416
@@ -2524,7 +2527,7 @@ FEATURES             Location/Qualifiers
                      VKKAVEFLKQNQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
                      AEHWVILAGTGQVTVNGKQFLLTENQSTFIPIGAEHSLENPGRIPLEVLEIQSGSYLGE
                      DDIIRIKDQYGRC"
-                     /locus_tag="O3/O3a_01_manC"
+                     /locus_tag="O3α_01_manC"
      gene            1439..2821
                      /gene="manB"
      CDS             1439..2821
@@ -2546,7 +2549,7 @@ FEATURES             Location/Qualifiers
                      YCDSGMIPWLLVAELLCLKNSSLKSLVADRQAAFPASGEINRKLGNAAEAIARIRAQYE
                      PAAAHIDTTDGISIEYPEWRFNLRTSNTEPVVRLNVESRADTALMNEKTAELLNLLKEE
                      SL"
-                     /locus_tag="O3/O3a_02_manB"
+                     /locus_tag="O3α_02_manB"
      gene            2827..3612
                      /gene="wzm"
      CDS             2827..3612
@@ -2563,7 +2566,7 @@ FEATURES             Location/Qualifiers
                      RICLPIIVTASAFINFLIIFGLFVLFLIVTGNFPGMIFFEIIPVLIVQMLFTLGLGIIL
                      GVLNVFVRDVGQFVNILLQFWFWFTPIVYVSKTLPEWVSGLLAYNPMATIIGSYQNVML
                      YHQSPNWMALLPVTVVSVILFLFAWRLFKKHAADIVDEI"
-                     /locus_tag="O3/O3a_03_wzm"
+                     /locus_tag="O3α_03_wzm"
      gene            3615..4910
                      /gene="wzt"
      CDS             3615..4910
@@ -2584,7 +2587,7 @@ FEATURES             Location/Qualifiers
                      EEYRWGQGGAKIIDYHIQSAGVDFPPSLTGNQQTDFLMKVVFEYDFDCVVPGILIKTLD
                      GLFLYGTNSFLASEGRENISVSRGDVRVFKFSLPVDLNSGDYLLSFGISAGNPQTDMTP
                      LDRRYDSIILHVTKSMDFWGVIDLKSSFTSYQ"
-                     /locus_tag="O3/O3a_04_wzt"
+                     /locus_tag="O3α_04_wzt"
      gene            4930..7056
                      /gene="wbdD"
      CDS             4930..7056
@@ -2609,7 +2612,7 @@ FEATURES             Location/Qualifiers
                      NENQQLRQEIEKIHRSRSWRMTKGYRYLGLQIHLLRQYGFVQRCKHFIKRVLRFVFSFM
                      RKHPQVKHTAVNGLHKLGLYQPAYRLYRRMNPLPHSQYQADAQILSQTELQVMHPELLP
                      PEVYEIYLKLTKNK"
-                     /locus_tag="O3/O3a_05_wbdD"
+                     /locus_tag="O3α_05_wbdD"
      gene            7067..9589
                      /gene="wbdA"
      CDS             7067..9589
@@ -2637,7 +2640,7 @@ FEATURES             Location/Qualifiers
                      LFIVGKQGWNVDSLCEKLRHHPQLNKKLFWLQNISDEFLAELYARSRALIFASQGEGFG
                      LPLIEAAQKKLPVIIRDIPVFKEIAQEHAWYFSGEAPSDIAKAVEEWLALYEQNAHPRS
                      ENINWLTWKQSAEFLLKNLPIIAPAAKQ"
-                     /locus_tag="O3/O3a_06_wbdA"
+                     /locus_tag="O3α_06_wbdA"
      gene            9636..10781
                      /gene="wbdB"
      CDS             9636..10781
@@ -2657,7 +2660,7 @@ FEATURES             Location/Qualifiers
                      LLQAYQLLPMETRMRYPLILSGYRGWEDDVLWQLVERGTREGWIRYLGYVPDEDLPYLY
                      AAARTFVYPSFYEGFGLPILEAMSCGVPVVCSNVTSLPEVVGDAGLVADPNDVDAISAH
                      ILQSLQDDSWREIATARGLAQAKQFSWENCTTQTINAYKLL"
-                     /locus_tag="O3/O3a_07_wbdB"
+                     /locus_tag="O3α_07_wbdB"
      gene            10791..11906
                      /gene="wbdC"
      CDS             10791..11906
@@ -2677,7 +2680,7 @@ FEATURES             Location/Qualifiers
                      IVGGGPLEAEVRREAQQRGLSNVVFTGMLNDEDKYILFQLCRGVVFPSHLRSEAFGITL
                      LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPNDSQALVEAMNELWHNDETASRYGE
                      NSRRRFEEMFTADHMIDAYVNLYTTLLESKS"
-                     /locus_tag="O3/O3a_08_wbdC"
+                     /locus_tag="O3α_08_wbdC"
 ORIGIN
         1 atgttacttc ctgtaattat ggctggtggt accggcagtc gtctctggcc gatgtctcgc
        61 gagctttacc cgaaacagtt cctccggctg tacgggcaga actccatgct gcaggaaacc
@@ -2907,10 +2910,11 @@ FEATURES             Location/Qualifiers
                      /strain="539"
                      /serovar="O3b"
                      /db_xref="taxon:573"
-                     /note="O locus: O3b"
-                     /note="O type: O3b"
+                     /note="O locus: O3β"
+                     /note="O type: O3β"
                      /note="annotation edited from original by K. Wyres Jan
                      2018"
+                     /note="Updated from O3b by Tom Stanton in Feb 2025"
      gene            1..1416
                      /gene="manC"
      CDS             1..1416
@@ -2932,7 +2936,7 @@ FEATURES             Location/Qualifiers
                      VKKAVEFLKQNQRSEYKRHREIYRPWGRCDVVVQTPRFNVNRITVKPGGAFSMQMHHHR
                      AEHWVILAGTGQVTVNGKQFLLTENQSTFIPIGAEHSLENPGRIPLEVLEIQSGSYLGE
                      DDIIRIKDQYGRC"
-                     /locus_tag="O3b_01_manC"
+                     /locus_tag="O3β_01_manC"
      gene            1439..2821
                      /gene="manB"
      CDS             1439..2821
@@ -2954,7 +2958,7 @@ FEATURES             Location/Qualifiers
                      YCDSGMIPWLLVAELLCLKNSSLKSLVADRQAAFPASGEINRKLGNAAEAIARIRAQYE
                      PAAAHIDTTDGISIEYPEWRFNLRTSNTEPVVRLNVESRADTALMNEKTAELLNLLKEE
                      SL"
-                     /locus_tag="O3b_02_manB"
+                     /locus_tag="O3β_02_manB"
      gene            2827..3612
                      /gene="wzm"
      CDS             2827..3612
@@ -2971,7 +2975,7 @@ FEATURES             Location/Qualifiers
                      RICLPIIVTASAFINFLIIFGLFVLFLIVTGNFPGMIFFEIIPVLIVQMLFTLGLGIIL
                      GVLNVFVRDVGQFVNILLQFWFWFTPIVYVSKTLPEWVSGLLAYNPMATIIGSYQNVML
                      YHQSPNWLALLPVTVLSVILFLFAWRLFKKHAADIVDEI"
-                     /locus_tag="O3b_03_wzm"
+                     /locus_tag="O3β_03_wzm"
      gene            3615..4910
                      /gene="wzt"
      CDS             3615..4910
@@ -2992,7 +2996,7 @@ FEATURES             Location/Qualifiers
                      EEYRWGQGGAKIIDYHIQSAGVDFPPSLTGNQQTDFLMKVVFEYDFDCVVPGLLIKTLD
                      GLFLYGTNSFLASEGRENISVSRGDVRVFKFSFPVDLNSGDYLLSFGISEGSPQTEMTP
                      LDRRYDSIILHVTKSMDFWGVIDLKSTFNSYK"
-                     /locus_tag="O3b_04_wzt"
+                     /locus_tag="O3β_04_wzt"
      gene            4931..6988
                      /gene="wbdD"
      CDS             4931..6988
@@ -3016,7 +3020,7 @@ FEATURES             Location/Qualifiers
                      PQDVTTNVQPRIEIEQSKAVDSEEIMRLHTQLNDAQQEIENLRHEIAKIHYSRSWKMTK
                      WYRYAGLQYYLLRQYGFKQRFKHLLKRVLSNVIYFLRAHPRLKQKVINLLRTIGIYDFA
                      YRMHRRMNPGSHNPYPNDPQYQSQTEKQILHPELLPPEVNSIFSELKNKR"
-                     /locus_tag="O3b_05_wbdD"
+                     /locus_tag="O3β_05_wbdD"
      gene            6999..9521
                      /gene="wbdA"
      CDS             6999..9521
@@ -3044,7 +3048,7 @@ FEATURES             Location/Qualifiers
                      LFIIGKQGWHVDDLCERLRHHPQLNKKLFWLQNISDEFLTKLYSQSSALIFASLGEGFG
                      LPLIEAAQKKLPVIIRDIPVFKEIAQEHAWYFSGEAPADIAKAVEDWLALYEQNAHPRS
                      ENINWLTWKQSAEFLLKNLPIIAPAAKQ"
-                     /locus_tag="O3b_06_wbdA"
+                     /locus_tag="O3β_06_wbdA"
      gene            9568..10713
                      /gene="wbdB"
      CDS             9568..10713
@@ -3064,7 +3068,7 @@ FEATURES             Location/Qualifiers
                      LLQAYQLLPMETRMRYPLILSGYRGWEDDVLWQLVERGTREGWIRYLGYVPDEDLPYLY
                      AAARTFVYPSFYEGFGLPILEAMSCGVPVVCSNVTSLPEVVGDAGLVADPNDVDAISAH
                      ILQSLQDDSWREIATARGLAQAKQFSWENCTTQTINAYKLL"
-                     /locus_tag="O3b_07_wbdB"
+                     /locus_tag="O3β_07_wbdB"
      gene            10723..11838
                      /gene="wbdC"
      CDS             10723..11838
@@ -3084,7 +3088,7 @@ FEATURES             Location/Qualifiers
                      IVGGGPLEAEVRREAQQRGLSNVVFTGMLNDEDKYILFQLCRGVVFPSHLRSEAFGITL
                      LEGARFARPLISCEIGTGTSFINQDKVNGCVIPPNDSQALVEAMNELWHNDETASRYGE
                      NSRRRFEEMFTADHMIDAYVNLYTTLLESKS"
-                     /locus_tag="O3b_08_wbdC"
+                     /locus_tag="O3β_08_wbdC"
 ORIGIN
         1 atgttgcttc ctgtgatcat ggctggtggt accggcagtc gtctctggcc gatgtctcgc
        61 gagctttacc cgaaacagtt cctccgcctg ttcgggcaga actccatgct gcaggaaacc
@@ -4046,9 +4050,10 @@ FEATURES             Location/Qualifiers
                      /db_xref="taxon:573"
                      /note="Statens Serum Institut Klebsiella pnuemoniae
                      serotype O8 reference strains"
-                     /note="O locus: O8"
-                     /note="O type: O2a"
+                     /note="O locus: O1α,O2δ"
+                     /note="O type: O2δ"
                      /note="original sequence manually trimmed"
+                     /note="Updated from O8 by Tom Stanton in Feb 2025"
      gene            1..780
                      /gene="wzm"
      CDS             1..780
@@ -4063,7 +4068,7 @@ FEATURES             Location/Qualifiers
                      VIPLSNVMMEGLHFLCTIPVIIAFLFVYGMRPSLSWLWGIPIIAIGQVIFTFGISIIFS
                      TLNLFFRDLERFVSLGIMLMFYCTPILYASDMIPEKFSWIITYNPLASMILSWRELFMN
                      GVLNYEYISILYITGFILTIVGLAIFNKLKYRFAEIL"
-                     /locus_tag="O8_01_wzm"
+                     /locus_tag="O1α,O2δ_01_wzm"
      gene            780..1520
                      /gene="wzt"
      CDS             780..1520
@@ -4078,7 +4083,7 @@ FEATURES             Location/Qualifiers
                      PELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGEFIDEPIRVYSSGMLAKLGFSV
                      ISQVEPDILIIDEVLAVGDISFQAKCIKTIREFKKKGVTILFVSHNMSDVERICDRVVW
                      IENHRLREIGSAERIIELYKQAMA"
-                     /locus_tag="O8_02_wzt"
+                     /locus_tag="O1α,O2δ_02_wzt"
      gene            1534..3426
                      /gene="wbbM"
      CDS             1534..3426
@@ -4098,7 +4103,7 @@ FEATURES             Location/Qualifiers
                      MVKEDTFSLLMATLKAKKYWFLDQDIMNKVFFGRVKFLPLEWNVYHGNGNTDDFFPNLK
                      FSTFMRFLQARSNPKMIHYAGENKPWNTDKVDFYDDFFENIAHTPWEQEVYYRQLPVTS
                      VMHSHGAETQPAVLMQTKIKSALMPYVNKYAPVGSPRRNTLTKYYYKVRRSILG"
-                     /locus_tag="O8_03_wbbM"
+                     /locus_tag="O1α,O2δ_03_wbbM"
      gene            3445..4599
                      /gene="glf"
      CDS             3445..4599
@@ -4114,7 +4119,7 @@ FEATURES             Location/Qualifiers
                      EREDYAHVFYSGPLDAFYSYQYGRLGYRTLDFEKFTYQGDYQGCAVMNYCSIDVPYTRI
                      TEHKYFSPWESHEGSVCYKEYSRACGENDIPYYPIRQMGEMALLEKYLSLAESEKNITF
                      VGRLGTYRYLDMDVTIAEALKTADEFLSSVANQEEMPVFTVPVR"
-                     /locus_tag="O8_04_glf"
+                     /locus_tag="O1α,O2δ_04_glf"
      gene            4596..5489
                      /gene="wbbN"
      CDS             4596..5489
@@ -4129,7 +4134,7 @@ FEATURES             Location/Qualifiers
                      VSFVGMIISSKVLQEHIDHIHDELFIYFDDLYFGYALTLDGQKILYSPELIFHHDVSIQ
                      GKIISPEWKVYYLCRNLILARKLFQEVKVFSNFSILIRLCKYLSILPWQRRKSSYLCFM
                      YRGIVHGIRGISGKQH"
-                     /locus_tag="O8_05_wbbN"
+                     /locus_tag="O1α,O2δ_05_wbbN"
      gene            5502..6635
                      /gene="wbbO"
      CDS             5502..6635
@@ -4145,7 +4150,7 @@ FEATURES             Location/Qualifiers
                      RNISFTLNVAGILVEHDKDAIPLDVIQRWHEEGAINWLGHSSNVFDLIEESNIVALPSV
                      YSEGVPRILLEASSVGRACIAYDVGGCDSLIVDNDNGLIVKSNSVHELADKLGFLLDNP
                      EARVEMGIKGRKRVQDKFSSVMIINKTLKTYHDVVEG"
-                     /locus_tag="O8_06_wbbO"
+                     /locus_tag="O1α,O2δ_06_wbbO"
      CDS             6759..8078
                      /note="orf11"
                      /codon_start=1
@@ -4160,7 +4165,7 @@ FEATURES             Location/Qualifiers
                      FSPLFDDVKAFIIELDASDDDFYDDFIAAAHQRIATLSADEYLFSLKDRVLKELEFSQA
                      NNARLEQTIDILEQKNNQLGQELAAQQVAQHEEKQNFHDQLTKRDEHHRALQNRYDIQE
                      REMFDQRAKLESLQQHNVNIIGSLSWRLTKPLRLIRRFFK"
-                     /locus_tag="O8_07"
+                     /locus_tag="O1α,O2δ_07"
      CDS             8397..9395
                      /note="orf12"
                      /codon_start=1
@@ -4173,7 +4178,7 @@ FEATURES             Location/Qualifiers
                      MHTAMLSMLVGSFFYSISRTEYFSRIIKERFSAFFVTCAVIISMVGVYAMNHSRLDYFL
                      FIAFVPMLFIDHLADDKIIKKIFTSDLFLFLGYISFPLYLLHELVIVSGFIFDPDNAWT
                      SISIAALTSILISYVYARFIDYPLYKALKRLISKMSWPGAKKDYRGNLLNQ"
-                     /locus_tag="O8_08"
+                     /locus_tag="O1α,O2δ_08"
 ORIGIN
         1 atgagtctaa aaatgaagta taatttaggg tatttgtttg atctgcttgt tgttataaca
        61 aacaaagatt tgaaggtaag atataaaagc agcgtatttg gctatttgtg gtcaattgcc
@@ -4333,7 +4338,7 @@ ORIGIN
      9301 actacccgct gtacaaagcg ttaaaaaggc taatatcaaa aatgtcctgg ccaggtgcta
      9361 aaaaagatta ccgtggtaat cttttaaatc aataa
 //
-LOCUS       O1/O2v3                 9400 bp    DNA     linear   BCT 14-FEB-2018
+LOCUS       O1α,O2γ                 9400 bp    DNA     linear   BCT 14-FEB-2018
 DEFINITION  Klebsiella pneumoniae strain CWK53 O2aeh O locus, complete sequence.
 ACCESSION   MG280710
 VERSION     MG280710.1
@@ -4372,8 +4377,9 @@ FEATURES             Location/Qualifiers
                      /db_xref="taxon:573"
                      /note="Sequence edited to remove hisI gene, Kelly Wyres
                      April 2021"
-                     /note="O locus: O1/O2v3"
-                     /note="O type: O2a"
+                     /note="O locus: O1α,O2γ"
+                     /note="O type: O2γ"
+                     /note="Updated from O1/O2v3 by Tom Stanton in Feb 2025"
      gene            1..768
                      /gene="wzm"
      CDS             1..768
@@ -4389,7 +4395,7 @@ FEATURES             Location/Qualifiers
                      SNVMMEGLHFLCTIPVIIAFLFVYGMSPSISWLWGIPIIAIGQVIFTFGISIIFSTLNL
                      FFRDLERFVSLGIMLMFYCTPILYAADMIPEKFSWIITYNPLASMILSWRQLFMDGVLN
                      YEYISILYVTGIILTIVGLSIFNKLKYRFAEIL"
-                     /locus_tag="O1/O2v3_01_wzm"
+                     /locus_tag="O1α,O2γ_01_wzm"
      misc_feature    1..>9400
                      /note="rfb gene cluster"
      gene            768..1508
@@ -4407,7 +4413,7 @@ FEATURES             Location/Qualifiers
                      PELTGRENIYLNATLLGLRRKEVQQRMERIIEFSELGDFIDEPIRVYSSGMLAKLGFSV
                      ISQVEPDILIIDEVLAVGDISFQAKCIQTIKDFKSKGVTILFVSHNMSDVEKICDRVVW
                      IEDHKLREIGSAERIIELYKQAMA"
-                     /locus_tag="O1/O2v3_02_wzt"
+                     /locus_tag="O1α,O2γ_02_wzt"
      gene            1523..3415
                      /gene="wbbM"
      CDS             1523..3415
@@ -4429,7 +4435,7 @@ FEATURES             Location/Qualifiers
                      MVKENTFAQLMSALKAKKYWFLDQDIMNKVFFGRVKFLPLEWNVYHGNGNTDDFFPNLK
                      FSTYMRFLEARRNPKMIHYAGENKPWNTEKVDFYDDFLENVLNTPWEKEIYYRQLPVAT
                      VVPNQHTELQQTVLLQTKIKRALMPYVNKYAPVGSPRRNKLTKYYYKVRRSILG"
-                     /locus_tag="O1/O2v3_03_wbbM"
+                     /locus_tag="O1α,O2γ_03_wbbM"
      gene            3434..4588
                      /gene="glf"
      CDS             3434..4588
@@ -4447,7 +4453,7 @@ FEATURES             Location/Qualifiers
                      NRESYDHVFYSGPLDAFYSYQHGRLGYRTLDFERFTWQGDYQGCAVMNYCSVDVPYTRI
                      TEHKYFSPWESHEGSVCYKEYSRACGEDDIPYYPIRQMGEMALLDKYLSLAENEKNITF
                      VGRLGTYRYLDMDVTIAEALKTADKYLSSLSNDEAMPVFVADVR"
-                     /locus_tag="O1/O2v3_04_glf"
+                     /locus_tag="O1α,O2γ_04_glf"
      gene            4585..5475
                      /gene="wbbN"
      CDS             4585..5475
@@ -4464,7 +4470,7 @@ FEATURES             Location/Qualifiers
                      SFVGMIIKREVLNEHLHHIYDELFLYFDDLYFGYQLTLSGEKIIYNPELVFTHDVSIQG
                      KVISPEWKVYYLCRNLILAKRIFTEVAVFSSSSILLRLCKYISIFPVQRRKWVYLKFLC
                      RGIVHGVKGISGKFH"
-                     /locus_tag="O1/O2v3_05_wbbN"
+                     /locus_tag="O1α,O2γ_05_wbbN"
      gene            5488..6621
                      /gene="wbbO"
      CDS             5488..6621
@@ -4482,7 +4488,7 @@ FEATURES             Location/Qualifiers
                      KNIHFTLNVAGILVENDKDAIPLATIQKWQSEGVINWLGHCSNVFDLIEESNIVALPSV
                      YAEGVPRILLEASSVGRACIAYDVGGCDSLIINNDNGLIVKSKSVEELAEKLGFLLDNP
                      ETRVAMGINGRKRIQDKFSSVMIINKTLKTYRDVVEE"
-                     /locus_tag="O1/O2v3_06_wbbO"
+                     /locus_tag="O1α,O2γ_06_wbbO"
      CDS             6743..8047
                      /note="Orf7"
                      /codon_start=1
@@ -4497,7 +4503,7 @@ FEATURES             Location/Qualifiers
                      HPFYQQVKEFIVALDAKDDDFYDEFIAAAHHRITTLSAEEYLFSLKDRVLKELEFFQAK
                      SSALQQEVETLTDSFAEQKDENAILHNQLHEIEERVTEQEKNIRQLTDKNNNMHHEITI
                      KQQEFNEIYQHHKNLISSLSWKLTKPLRVVRRFFK"
-                     /locus_tag="O1/O2v3_07"
+                     /locus_tag="O1α,O2γ_07"
      CDS             8381..9400
                      /note="Orf8; involved in lipopolysaccharide O-antigen
                      biosynthesis"
@@ -4511,7 +4517,7 @@ FEATURES             Location/Qualifiers
                      AVVAGLLFIFLWHKHPSGIPPSMLTAMLSMLIGSLFFSLSQTEYFKCLMKEKFMAFFIT
                      AAAIVSIVGVYAMNHSRLDYFLFVAFIPMLFIDHLPDNQLIKRVFTSNLFLFLGYISFP
                      LYLLHELVIVSGFIFDPENAWVSISIAAFASIFIAYIYARFIDYPLYRALKRQIAKIS"
-                     /locus_tag="O1/O2v3_08"
+                     /locus_tag="O1α,O2γ_08"
 ORIGIN
         1 atgaagtata atataggata tttgtttgat cttcttgttg taataacaaa caaagatttg
        61 aaagtacgtt ataaaagcag cgtatttggt tacttatggt caatcgcaaa tccactgctt

--- a/reference_database/Klebsiella_o_locus_primary_reference.logic
+++ b/reference_database/Klebsiella_o_locus_primary_reference.logic
@@ -1,25 +1,13 @@
 loci	genes	phenotype
-O1α,O2α wbbY    O1α,O2α
-O1α,O2β wbbY    O1α,O2β
-O1α,O2δ	wbbY	O1α,O2δ
-O1α,O2γ	wbbY	O1α,O2γ
-O1α,O2α wbbY;wbbZ   O1αβ,O2α
-O1α,O2β wbbY;wbbZ   O1αβ,O2β
-O1α,O2δ	wbbY;wbbZ	O1αβ,O2δ
-O1α,O2γ wbbY;wbbZ	O1αβ,O2γ
-O1α,O2α wbmV;wbmW
-O1α,O2β wbmV;wbmW
-O1α,O2δ wbmV;wbmW
-O1α,O2γ	wbmV;wbmW	O2ac
-O1α,O2α gmlA;gmlB;gmlD
-O1α,O2β gmlA;gmlB;gmlD
-O1α,O2δ gmlA;gmlB;gmlD
-O1α,O2γ	gmlA;gmlB;gmlD	O2aeh
-O1α,O2α wbbY;wbmV;wbmW
-O1α,O2β wbbY;wbmV;wbmW
-O1α,O2δ wbbY;wbmV;wbmW
-O1α,O2γ	wbbY;wbmV;wbmW	O1a (O2ac)
-O1α,O2α wbbY;wbbZ;wbmV;wbmW
-O1α,O2β wbbY;wbbZ;wbmV;wbmW
-O1α,O2δ wbbY;wbbZ;wbmV;wbmW
-O1α,O2γ	wbbY;wbbZ;wbmV;wbmW	O1ab (O2ac)
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC	O2β
+OL2α.1;OL2α.2;OL2α.3	orf8	O2γ
+OL2α.1;OL2α.2;OL2α.3	wbbY	O1α,2α
+OL2α.1;OL2α.2;OL2α.3	wbbY;wbbZ	O1αβ,2α
+OL2α.1;OL2α.2;OL2α.3	orf8;wbbY;wbbZ	O1αβ,2γ
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbbY	O1α,2β
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbbY;wbbZ	O1αβ,2β
+OL2α.1;OL2α.2;OL2α.3	wbmV;wbmW	O11α,2α
+OL2α.1;OL2α.2;OL2α.3	wbmV;wbmW;wbmX	O11αβ,2α
+OL2α.1;OL2α.2;OL2α.3	orf8;wbmV;wbmW;wbmX	O11αβ,2γ
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbmV;wbmW	O11α,2β
+OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC;wbmV;wbmW;wbmX	O11αβ,2β

--- a/reference_database/Klebsiella_o_locus_primary_reference.logic
+++ b/reference_database/Klebsiella_o_locus_primary_reference.logic
@@ -1,6 +1,6 @@
 loci	genes	phenotype
 OL2α.1;OL2α.2;OL2α.3	gmlA;gmlB;gmlC	O2β
-OL2α.1;OL2α.2;OL2α.3	orf8	O2γ
+OL2α.1;OL2α.2;OL2α.3	orf8	O2αγ
 OL2α.1;OL2α.2;OL2α.3	wbbY	O1α,2α
 OL2α.1;OL2α.2;OL2α.3	wbbY;wbbZ	O1αβ,2α
 OL2α.1;OL2α.2;OL2α.3	orf8;wbbY;wbbZ	O1αβ,2γ

--- a/reference_database/Klebsiella_o_locus_primary_reference.logic
+++ b/reference_database/Klebsiella_o_locus_primary_reference.logic
@@ -1,8 +1,25 @@
 loci	genes	phenotype
-O1/O2v1;O1/O2v2;O1/O2v3	wbbY	O1a
-O1/O2v1;O1/O2v2;O1/O2v3	wbbY;wbbZ	O1ab
-O8	wbbY	O8
-O1/O2v1;O1/O2v2;O1/O2v3;O8	wbmV;wbmW	O2ac
-O1/O2v1;O1/O2v2;O1/O2v3;O8	gmlA;gmlB;gmlD	O2aeh
-O1/O2v1;O1/O2v2;O1/O2v3;O8	wbbY;wbmV;wbmW	O1a (O2ac)
-O1/O2v1;O1/O2v2;O1/O2v3;O8	wbbY;wbbZ;wbmV;wbmW	O1ab (O2ac)
+O1α,O2α wbbY    O1α,O2α
+O1α,O2β wbbY    O1α,O2β
+O1α,O2δ	wbbY	O1α,O2δ
+O1α,O2γ	wbbY	O1α,O2γ
+O1α,O2α wbbY;wbbZ   O1αβ,O2α
+O1α,O2β wbbY;wbbZ   O1αβ,O2β
+O1α,O2δ	wbbY;wbbZ	O1αβ,O2δ
+O1α,O2γ wbbY;wbbZ	O1αβ,O2γ
+O1α,O2α wbmV;wbmW
+O1α,O2β wbmV;wbmW
+O1α,O2δ wbmV;wbmW
+O1α,O2γ	wbmV;wbmW	O2ac
+O1α,O2α gmlA;gmlB;gmlD
+O1α,O2β gmlA;gmlB;gmlD
+O1α,O2δ gmlA;gmlB;gmlD
+O1α,O2γ	gmlA;gmlB;gmlD	O2aeh
+O1α,O2α wbbY;wbmV;wbmW
+O1α,O2β wbbY;wbmV;wbmW
+O1α,O2δ wbbY;wbmV;wbmW
+O1α,O2γ	wbbY;wbmV;wbmW	O1a (O2ac)
+O1α,O2α wbbY;wbbZ;wbmV;wbmW
+O1α,O2β wbbY;wbbZ;wbmV;wbmW
+O1α,O2δ wbbY;wbbZ;wbmV;wbmW
+O1α,O2γ	wbbY;wbbZ;wbmV;wbmW	O1ab (O2ac)


### PR DESCRIPTION
Updating KpSC O-locus nomenclature following the release of this [paper](https://doi.org/10.1128/mmbr.00090-23).